### PR TITLE
Handle missing SendGrid configuration safely

### DIFF
--- a/processTransaction/index.js
+++ b/processTransaction/index.js
@@ -5,13 +5,23 @@ const { loadConfig, normalizeTransactionCategory, generateTransactionName } = re
 
 // Initialize Stripe and SendGrid
 const initializeServices = (isLiveMode) => {
-    const stripeKey = isLiveMode 
-        ? process.env.STRIPE_LIVE_SECRET_KEY 
+    const stripeKey = isLiveMode
+        ? process.env.STRIPE_LIVE_SECRET_KEY
         : process.env.STRIPE_TEST_SECRET_KEY;
-    
+
     const stripe = new Stripe(stripeKey);
-    sgMail.setApiKey(process.env.SENDGRID_API_KEY);
-    
+
+    const sendgridKey = process.env.SENDGRID_API_KEY;
+    if (sendgridKey) {
+        try {
+            sgMail.setApiKey(sendgridKey);
+        } catch (error) {
+            console.error('Failed to initialize SendGrid:', error.message);
+        }
+    } else {
+        console.log('SendGrid API key not configured. Email notifications disabled.');
+    }
+
     return { stripe };
 };
 


### PR DESCRIPTION
## Summary
- guard SendGrid initialization so missing API keys no longer throw during checkout handling
- log when email notifications are disabled while keeping Stripe initialization unchanged

## Testing
- npm test -- --runTestsByPath tests/checkoutCrmSync.test.js *(fails: existing SyntaxError in services/accounting/quickbooksProvider.js while running suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e118d624b4832c98eb5e140ed5e1e1