### PR TITLE
Handle QuickBooks refresh token failures

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -633,11 +633,11 @@ class QuickBooksProvider extends BaseAccountingProvider {
         }
 
         try {
-            const refreshToken = await new Promise((resolve, reject) => {
+            const refreshResponse = await new Promise((resolve, reject) => {
                 if (!this.qbo) {
                     this._initializeClient();
                 }
-                
+
                 this.qbo.refreshAccessToken((err, data) => {
                     if (err) {
                         this.logger.error('[QBO] Error refreshing token:', err);
@@ -648,17 +648,26 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 });
             });
 
+            if (!refreshResponse || typeof refreshResponse !== 'object') {
+                throw new Error('Invalid token refresh response from QuickBooks');
+            }
+
+            if (!refreshResponse.access_token || refreshResponse.error) {
+                const errorDescription = refreshResponse.error_description || refreshResponse.error || 'Missing access token';
+                throw new Error(errorDescription);
+            }
+
             // Update stored tokens
-            this.oauthTokens.accessToken = refreshToken.access_token;
-            if (refreshToken.refresh_token) {
-                this.oauthTokens.refreshToken = refreshToken.refresh_token;
+            this.oauthTokens.accessToken = refreshResponse.access_token;
+            if (refreshResponse.refresh_token) {
+                this.oauthTokens.refreshToken = refreshResponse.refresh_token;
             }
 
             // Reinitialize client with new token
             this._initializeClient();
 
             this.logger.log('[QBO] Successfully refreshed OAuth tokens');
-            
+
             // Note: In production, you should persist these tokens to storage
             // so they can be used across sessions
             if (process.env.NODE_ENV === 'production') {
@@ -668,7 +677,8 @@ class QuickBooksProvider extends BaseAccountingProvider {
             return true;
         } catch (error) {
             this.logger.error('[QBO] Failed to refresh tokens:', error);
-            throw new Error(`Failed to refresh OAuth tokens: ${error.message}`);
+            const message = error && error.message ? error.message : 'Unknown error';
+            throw new Error(`Failed to refresh OAuth tokens: ${message}`);
         }
     }
 

--- a/tests/quickbooksProvider.test.js
+++ b/tests/quickbooksProvider.test.js
@@ -25,6 +25,11 @@ class MockQBOClient {
         };
         this.shouldFailAuth = false;
         this.tokenRefreshCount = 0;
+        this.refreshError = null;
+        this.refreshResponse = {
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token'
+        };
     }
 
     reset() {
@@ -34,6 +39,11 @@ class MockQBOClient {
         this.deposits = [];
         this.shouldFailAuth = false;
         this.tokenRefreshCount = 0;
+        this.refreshError = null;
+        this.refreshResponse = {
+            access_token: 'new-access-token',
+            refresh_token: 'new-refresh-token'
+        };
     }
 
     query(queryStr, callback) {
@@ -187,10 +197,11 @@ class MockQBOClient {
 
     refreshAccessToken(callback) {
         this.tokenRefreshCount++;
-        callback(null, {
-            access_token: 'new-access-token',
-            refresh_token: 'new-refresh-token'
-        });
+        if (this.refreshError) {
+            return callback(this.refreshError);
+        }
+
+        callback(null, this.refreshResponse);
     }
 
     // Find methods to match the real node-quickbooks API
@@ -913,7 +924,7 @@ async function runTests() {
     // Test 15: Token refresh
     try {
         mockQBOClient.reset();
-        
+
         const config = {
             companyId: 'test-company-123',
             environment: 'sandbox',
@@ -924,7 +935,7 @@ async function runTests() {
         };
 
         const provider = new QuickBooksProvider(config);
-        
+
         const initialRefreshCount = mockQBOClient.tokenRefreshCount;
         const result = await provider.refreshTokens();
 
@@ -938,6 +949,38 @@ async function runTests() {
     } catch (error) {
         console.log('❌ Token refresh - error:', error.message);
         failed++;
+    }
+
+    // Test 16: Token refresh failure surfaces error
+    try {
+        mockQBOClient.reset();
+        mockQBOClient.refreshResponse = {
+            error: 'invalid_grant',
+            error_description: 'Incorrect or invalid refresh token'
+        };
+
+        const config = {
+            companyId: 'test-company-123',
+            environment: 'sandbox',
+            oauthTokens: {
+                accessToken: 'expired-token',
+                refreshToken: 'invalid-refresh-token'
+            }
+        };
+
+        const provider = new QuickBooksProvider(config);
+
+        await provider.refreshTokens();
+        console.log('❌ Token refresh failure - expected error but succeeded');
+        failed++;
+    } catch (error) {
+        if (error.message.includes('Incorrect or invalid refresh token')) {
+            console.log('✅ Token refresh failure surfaces error');
+            passed++;
+        } else {
+            console.log('❌ Token refresh failure - unexpected error:', error.message);
+            failed++;
+        }
     }
 
     // Print summary


### PR DESCRIPTION
## Summary
- validate the QuickBooks token refresh flow so that invalid refresh responses throw clear errors instead of proceeding with undefined tokens
- extend the QuickBooks provider unit tests to cover refresh success and failure scenarios

## Testing
- node tests/quickbooksProvider.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e10bf1f560832c8a2d9adc35d8b4a4