### PR TITLE
Add configurable per-transaction payout journal mode

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -180,7 +180,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 PrivateNote: journalEntry.memo || '',
                 Line: journalEntry.lines.map((line, index) => ({
                     Id: (index + 1).toString(),
-                    Description: line.description || journalEntry.memo || '',
+                    Description: line.memo || line.description || journalEntry.memo || '',
                     Amount: (line.amount / 100).toFixed(2), // Convert cents to dollars
                     DetailType: 'JournalEntryLineDetail',
                     JournalEntryLineDetail: {
@@ -409,7 +409,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                             value: line.accountId
                         }
                     },
-                    Description: line.description || deposit.memo || ''
+                    Description: line.memo || line.description || deposit.memo || ''
                 }))
             };
 

--- a/services/accountingSyncConfig.js
+++ b/services/accountingSyncConfig.js
@@ -59,6 +59,7 @@ class AccountingSyncConfig {
                 granularity: process.env.ACCOUNTING_POSTING_GRANULARITY || 'per-payout', // per-payout, per-day, per-transaction
                 strategy: process.env.ACCOUNTING_POSTING_STRATEGY || 'je-transfer', // je-transfer, deposit
                 dateSource: process.env.ACCOUNTING_POSTING_DATE_SOURCE || 'arrival', // arrival, created
+                transactionLineMode: (process.env.ACCOUNTING_POSTING_TRANSACTION_LINE_MODE || 'summary').toLowerCase(),
                 timezone: process.env.ACCOUNTING_TIMEZONE || 'America/New_York',
                 autoCreateAccounts: process.env.ACCOUNTING_AUTO_CREATE_ACCOUNTS === 'true'
             },

