### PR TITLE
Ensure payout sync uses ensured account IDs for transfers and deposits

### DIFF
--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -620,13 +620,27 @@ class PayoutSyncService {
         // Ensure all required accounts exist in the accounting system
         // and get their account IDs
         const accountsToEnsure = new Set();
+        const addAccountToEnsure = (accountName) => {
+            if (accountName) {
+                accountsToEnsure.add(accountName);
+            }
+        };
+
         for (const doc of postingInstructions.documents) {
-            if (doc.type === 'journal') {
-                doc.lines.forEach(line => {
-                    if (line.accountName) {
-                        accountsToEnsure.add(line.accountName);
-                    }
-                });
+            switch (doc.type) {
+                case 'journal':
+                    doc.lines.forEach(line => addAccountToEnsure(line.accountName));
+                    break;
+                case 'transfer':
+                    addAccountToEnsure(doc.fromAccountName);
+                    addAccountToEnsure(doc.toAccountName);
+                    break;
+                case 'deposit':
+                    addAccountToEnsure(doc.toAccountName);
+                    doc.lines.forEach(line => addAccountToEnsure(line.accountName));
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -685,8 +699,12 @@ class PayoutSyncService {
 
                     case 'transfer':
                         // Map account names to IDs (in production, lookup from chart of accounts)
-                        const fromAccountId = `account-${doc.fromAccountName}`;
-                        const toAccountId = `account-${doc.toAccountName}`;
+                        const fromAccountId = accountMap[doc.fromAccountName];
+                        const toAccountId = accountMap[doc.toAccountName];
+
+                        if (!fromAccountId || !toAccountId) {
+                            throw new Error(`Account ID not found for transfer accounts: from=${doc.fromAccountName}, to=${doc.toAccountName}`);
+                        }
 
                         result = await this.accountingProvider.upsertTransfer({
                             docNumber: doc.docNumber,
@@ -704,19 +722,29 @@ class PayoutSyncService {
                         break;
 
                     case 'deposit':
-                        const depositAccountId = `account-${doc.toAccountName}`;
+                        const depositAccountId = accountMap[doc.toAccountName];
+                        if (!depositAccountId) {
+                            throw new Error(`Account ID not found for deposit account: ${doc.toAccountName}`);
+                        }
+
+                        const depositLinesWithAccountIds = doc.lines.map(line => {
+                            const accountId = accountMap[line.accountName];
+                            if (!accountId) {
+                                throw new Error(`Account ID not found for deposit line account: ${line.accountName}`);
+                            }
+                            return {
+                                ...line,
+                                accountId
+                            };
+                        });
 
                         result = await this.accountingProvider.upsertDeposit({
                             docNumber: doc.docNumber,
                             date: doc.date,
                             toAccountId: depositAccountId,
-                            lines: doc.lines.map(line => ({
-                                accountId: `account-${line.accountName}`,
-                                amount: line.amount,
-                                memo: line.memo
-                            })),
+                            lines: depositLinesWithAccountIds,
                             memo: doc.memo,
-                            metadata: { 
+                            metadata: {
                                 payoutId: postingInstructions.payoutId,
                                 stripeAccountId: postingInstructions.stripeAccountId
                             }

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -53,8 +53,12 @@ class MockAccountingProvider {
     async ensureChartOfAccounts(accounts) {
         // Mock implementation - returns account IDs for all account names
         const accountMap = {};
-        accounts.forEach((account, index) => {
-            accountMap[account.name] = `account-${index + 1}`;
+        accounts.forEach((account) => {
+            const normalized = account.name
+                .toLowerCase()
+                .replace(/\s+/g, '_')
+                .replace(/[^a-z0-9_]/g, '');
+            accountMap[account.name] = `acct-${normalized}`;
         });
         return accountMap;
     }
@@ -451,6 +455,16 @@ async function runTests() {
                     toAccountName: 'Operating Bank',
                     amount: 1000,
                     memo: 'Test transfer'
+                },
+                {
+                    type: 'deposit',
+                    docNumber: 'STRIPE-default-po_post_test-DEP',
+                    date: new Date(),
+                    toAccountName: 'Operating Bank',
+                    memo: 'Test deposit',
+                    lines: [
+                        { accountName: 'Stripe Clearing', amount: 1000, memo: 'Deposit from clearing' }
+                    ]
                 }
             ]
         };
@@ -459,15 +473,38 @@ async function runTests() {
 
         if (providerDocIds.journalEntry &&
             providerDocIds.transfer &&
+            providerDocIds.deposit &&
             provider.journalEntries.length === 1 &&
-            provider.transfers.length === 1) {
-            console.log('✅ Post to accounting provider');
-            passed++;
+            provider.transfers.length === 1 &&
+            provider.deposits.length === 1) {
+            const expectedId = (name) => `acct-${name.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '')}`;
+            const transfer = provider.transfers[0];
+            const deposit = provider.deposits[0];
+
+            const transferAccountsCorrect =
+                transfer.fromAccountId === expectedId('Stripe Clearing') &&
+                transfer.toAccountId === expectedId('Operating Bank');
+
+            const depositAccountsCorrect =
+                deposit.toAccountId === expectedId('Operating Bank') &&
+                deposit.lines.length === 1 &&
+                deposit.lines[0].accountId === expectedId('Stripe Clearing');
+
+            if (transferAccountsCorrect && depositAccountsCorrect) {
+                console.log('✅ Post to accounting provider');
+                passed++;
+            } else {
+                console.log('❌ Post to accounting provider - incorrect account IDs');
+                console.log('   Transfer:', transfer);
+                console.log('   Deposit:', deposit);
+                failed++;
+            }
         } else {
             console.log('❌ Post to accounting provider - failed');
             console.log('   Provider doc IDs:', providerDocIds);
             console.log('   JE count:', provider.journalEntries.length);
             console.log('   Transfer count:', provider.transfers.length);
+            console.log('   Deposit count:', provider.deposits.length);
             failed++;
         }
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure payout sync requests all referenced accounts and uses the returned IDs for journals, transfers, and deposits
- expand payout sync unit coverage to validate transfers and deposits use ensured account IDs

## Testing
- npm test -- payoutSync

------
https://chatgpt.com/codex/tasks/task_e_68e07824d6e8832c90147de7f8bdf91e