### PR TITLE
Improve payout charge descriptions and tracking metadata

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -180,7 +180,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 PrivateNote: journalEntry.memo || '',
                 Line: journalEntry.lines.map((line, index) => ({
                     Id: (index + 1).toString(),
-                    Description: line.memo || line.description || journalEntry.memo || '',
+                    Description: line.description || line.memo || journalEntry.memo || '',
                     Amount: (line.amount / 100).toFixed(2), // Convert cents to dollars
                     DetailType: 'JournalEntryLineDetail',
                     JournalEntryLineDetail: {

--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -959,11 +959,89 @@ class PayoutSyncService {
             return txn.metadata.statement_descriptor;
         }
 
-        if (txn.source) {
-            return `Stripe ${txn.type || 'transaction'} ${txn.source}`;
+        const base = `Stripe ${txn.type || 'transaction'}`.trim();
+
+        // Only append the source/ID for non-charge transactions so the charge
+        // identifier can be displayed in the dedicated Name column.
+        if (txn.source && txn.type !== 'charge' && txn.type !== 'payment') {
+            return `${base} ${txn.source}`.trim();
         }
 
-        return `Stripe ${txn.type || 'transaction'} ${txn.id || ''}`.trim();
+        if (txn.id && txn.type !== 'charge' && txn.type !== 'payment') {
+            return `${base} ${txn.id}`.trim();
+        }
+
+        return base;
+    }
+
+    /**
+     * Build a richer description for a balance transaction, primarily used for
+     * charge tracking when rendering posting instructions or accounting lines.
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {string|null}
+     * @private
+     */
+    _buildTransactionDescription(txn) {
+        if (!txn || typeof txn !== 'object') {
+            return null;
+        }
+
+        const memo = this._buildTransactionMemo(txn);
+
+        // Only enrich charge/payment transactions with detailed amounts. Other
+        // transaction types keep the memo-only description.
+        if (txn.type !== 'charge' && txn.type !== 'payment') {
+            return memo;
+        }
+
+        const details = [];
+
+        if (typeof txn.amount === 'number') {
+            const formatted = this._formatCurrency(txn.amount, txn.currency);
+            if (formatted) {
+                details.push(`Gross: ${formatted}`);
+            }
+        }
+
+        if (typeof txn.fee === 'number' && txn.fee !== 0) {
+            const formattedFee = this._formatCurrency(Math.abs(txn.fee), txn.currency);
+            if (formattedFee) {
+                details.push(`Fees: ${formattedFee}`);
+            }
+        }
+
+        if (typeof txn.net === 'number') {
+            const formattedNet = this._formatCurrency(txn.net, txn.currency);
+            if (formattedNet) {
+                details.push(`Net: ${formattedNet}`);
+            }
+        }
+
+        if (details.length === 0) {
+            return memo;
+        }
+
+        const detailString = details.join(', ');
+        return memo ? `${memo} | ${detailString}` : detailString;
+    }
+
+    /**
+     * Build the name to associate with a transaction line. For Stripe charges we
+     * prefer the charge identifier so it can surface in accounting Name columns.
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {string|null}
+     * @private
+     */
+    _buildTransactionName(txn) {
+        if (!txn || typeof txn !== 'object') {
+            return null;
+        }
+
+        if (txn.type === 'charge' || txn.type === 'payment') {
+            return txn.source || txn.id || null;
+        }
+
+        return null;
     }
 
     /**
@@ -1026,6 +1104,8 @@ class PayoutSyncService {
 
         const { revenueAccount, refundsAccount, feesAccount, chargebackAccount, adjustmentAccount } = accounts;
         const memo = this._buildTransactionMemo(txn);
+        const description = this._buildTransactionDescription(txn);
+        const name = this._buildTransactionName(txn);
         const metadata = this._buildTransactionMetadata(txn);
         const rawAmount = typeof txn.net === 'number' ? txn.net : txn.amount;
         const amount = Math.abs(rawAmount || 0);
@@ -1040,6 +1120,8 @@ class PayoutSyncService {
             accountName,
             amount,
             memo,
+            description,
+            name,
             metadata
         });
 
@@ -1125,7 +1207,7 @@ class PayoutSyncService {
      */
     _getAccountSubType(accountName) {
         const normalizedName = accountName.toLowerCase();
-        
+
         if (normalizedName.includes('clearing')) {
             return 'CashOnHand';
         } else if (normalizedName.includes('bank')) {
@@ -1135,8 +1217,33 @@ class PayoutSyncService {
         } else if (normalizedName.includes('fee') || normalizedName.includes('expense')) {
             return 'SuppliesMaterials';
         }
-        
+
         return 'CashOnHand'; // Default
+    }
+
+    /**
+     * Format an amount (in cents) into a currency string for descriptions.
+     * @param {number} amount - Amount in the smallest currency unit
+     * @param {string} currency - ISO currency code (defaults to USD)
+     * @returns {string|null}
+     * @private
+     */
+    _formatCurrency(amount, currency = 'usd') {
+        if (typeof amount !== 'number' || Number.isNaN(amount)) {
+            return null;
+        }
+
+        const iso = (currency || 'usd').toUpperCase();
+        const absolute = Math.abs(amount) / 100;
+        const formatted = absolute.toFixed(2);
+
+        let symbol = `${iso} `;
+        if (iso === 'USD') {
+            symbol = '$';
+        }
+
+        const sign = amount < 0 ? '-' : '';
+        return `${sign}${symbol}${formatted}`;
     }
 }
 

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -741,12 +741,14 @@ async function runTests() {
         const feeTransaction = balanceTransactions.find(txn => txn.id === 'txn_fee_1');
         const adjustmentTransaction = balanceTransactions.find(txn => txn.id === 'txn_adjust_1');
 
+        const expectedChargeDescription = 'Donation A | Gross: $50.00, Fees: $1.50, Net: $48.50';
+
         const linesValid = journal &&
             clearingLine &&
             clearingLine.type === 'debit' &&
             clearingLine.amount === payout.amount &&
             detailLines.length === balanceTransactions.length &&
-            chargeLine && chargeLine.type === 'credit' && chargeLine.accountKey === 'revenue' && chargeLine.amount === Math.abs(chargeTransaction.net) && chargeLine.memo === 'Donation A' &&
+            chargeLine && chargeLine.type === 'credit' && chargeLine.accountKey === 'revenue' && chargeLine.amount === Math.abs(chargeTransaction.net) && chargeLine.memo === 'Donation A' && chargeLine.description === expectedChargeDescription && chargeLine.name === 'ch_123' &&
             refundLine && refundLine.type === 'debit' && refundLine.accountKey === 'refunds' && refundLine.amount === Math.abs(refundTransaction.net) &&
             feeLine && feeLine.type === 'debit' && feeLine.accountKey === 'fees' && feeLine.amount === Math.abs(feeTransaction.net) &&
             adjustmentLine && adjustmentLine.type === 'credit' && adjustmentLine.accountKey === 'adjustments' && adjustmentLine.amount === Math.abs(adjustmentTransaction.net) &&

--- a/tests/quickbooksProvider.test.js
+++ b/tests/quickbooksProvider.test.js
@@ -533,7 +533,7 @@ async function runTests() {
         if (result.created === true &&
             result.docNumber === 'JE-2024-001' &&
             mockQBOClient.journalEntries.length === 1 &&
-            mockQBOClient.journalEntries[0].Line[0].Description === 'Debit memo' &&
+            mockQBOClient.journalEntries[0].Line[0].Description === 'Debit line' &&
             mockQBOClient.journalEntries[0].Line[1].Description === 'Credit line') {
             console.log('✅ Create journal entry');
             passed++;


### PR DESCRIPTION
## Summary
- enrich per-transaction journal lines with charge identifiers and detailed descriptions for payout tracking
- prefer detailed line descriptions when creating QuickBooks journal entries
- update automated tests to cover the new metadata and description expectations

## Testing
- node tests/payoutSync.test.js
- node tests/quickbooksProvider.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e11d32bc7c832c81ade39d545acb95