--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -399,12 +399,14 @@ class PayoutSyncService {
      * @param {string} stripeAccountId - Stripe account ID
      * @returns {Object} Posting instructions
      */
-    generatePostingInstructions(payout, summary, stripeAccountId = null) {
+    generatePostingInstructions(payout, summary, stripeAccountId = null, balanceTransactions = []) {
         this.logger.log(`[PayoutSync] Generating posting instructions for payout: ${payout.id}`);
 
         const config = this.config.getConfig();
-        const accountConfig = config.accounts;
-        const postingConfig = config.posting;
+        const accountConfig = config.accounts || {};
+        const postingConfig = config.posting || {};
+        const transactionLineMode = (postingConfig.transactionLineMode || 'summary').toLowerCase();
+        const usePerTransactionLines = transactionLineMode === 'per-transaction' && Array.isArray(balanceTransactions) && balanceTransactions.length > 0;
 
         // Determine accounts
         const clearingAccount = accountConfig.stripeClearingAccount;
@@ -429,76 +431,97 @@ class PayoutSyncService {
         const jeLines = [];
         let clearingNet = 0;
 
-        // Revenue (charges)
-        if (summary.charges.grossAmount > 0) {
-            jeLines.push({
-                type: 'credit',
-                accountKey: 'revenue',
-                accountName: revenueAccount,
-                amount: summary.charges.grossAmount,
-                memo: `Revenue from ${summary.charges.count} Stripe charges`
-            });
-            clearingNet += summary.charges.grossAmount;
-        }
+        if (usePerTransactionLines) {
+            for (const txn of balanceTransactions) {
+                if (!this._shouldIncludeTransactionInJournal(txn)) {
+                    continue;
+                }
 
-        // Refunds
-        if (summary.refunds.amount > 0) {
-            jeLines.push({
-                type: 'debit',
-                accountKey: 'refunds',
-                accountName: refundsAccount,
-                amount: summary.refunds.amount,
-                memo: `Stripe refunds - ${summary.refunds.count} transactions`
-            });
-            clearingNet -= summary.refunds.amount;
-        }
+                const line = this._mapTransactionToJournalLine(txn, {
+                    revenueAccount,
+                    refundsAccount,
+                    feesAccount,
+                    chargebackAccount,
+                    adjustmentAccount
+                });
 
-        // Stripe fees
-        const totalFees = summary.fees.stripe.amount + summary.fees.application.amount;
-        if (totalFees > 0) {
-            jeLines.push({
-                type: 'debit',
-                accountKey: 'fees',
-                accountName: feesAccount,
-                amount: totalFees,
-                memo: `Stripe processing fees`
-            });
-            clearingNet -= totalFees;
-        }
-
-        // Disputes/chargebacks
-        if (summary.disputes.amount > 0) {
-            jeLines.push({
-                type: 'debit',
-                accountKey: 'chargebacks',
-                accountName: chargebackAccount,
-                amount: summary.disputes.amount,
-                memo: `Chargebacks - ${summary.disputes.count} disputes`
-            });
-            clearingNet -= summary.disputes.amount;
-        }
-
-        // Adjustments
-        if (summary.adjustments.amount !== 0) {
-            const adjustmentAmount = Math.abs(summary.adjustments.amount);
-            if (summary.adjustments.amount > 0) {
+                if (line) {
+                    jeLines.push(line);
+                    clearingNet += line.type === 'credit' ? line.amount : -line.amount;
+                }
+            }
+        } else {
+            // Revenue (charges)
+            if (summary.charges.grossAmount > 0) {
                 jeLines.push({
                     type: 'credit',
-                    accountKey: 'adjustments',
-                    accountName: adjustmentAccount,
-                    amount: adjustmentAmount,
-                    memo: `Positive Stripe adjustments`
+                    accountKey: 'revenue',
+                    accountName: revenueAccount,
+                    amount: summary.charges.grossAmount,
+                    memo: `Revenue from ${summary.charges.count} Stripe charges`
                 });
-                clearingNet += adjustmentAmount;
-            } else {
+                clearingNet += summary.charges.grossAmount;
+            }
+
+            // Refunds
+            if (summary.refunds.amount > 0) {
                 jeLines.push({
                     type: 'debit',
-                    accountKey: 'adjustments',
-                    accountName: adjustmentAccount,
-                    amount: adjustmentAmount,
-                    memo: `Negative Stripe adjustments`
+                    accountKey: 'refunds',
+                    accountName: refundsAccount,
+                    amount: summary.refunds.amount,
+                    memo: `Stripe refunds - ${summary.refunds.count} transactions`
                 });
-                clearingNet -= adjustmentAmount;
+                clearingNet -= summary.refunds.amount;
+            }
+
+            // Stripe fees
+            const totalFees = summary.fees.stripe.amount + summary.fees.application.amount;
+            if (totalFees > 0) {
+                jeLines.push({
+                    type: 'debit',
+                    accountKey: 'fees',
+                    accountName: feesAccount,
+                    amount: totalFees,
+                    memo: `Stripe processing fees`
+                });
+                clearingNet -= totalFees;
+            }
+
+            // Disputes/chargebacks
+            if (summary.disputes.amount > 0) {
+                jeLines.push({
+                    type: 'debit',
+                    accountKey: 'chargebacks',
+                    accountName: chargebackAccount,
+                    amount: summary.disputes.amount,
+                    memo: `Chargebacks - ${summary.disputes.count} disputes`
+                });
+                clearingNet -= summary.disputes.amount;
+            }
+
+            // Adjustments
+            if (summary.adjustments.amount !== 0) {
+                const adjustmentAmount = Math.abs(summary.adjustments.amount);
+                if (summary.adjustments.amount > 0) {
+                    jeLines.push({
+                        type: 'credit',
+                        accountKey: 'adjustments',
+                        accountName: adjustmentAccount,
+                        amount: adjustmentAmount,
+                        memo: `Positive Stripe adjustments`
+                    });
+                    clearingNet += adjustmentAmount;
+                } else {
+                    jeLines.push({
+                        type: 'debit',
+                        accountKey: 'adjustments',
+                        accountName: adjustmentAccount,
+                        amount: adjustmentAmount,
+                        memo: `Negative Stripe adjustments`
+                    });
+                    clearingNet -= adjustmentAmount;
+                }
             }
         }
 
@@ -550,7 +573,10 @@ class PayoutSyncService {
                 date: postingDate,
                 reference: `Stripe Payout ${stripeAccountId ? stripeAccountId + '/' : ''}${payout.id}`,
                 memo: `Stripe payout activity for ${postingDate.toISOString().split('T')[0]}`,
-                lines: jeLines
+                lines: jeLines,
+                metadata: {
+                    transactionLineMode
+                }
             });
         }
 
@@ -897,6 +923,154 @@ class PayoutSyncService {
         }
 
         return description;
+    }
+
+    /**
+     * Determine whether a balance transaction should be translated into a journal line
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {boolean}
+     * @private
+     */
+    _shouldIncludeTransactionInJournal(txn) {
+        if (!txn || typeof txn !== 'object') {
+            return false;
+        }
+
+        const excludedTypes = new Set(['payout', 'advance', 'payout_cancel']);
+        return !excludedTypes.has(txn.type);
+    }
+
+    /**
+     * Build a memo for a per-transaction journal line
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {string}
+     * @private
+     */
+    _buildTransactionMemo(txn) {
+        if (!txn || typeof txn !== 'object') {
+            return 'Stripe transaction';
+        }
+
+        if (txn.description) {
+            return txn.description;
+        }
+
+        if (txn.metadata && txn.metadata.statement_descriptor) {
+            return txn.metadata.statement_descriptor;
+        }
+
+        if (txn.source) {
+            return `Stripe ${txn.type || 'transaction'} ${txn.source}`;
+        }
+
+        return `Stripe ${txn.type || 'transaction'} ${txn.id || ''}`.trim();
+    }
+
+    /**
+     * Build metadata for a per-transaction journal line
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {Object}
+     * @private
+     */
+    _buildTransactionMetadata(txn) {
+        if (!txn || typeof txn !== 'object') {
+            return {};
+        }
+
+        const metadata = {
+            balanceTransactionId: txn.id || null,
+            stripeType: txn.type || null,
+            source: txn.source || null,
+            payoutId: txn.payout || null,
+            amount: typeof txn.amount === 'number' ? txn.amount : null,
+            net: typeof txn.net === 'number' ? txn.net : null,
+            fee: typeof txn.fee === 'number' ? txn.fee : null,
+            currency: txn.currency || null,
+            description: txn.description || null,
+            reportingCategory: txn.reporting_category || null,
+            created: txn.created || null,
+            availableOn: txn.available_on || null
+        };
+
+        if (txn.metadata && Object.keys(txn.metadata).length > 0) {
+            metadata.stripeMetadata = txn.metadata;
+        }
+
+        if (Array.isArray(txn.fee_details) && txn.fee_details.length > 0) {
+            metadata.feeDetails = txn.fee_details.map(detail => ({
+                type: detail.type,
+                amount: detail.amount,
+                application: detail.application || null,
+                description: detail.description || null
+            }));
+        }
+
+        if (txn.exchange_rate) {
+            metadata.exchangeRate = txn.exchange_rate;
+        }
+
+        return metadata;
+    }
+
+    /**
+     * Map a Stripe balance transaction to a journal entry line in per-transaction mode
+     * @param {Object} txn - Stripe balance transaction
+     * @param {Object} accounts - Account mapping
+     * @returns {Object|null} Journal line or null if the transaction should be skipped
+     * @private
+     */
+    _mapTransactionToJournalLine(txn, accounts) {
+        if (!txn || typeof txn !== 'object') {
+            return null;
+        }
+
+        const { revenueAccount, refundsAccount, feesAccount, chargebackAccount, adjustmentAccount } = accounts;
+        const memo = this._buildTransactionMemo(txn);
+        const metadata = this._buildTransactionMetadata(txn);
+        const rawAmount = typeof txn.net === 'number' ? txn.net : txn.amount;
+        const amount = Math.abs(rawAmount || 0);
+
+        if (!amount) {
+            return null;
+        }
+
+        const makeLine = (type, accountKey, accountName) => ({
+            type,
+            accountKey,
+            accountName,
+            amount,
+            memo,
+            metadata
+        });
+
+        switch (txn.type) {
+            case 'charge':
+            case 'payment':
+                return makeLine('credit', 'revenue', revenueAccount);
+            case 'refund':
+            case 'payment_refund':
+                return makeLine('debit', 'refunds', refundsAccount);
+            case 'stripe_fee':
+            case 'application_fee':
+                return makeLine('debit', 'fees', feesAccount);
+            case 'application_fee_refund':
+                return makeLine('credit', 'fees', feesAccount);
+            case 'adjustment':
+                return rawAmount >= 0
+                    ? makeLine('credit', 'adjustments', adjustmentAccount)
+                    : makeLine('debit', 'adjustments', adjustmentAccount);
+            default:
+                if (txn.type && txn.type.includes('dispute')) {
+                    return rawAmount >= 0
+                        ? makeLine('credit', 'chargebacks', chargebackAccount)
+                        : makeLine('debit', 'chargebacks', chargebackAccount);
+                }
+
+                // Fallback: treat as adjustment using sign of amount
+                return rawAmount >= 0
+                    ? makeLine('credit', 'adjustments', adjustmentAccount)
+                    : makeLine('debit', 'adjustments', adjustmentAccount);
+        }
     }
 
     /**

--- a/stripeWebhook/index.js
+++ b/stripeWebhook/index.js
@@ -1070,7 +1070,8 @@ const processPayoutJob = async (context, payoutId, stripeAccountId, payoutSyncSe
             const postingInstructions = payoutSyncService.generatePostingInstructions(
                 payout,
                 summary,
-                stripeAccountId
+                stripeAccountId,
+                balanceTransactions
             );
             
             // Record the failed sync in ledger so next payout can use its arrival_date as lower bound
@@ -1113,7 +1114,8 @@ const processPayoutJob = async (context, payoutId, stripeAccountId, payoutSyncSe
         const postingInstructions = payoutSyncService.generatePostingInstructions(
             payout,
             summary,
-            stripeAccountId
+            stripeAccountId,
+            balanceTransactions
         );
         context.log(`[PayoutJob] Generated ${postingInstructions.documents.length} documents`);
 

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -634,6 +634,141 @@ async function runTests() {
         failed++;
     }
 
+    // Test 10: Per-transaction journal line mode emits detailed lines
+    try {
+        const mockConfig = {
+            getConfig: () => ({
+                provider: 'quickbooks',
+                accounts: {
+                    stripeClearingAccount: 'Stripe Clearing',
+                    operatingBankAccount: 'Operating Bank',
+                    revenueAccount: 'Revenue',
+                    refundsAccount: 'Refunds',
+                    stripeFeeAccount: 'Stripe Fees',
+                    chargebackAccount: 'Chargebacks',
+                    adjustmentAccount: 'Adjustments'
+                },
+                posting: {
+                    strategy: 'je-transfer',
+                    transactionLineMode: 'per-transaction',
+                    dateSource: 'arrival'
+                }
+            }),
+            getStripeAccount: () => null
+        };
+
+        const syncLedger = new SyncLedger();
+        const provider = new MockAccountingProvider();
+        const service = new PayoutSyncService(mockConfig, provider, syncLedger);
+
+        const baseTime = Math.floor(Date.now() / 1000);
+        const balanceTransactions = [
+            {
+                id: 'txn_charge_1',
+                type: 'charge',
+                amount: 5000,
+                net: 4850,
+                fee: 150,
+                currency: 'usd',
+                description: 'Donation A',
+                source: 'ch_123',
+                metadata: { donationId: 'don_1' },
+                created: baseTime - 3600,
+                available_on: baseTime,
+                payout: 'po_txn_mode'
+            },
+            {
+                id: 'txn_refund_1',
+                type: 'refund',
+                amount: -2000,
+                net: -2000,
+                fee: 0,
+                currency: 'usd',
+                description: 'Refund B',
+                source: 're_123',
+                created: baseTime - 3200,
+                available_on: baseTime,
+                payout: 'po_txn_mode'
+            },
+            {
+                id: 'txn_fee_1',
+                type: 'stripe_fee',
+                amount: -150,
+                net: -150,
+                fee: 0,
+                currency: 'usd',
+                description: 'Stripe fee for payout',
+                created: baseTime - 3000,
+                available_on: baseTime,
+                payout: 'po_txn_mode'
+            },
+            {
+                id: 'txn_adjust_1',
+                type: 'adjustment',
+                amount: 100,
+                net: 100,
+                fee: 0,
+                currency: 'usd',
+                description: 'Positive adjustment',
+                metadata: { reason: 'Manual correction' },
+                created: baseTime - 2800,
+                available_on: baseTime,
+                payout: 'po_txn_mode'
+            }
+        ];
+
+        const summary = service.summarize(balanceTransactions);
+        const payout = {
+            id: 'po_txn_mode',
+            amount: summary.total,
+            arrival_date: baseTime,
+            created: baseTime
+        };
+
+        const instructions = service.generatePostingInstructions(payout, summary, null, balanceTransactions);
+        const journal = instructions.documents.find(doc => doc.type === 'journal');
+        const clearingLine = journal ? journal.lines.find(line => line.accountKey === 'clearing') : null;
+        const detailLines = journal ? journal.lines.filter(line => line.accountKey !== 'clearing') : [];
+        const chargeLine = detailLines.find(line => line.metadata?.balanceTransactionId === 'txn_charge_1');
+        const refundLine = detailLines.find(line => line.metadata?.balanceTransactionId === 'txn_refund_1');
+        const feeLine = detailLines.find(line => line.metadata?.balanceTransactionId === 'txn_fee_1');
+        const adjustmentLine = detailLines.find(line => line.metadata?.balanceTransactionId === 'txn_adjust_1');
+        const allHaveMetadata = detailLines.every(line => line.metadata && line.metadata.balanceTransactionId);
+        const metadataMode = journal?.metadata?.transactionLineMode === 'per-transaction';
+
+        const chargeTransaction = balanceTransactions.find(txn => txn.id === 'txn_charge_1');
+        const refundTransaction = balanceTransactions.find(txn => txn.id === 'txn_refund_1');
+        const feeTransaction = balanceTransactions.find(txn => txn.id === 'txn_fee_1');
+        const adjustmentTransaction = balanceTransactions.find(txn => txn.id === 'txn_adjust_1');
+
+        const linesValid = journal &&
+            clearingLine &&
+            clearingLine.type === 'debit' &&
+            clearingLine.amount === payout.amount &&
+            detailLines.length === balanceTransactions.length &&
+            chargeLine && chargeLine.type === 'credit' && chargeLine.accountKey === 'revenue' && chargeLine.amount === Math.abs(chargeTransaction.net) && chargeLine.memo === 'Donation A' &&
+            refundLine && refundLine.type === 'debit' && refundLine.accountKey === 'refunds' && refundLine.amount === Math.abs(refundTransaction.net) &&
+            feeLine && feeLine.type === 'debit' && feeLine.accountKey === 'fees' && feeLine.amount === Math.abs(feeTransaction.net) &&
+            adjustmentLine && adjustmentLine.type === 'credit' && adjustmentLine.accountKey === 'adjustments' && adjustmentLine.amount === Math.abs(adjustmentTransaction.net) &&
+            allHaveMetadata &&
+            chargeLine.metadata?.stripeMetadata?.donationId === 'don_1' &&
+            chargeLine.metadata?.amount === chargeTransaction.amount &&
+            chargeLine.metadata?.net === chargeTransaction.net &&
+            metadataMode;
+
+        if (linesValid) {
+            console.log('✅ Per-transaction journal line mode emits detailed lines');
+            passed++;
+        } else {
+            console.log('❌ Per-transaction journal line mode failed');
+            console.log('   Journal:', journal);
+            failed++;
+        }
+    } catch (error) {
+        console.log('❌ Per-transaction journal line mode - error:', error.message);
+        failed++;
+    }
+
     // Summary
     console.log(`\n📊 Payout Sync Test Results: ${passed}/${passed + failed} tests passed`);
 

--- a/tests/quickbooksProvider.test.js
+++ b/tests/quickbooksProvider.test.js
@@ -512,7 +512,7 @@ async function runTests() {
             date: new Date('2024-01-15'),
             memo: 'Test journal entry',
             lines: [
-                { type: 'debit', accountId: 'acc-1', amount: 1000, description: 'Debit line' },
+                { type: 'debit', accountId: 'acc-1', amount: 1000, memo: 'Debit memo', description: 'Debit line' },
                 { type: 'credit', accountId: 'acc-2', amount: 1000, description: 'Credit line' }
             ]
         };
@@ -521,7 +521,9 @@ async function runTests() {
 
         if (result.created === true &&
             result.docNumber === 'JE-2024-001' &&
-            mockQBOClient.journalEntries.length === 1) {
+            mockQBOClient.journalEntries.length === 1 &&
+            mockQBOClient.journalEntries[0].Line[0].Description === 'Debit memo' &&
+            mockQBOClient.journalEntries[0].Line[1].Description === 'Credit line') {
             console.log('✅ Create journal entry');
             passed++;
         } else {
@@ -737,8 +739,8 @@ async function runTests() {
             toAccountId: 'acc-bank',
             memo: 'Test deposit',
             lines: [
-                { accountId: 'acc-revenue', amount: 1000, description: 'Revenue line 1' },
-                { accountId: 'acc-revenue', amount: 500, description: 'Revenue line 2' }
+                { accountId: 'acc-revenue', amount: 1000, memo: 'Deposit memo line 1', description: 'Revenue line 1' },
+                { accountId: 'acc-revenue', amount: 500 }
             ]
         };
 
@@ -748,7 +750,9 @@ async function runTests() {
             result.docNumber === 'DEP-2024-001' &&
             result.totalAmt === 1500 &&
             mockQBOClient.deposits.length === 1 &&
-            mockQBOClient.deposits[0].DocNumber === 'DEP-2024-001') {
+            mockQBOClient.deposits[0].DocNumber === 'DEP-2024-001' &&
+            mockQBOClient.deposits[0].Line[0].Description === 'Deposit memo line 1' &&
+            mockQBOClient.deposits[0].Line[1].Description === 'Test deposit') {
             console.log('✅ Create deposit');
             passed++;
         } else {


### PR DESCRIPTION
## Summary
- add a transaction line mode configuration for accounting posting policies
- extend payout posting generation to accept raw balance transactions and emit per-transaction journal lines when configured
- update the Stripe webhook payout handler and payout sync tests to cover the new detailed line mode

## Testing
- node tests/payoutSync.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e105bf01d0832c8b02ef215b54d53e