### PR TITLE
Fix QuickBooks transfer search and harden payout logging

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -250,30 +250,47 @@ class QuickBooksProvider extends BaseAccountingProvider {
         }
 
         try {
-            // Search for existing Transfer by PrivateNote containing docNumber
-            // Use array criteria with LIKE operator
-            const existingTransfers = await this._executeWithTokenRefresh(() =>
-                new Promise((resolve, reject) => {
-                    this.qbo.findTransfers([
-                        { field: 'PrivateNote', value: `%${transfer.docNumber}%`, operator: 'LIKE' }
-                    ], (err, data) => {
-                        if (err) reject(err);
-                        else resolve(data.QueryResponse.Transfer || []);
-                    });
-                })
-            );
+            const transferDate = this._formatDate(transfer.date);
+            const transferAmount = (transfer.amount / 100).toFixed(2);
 
-            if (existingTransfers.length > 0) {
-                // Transfer exists - return existing
-                const existing = existingTransfers[0];
-                this.logger.log(`[QBO] Transfer already exists: ${transfer.docNumber} (ID: ${existing.Id})`);
+            // Search for an existing transfer by date/amount and validate with metadata
+            let existingTransfers = [];
+            try {
+                existingTransfers = await this._executeWithTokenRefresh(() =>
+                    new Promise((resolve, reject) => {
+                        this.qbo.findTransfers([
+                            { field: 'TxnDate', value: transferDate, operator: '=' },
+                            { field: 'Amount', value: transferAmount, operator: '=' }
+                        ], (err, data) => {
+                            if (err) reject(err);
+                            else resolve(data.QueryResponse.Transfer || []);
+                        });
+                    })
+                );
+            } catch (searchError) {
+                this.logger.warn('[QBO] Transfer lookup failed, will attempt to create new transfer:', searchError.message);
+                existingTransfers = [];
+            }
+
+            const matchingTransfer = existingTransfers.find(existing => {
+                const note = existing.PrivateNote || '';
+                const fromAccountId = existing.FromAccountRef && existing.FromAccountRef.value;
+                const toAccountId = existing.ToAccountRef && existing.ToAccountRef.value;
+
+                return note.includes(transfer.docNumber) &&
+                    fromAccountId === transfer.fromAccountId &&
+                    toAccountId === transfer.toAccountId;
+            });
+
+            if (matchingTransfer) {
+                this.logger.log(`[QBO] Transfer already exists: ${transfer.docNumber} (ID: ${matchingTransfer.Id})`);
                 return {
-                    id: existing.Id,
+                    id: matchingTransfer.Id,
                     docNumber: transfer.docNumber,
-                    txnDate: existing.TxnDate,
-                    fromAccountRef: existing.FromAccountRef,
-                    toAccountRef: existing.ToAccountRef,
-                    amount: Math.round(parseFloat(existing.Amount) * 100), // Convert dollars back to cents
+                    txnDate: matchingTransfer.TxnDate,
+                    fromAccountRef: matchingTransfer.FromAccountRef,
+                    toAccountRef: matchingTransfer.ToAccountRef,
+                    amount: Math.round(parseFloat(matchingTransfer.Amount) * 100), // Convert dollars back to cents
                     provider: 'quickbooks',
                     created: false
                 };
@@ -288,7 +305,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                     value: transfer.toAccountId
                 },
                 Amount: (transfer.amount / 100).toFixed(2), // Convert cents to dollars
-                TxnDate: this._formatDate(transfer.date),
+                TxnDate: transferDate,
                 PrivateNote: `${transfer.memo || ''} [DocNum: ${transfer.docNumber}]`
             };
 
@@ -342,18 +359,23 @@ class QuickBooksProvider extends BaseAccountingProvider {
         }
 
         try {
-            // Search for existing Deposit by PrivateNote containing docNumber
-            // Use array criteria with LIKE operator
-            const existingDeposits = await this._executeWithTokenRefresh(() =>
-                new Promise((resolve, reject) => {
-                    this.qbo.findDeposits([
-                        { field: 'PrivateNote', value: `%${deposit.docNumber}%`, operator: 'LIKE' }
-                    ], (err, data) => {
-                        if (err) reject(err);
-                        else resolve(data.QueryResponse.Deposit || []);
-                    });
-                })
-            );
+            // Search for existing deposit by DocNumber
+            let existingDeposits = [];
+            try {
+                existingDeposits = await this._executeWithTokenRefresh(() =>
+                    new Promise((resolve, reject) => {
+                        this.qbo.findDeposits([
+                            { field: 'DocNumber', value: deposit.docNumber, operator: '=' }
+                        ], (err, data) => {
+                            if (err) reject(err);
+                            else resolve(data.QueryResponse.Deposit || []);
+                        });
+                    })
+                );
+            } catch (searchError) {
+                this.logger.warn('[QBO] Deposit lookup failed, will attempt to create new deposit:', searchError.message);
+                existingDeposits = [];
+            }
 
             if (existingDeposits.length > 0) {
                 // Deposit exists - return existing
@@ -372,6 +394,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
 
             // Create new deposit
             const depositData = {
+                DocNumber: deposit.docNumber,
                 DepositToAccountRef: {
                     value: deposit.toAccountId
                 },

--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -620,13 +620,27 @@ class PayoutSyncService {
         // Ensure all required accounts exist in the accounting system
         // and get their account IDs
         const accountsToEnsure = new Set();
+        const addAccountToEnsure = (accountName) => {
+            if (accountName) {
+                accountsToEnsure.add(accountName);
+            }
+        };
+
         for (const doc of postingInstructions.documents) {
-            if (doc.type === 'journal') {
-                doc.lines.forEach(line => {
-                    if (line.accountName) {
-                        accountsToEnsure.add(line.accountName);
-                    }
-                });
+            switch (doc.type) {
+                case 'journal':
+                    doc.lines.forEach(line => addAccountToEnsure(line.accountName));
+                    break;
+                case 'transfer':
+                    addAccountToEnsure(doc.fromAccountName);
+                    addAccountToEnsure(doc.toAccountName);
+                    break;
+                case 'deposit':
+                    addAccountToEnsure(doc.toAccountName);
+                    doc.lines.forEach(line => addAccountToEnsure(line.accountName));
+                    break;
+                default:
+                    break;
             }
         }
 
@@ -685,8 +699,12 @@ class PayoutSyncService {
 
                     case 'transfer':
                         // Map account names to IDs (in production, lookup from chart of accounts)
-                        const fromAccountId = `account-${doc.fromAccountName}`;
-                        const toAccountId = `account-${doc.toAccountName}`;
+                        const fromAccountId = accountMap[doc.fromAccountName];
+                        const toAccountId = accountMap[doc.toAccountName];
+
+                        if (!fromAccountId || !toAccountId) {
+                            throw new Error(`Account ID not found for transfer accounts: from=${doc.fromAccountName}, to=${doc.toAccountName}`);
+                        }
 
                         result = await this.accountingProvider.upsertTransfer({
                             docNumber: doc.docNumber,
@@ -704,19 +722,29 @@ class PayoutSyncService {
                         break;
 
                     case 'deposit':
-                        const depositAccountId = `account-${doc.toAccountName}`;
+                        const depositAccountId = accountMap[doc.toAccountName];
+                        if (!depositAccountId) {
+                            throw new Error(`Account ID not found for deposit account: ${doc.toAccountName}`);
+                        }
+
+                        const depositLinesWithAccountIds = doc.lines.map(line => {
+                            const accountId = accountMap[line.accountName];
+                            if (!accountId) {
+                                throw new Error(`Account ID not found for deposit line account: ${line.accountName}`);
+                            }
+                            return {
+                                ...line,
+                                accountId
+                            };
+                        });
 
                         result = await this.accountingProvider.upsertDeposit({
                             docNumber: doc.docNumber,
                             date: doc.date,
                             toAccountId: depositAccountId,
-                            lines: doc.lines.map(line => ({
-                                accountId: `account-${line.accountName}`,
-                                amount: line.amount,
-                                memo: line.memo
-                            })),
+                            lines: depositLinesWithAccountIds,
                             memo: doc.memo,
-                            metadata: { 
+                            metadata: {
                                 payoutId: postingInstructions.payoutId,
                                 stripeAccountId: postingInstructions.stripeAccountId
                             }

--- a/stripeWebhook/index.js
+++ b/stripeWebhook/index.js
@@ -14,6 +14,29 @@ const PayoutSyncService = require('../services/payoutSyncService');
 const WebhookEventStore = require('../services/webhookEventStore');
 const SyncLedger = require('../services/syncLedger');
 
+const createContextLogger = (context) => {
+    const baseLog = (...args) => context.log(...args);
+
+    const resolveMethod = (method) => {
+        if (context.log && typeof context.log[method] === 'function') {
+            return (...args) => context.log[method](...args);
+        }
+
+        if (typeof context[method] === 'function') {
+            return (...args) => context[method](...args);
+        }
+
+        return baseLog;
+    };
+
+    return {
+        log: baseLog,
+        info: resolveMethod('info'),
+        warn: resolveMethod('warn'),
+        error: resolveMethod('error')
+    };
+};
+
 // Global service instances
 const idempotencyService = new IdempotencyService();
 const metricsService = new MetricsService();
@@ -943,9 +966,10 @@ const processPayoutPaid = async (context, payout, stripeAccountId = null, eventI
         );
         
         // Set the context logger so we can see the logs
-        payoutSyncService.logger = context;
+        const contextLogger = createContextLogger(context);
+        payoutSyncService.logger = contextLogger;
         if (accountingProvider.logger) {
-            accountingProvider.logger = context;
+            accountingProvider.logger = contextLogger;
         }
 
         // Enqueue job for async processing

--- a/tests/journalEntryCreation.test.js
+++ b/tests/journalEntryCreation.test.js
@@ -61,10 +61,12 @@ class MockQBOClient {
 
         if (Array.isArray(criteria)) {
             criteria.forEach(c => {
-                if (c.field === 'PrivateNote' && c.operator === 'LIKE') {
-                    const searchValue = c.value.replace(/%/g, '');
-                    filteredTransfers = filteredTransfers.filter(t => 
-                        t.PrivateNote && t.PrivateNote.includes(searchValue)
+                if (c.field === 'TxnDate') {
+                    filteredTransfers = filteredTransfers.filter(t => t.TxnDate === c.value);
+                }
+                if (c.field === 'Amount') {
+                    filteredTransfers = filteredTransfers.filter(t =>
+                        parseFloat(t.Amount).toFixed(2) === parseFloat(c.value).toFixed(2)
                     );
                 }
             });

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -53,8 +53,12 @@ class MockAccountingProvider {
     async ensureChartOfAccounts(accounts) {
         // Mock implementation - returns account IDs for all account names
         const accountMap = {};
-        accounts.forEach((account, index) => {
-            accountMap[account.name] = `account-${index + 1}`;
+        accounts.forEach((account) => {
+            const normalized = account.name
+                .toLowerCase()
+                .replace(/\s+/g, '_')
+                .replace(/[^a-z0-9_]/g, '');
+            accountMap[account.name] = `acct-${normalized}`;
         });
         return accountMap;
     }
@@ -451,6 +455,16 @@ async function runTests() {
                     toAccountName: 'Operating Bank',
                     amount: 1000,
                     memo: 'Test transfer'
+                },
+                {
+                    type: 'deposit',
+                    docNumber: 'STRIPE-default-po_post_test-DEP',
+                    date: new Date(),
+                    toAccountName: 'Operating Bank',
+                    memo: 'Test deposit',
+                    lines: [
+                        { accountName: 'Stripe Clearing', amount: 1000, memo: 'Deposit from clearing' }
+                    ]
                 }
             ]
         };
@@ -459,15 +473,38 @@ async function runTests() {
 
         if (providerDocIds.journalEntry &&
             providerDocIds.transfer &&
+            providerDocIds.deposit &&
             provider.journalEntries.length === 1 &&
-            provider.transfers.length === 1) {
-            console.log('✅ Post to accounting provider');
-            passed++;
+            provider.transfers.length === 1 &&
+            provider.deposits.length === 1) {
+            const expectedId = (name) => `acct-${name.toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '')}`;
+            const transfer = provider.transfers[0];
+            const deposit = provider.deposits[0];
+
+            const transferAccountsCorrect =
+                transfer.fromAccountId === expectedId('Stripe Clearing') &&
+                transfer.toAccountId === expectedId('Operating Bank');
+
+            const depositAccountsCorrect =
+                deposit.toAccountId === expectedId('Operating Bank') &&
+                deposit.lines.length === 1 &&
+                deposit.lines[0].accountId === expectedId('Stripe Clearing');
+
+            if (transferAccountsCorrect && depositAccountsCorrect) {
+                console.log('✅ Post to accounting provider');
+                passed++;
+            } else {
+                console.log('❌ Post to accounting provider - incorrect account IDs');
+                console.log('   Transfer:', transfer);
+                console.log('   Deposit:', deposit);
+                failed++;
+            }
         } else {
             console.log('❌ Post to accounting provider - failed');
             console.log('   Provider doc IDs:', providerDocIds);
             console.log('   JE count:', provider.journalEntries.length);
             console.log('   Transfer count:', provider.transfers.length);
+            console.log('   Deposit count:', provider.deposits.length);
             failed++;
         }
     } catch (error) {

--- a/tests/quickbooksProvider.test.js
+++ b/tests/quickbooksProvider.test.js
@@ -65,19 +65,31 @@ class MockQBOClient {
             }
             return callback(null, { QueryResponse: { JournalEntry: this.journalEntries } });
         } else if (queryStr.includes('FROM Transfer')) {
-            const noteMatch = queryStr.match(/PrivateNote LIKE '%([^%]+)%'/);
-            if (noteMatch) {
-                const transfer = this.transfers.find(t => t.PrivateNote && t.PrivateNote.includes(noteMatch[1]));
-                return callback(null, { QueryResponse: { Transfer: transfer ? [transfer] : [] } });
+            const dateMatch = queryStr.match(/TxnDate = '([^']+)'/);
+            const amountMatch = queryStr.match(/Amount = '([^']+)'/);
+
+            let transfers = this.transfers;
+
+            if (dateMatch) {
+                transfers = transfers.filter(t => t.TxnDate === dateMatch[1]);
             }
-            return callback(null, { QueryResponse: { Transfer: this.transfers } });
+
+            if (amountMatch) {
+                transfers = transfers.filter(t =>
+                    parseFloat(t.Amount).toFixed(2) === parseFloat(amountMatch[1]).toFixed(2)
+                );
+            }
+
+            return callback(null, { QueryResponse: { Transfer: transfers } });
         } else if (queryStr.includes('FROM Deposit')) {
-            const noteMatch = queryStr.match(/PrivateNote LIKE '%([^%]+)%'/);
-            if (noteMatch) {
-                const deposit = this.deposits.find(d => d.PrivateNote && d.PrivateNote.includes(noteMatch[1]));
-                return callback(null, { QueryResponse: { Deposit: deposit ? [deposit] : [] } });
+            const docNumberMatch = queryStr.match(/DocNumber = '([^']+)'/);
+            let deposits = this.deposits;
+
+            if (docNumberMatch) {
+                deposits = deposits.filter(d => d.DocNumber === docNumberMatch[1]);
             }
-            return callback(null, { QueryResponse: { Deposit: this.deposits } });
+
+            return callback(null, { QueryResponse: { Deposit: deposits } });
         }
 
         callback(null, { QueryResponse: {} });
@@ -157,6 +169,7 @@ class MockQBOClient {
             DepositToAccountRef: deposit.DepositToAccountRef,
             TxnDate: deposit.TxnDate,
             PrivateNote: deposit.PrivateNote,
+            DocNumber: deposit.DocNumber,
             Line: deposit.Line,
             TotalAmt: totalAmt.toFixed(2)
         };
@@ -249,13 +262,25 @@ class MockQBOClient {
 
         let filteredTransfers = this.transfers;
 
-        // Handle array criteria with LIKE operator
+        // Handle array criteria
         if (Array.isArray(criteria)) {
             criteria.forEach(c => {
-                if (c.field === 'PrivateNote' && c.operator === 'LIKE') {
-                    const searchValue = c.value.replace(/%/g, '');
-                    filteredTransfers = filteredTransfers.filter(t => 
-                        t.PrivateNote && t.PrivateNote.includes(searchValue)
+                if (c.field === 'TxnDate') {
+                    filteredTransfers = filteredTransfers.filter(t => t.TxnDate === c.value);
+                }
+                if (c.field === 'Amount') {
+                    filteredTransfers = filteredTransfers.filter(t =>
+                        parseFloat(t.Amount).toFixed(2) === parseFloat(c.value).toFixed(2)
+                    );
+                }
+                if (c.field === 'FromAccountRef') {
+                    filteredTransfers = filteredTransfers.filter(t =>
+                        t.FromAccountRef && t.FromAccountRef.value === c.value
+                    );
+                }
+                if (c.field === 'ToAccountRef') {
+                    filteredTransfers = filteredTransfers.filter(t =>
+                        t.ToAccountRef && t.ToAccountRef.value === c.value
                     );
                 }
             });
@@ -271,14 +296,11 @@ class MockQBOClient {
 
         let filteredDeposits = this.deposits;
 
-        // Handle array criteria with LIKE operator
+        // Handle array criteria
         if (Array.isArray(criteria)) {
             criteria.forEach(c => {
-                if (c.field === 'PrivateNote' && c.operator === 'LIKE') {
-                    const searchValue = c.value.replace(/%/g, '');
-                    filteredDeposits = filteredDeposits.filter(d => 
-                        d.PrivateNote && d.PrivateNote.includes(searchValue)
-                    );
+                if (c.field === 'DocNumber') {
+                    filteredDeposits = filteredDeposits.filter(d => d.DocNumber === c.value);
                 }
             });
         }
@@ -652,7 +674,7 @@ async function runTests() {
             Id: 'transfer-existing',
             FromAccountRef: { value: 'acc-1' },
             ToAccountRef: { value: 'acc-2' },
-            Amount: '5000.00',
+            Amount: '50.00',
             TxnDate: '2024-01-15',
             PrivateNote: 'Test transfer [DocNum: XFER-2024-001]'
         });
@@ -725,7 +747,8 @@ async function runTests() {
         if (result.created === true &&
             result.docNumber === 'DEP-2024-001' &&
             result.totalAmt === 1500 &&
-            mockQBOClient.deposits.length === 1) {
+            mockQBOClient.deposits.length === 1 &&
+            mockQBOClient.deposits[0].DocNumber === 'DEP-2024-001') {
             console.log('✅ Create deposit');
             passed++;
         } else {
@@ -747,7 +770,8 @@ async function runTests() {
             TxnDate: '2024-01-15',
             TotalAmt: '1500.00',
             PrivateNote: 'Test deposit [DocNum: DEP-2024-001]',
-            Line: []
+            Line: [],
+            DocNumber: 'DEP-2024-001'
         });
         
         const config = {


### PR DESCRIPTION
## Summary
- update the QuickBooks provider to look up transfers by date and amount, fall back gracefully, and persist deposit DocNumbers for idempotency
- wrap the Azure Function context logger with standard log/warn/error methods before passing it to the payout sync and QuickBooks provider
- align QuickBooks provider and journal entry tests with the new lookup behavior and assert DocNumber handling

## Testing
- npm test -- payoutSync

------
https://chatgpt.com/codex/tasks/task_e_68e07824d6e8832c90147de7f8bdf91e