### PR TITLE
Populate journal entry names and enrich descriptions

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -174,22 +174,54 @@ class QuickBooksProvider extends BaseAccountingProvider {
             }
 
             // Create new journal entry
+            const buildLineDescription = (line) => {
+                const parts = [];
+                const addPart = (value) => {
+                    if (!value || typeof value !== 'string') {
+                        return;
+                    }
+
+                    const trimmed = value.trim();
+                    if (trimmed.length === 0) {
+                        return;
+                    }
+
+                    if (!parts.includes(trimmed)) {
+                        parts.push(trimmed);
+                    }
+                };
+
+                addPart(line.description);
+                addPart(line.memo);
+                addPart(journalEntry.memo);
+
+                return parts.join(' | ');
+            };
+
             const jeData = {
                 DocNumber: journalEntry.docNumber,
                 TxnDate: this._formatDate(journalEntry.date),
                 PrivateNote: journalEntry.memo || '',
-                Line: journalEntry.lines.map((line, index) => ({
-                    Id: (index + 1).toString(),
-                    Description: line.description || line.memo || journalEntry.memo || '',
-                    Amount: (line.amount / 100).toFixed(2), // Convert cents to dollars
-                    DetailType: 'JournalEntryLineDetail',
-                    JournalEntryLineDetail: {
-                        PostingType: line.type === 'debit' ? 'Debit' : 'Credit',
-                        AccountRef: {
-                            value: line.accountId
+                Line: journalEntry.lines.map((line, index) => {
+                    const jeLine = {
+                        Id: (index + 1).toString(),
+                        Description: buildLineDescription(line) || '',
+                        Amount: (line.amount / 100).toFixed(2), // Convert cents to dollars
+                        DetailType: 'JournalEntryLineDetail',
+                        JournalEntryLineDetail: {
+                            PostingType: line.type === 'debit' ? 'Debit' : 'Credit',
+                            AccountRef: {
+                                value: line.accountId
+                            }
                         }
+                    };
+
+                    if (line.name) {
+                        jeLine.Name = line.name;
                     }
-                }))
+
+                    return jeLine;
+                })
             };
 
             const created = await this._executeWithTokenRefresh(() =>

--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -431,6 +431,23 @@ class PayoutSyncService {
         const jeLines = [];
         let clearingNet = 0;
 
+        const formatCurrency = (amount) => this._formatCurrency(amount, summary.currency);
+        const buildSummaryDescription = (label, details = []) => {
+            const parts = [
+                `Stripe payout ${payout.id}`,
+                summary.currency ? `Currency: ${summary.currency.toUpperCase()}` : null,
+                `Mode: ${transactionLineMode === 'per-transaction' ? 'Per transaction' : 'Summary'}`,
+                label,
+                ...details
+            ];
+
+            return parts
+                .filter(part => part && String(part).trim().length > 0)
+                .map(part => String(part).trim())
+                .filter((part, index, arr) => arr.indexOf(part) === index)
+                .join(' | ');
+        };
+
         if (usePerTransactionLines) {
             for (const txn of balanceTransactions) {
                 if (!this._shouldIncludeTransactionInJournal(txn)) {
@@ -446,6 +463,13 @@ class PayoutSyncService {
                 });
 
                 if (line) {
+                    line.description = buildSummaryDescription(line.description || line.memo || 'Stripe transaction', [
+                        line.metadata && line.metadata.balanceTransactionId
+                            ? `Transaction: ${line.metadata.balanceTransactionId}`
+                            : null,
+                        formatCurrency(line.amount) ? `Amount: ${formatCurrency(line.amount)}` : null
+                    ]);
+                    line.name = line.name || payout.id;
                     jeLines.push(line);
                     clearingNet += line.type === 'credit' ? line.amount : -line.amount;
                 }
@@ -458,7 +482,16 @@ class PayoutSyncService {
                     accountKey: 'revenue',
                     accountName: revenueAccount,
                     amount: summary.charges.grossAmount,
-                    memo: `Revenue from ${summary.charges.count} Stripe charges`
+                    memo: `Revenue from ${summary.charges.count} Stripe charges`,
+                    description: buildSummaryDescription('Revenue from Stripe charges', [
+                        summary.charges.count
+                            ? `${summary.charges.count} charge${summary.charges.count === 1 ? '' : 's'}`
+                            : null,
+                        formatCurrency(summary.charges.grossAmount)
+                            ? `Gross: ${formatCurrency(summary.charges.grossAmount)}`
+                            : null
+                    ]),
+                    name: payout.id
                 });
                 clearingNet += summary.charges.grossAmount;
             }
@@ -470,7 +503,16 @@ class PayoutSyncService {
                     accountKey: 'refunds',
                     accountName: refundsAccount,
                     amount: summary.refunds.amount,
-                    memo: `Stripe refunds - ${summary.refunds.count} transactions`
+                    memo: `Stripe refunds - ${summary.refunds.count} transactions`,
+                    description: buildSummaryDescription('Stripe refunds', [
+                        summary.refunds.count
+                            ? `${summary.refunds.count} refund${summary.refunds.count === 1 ? '' : 's'}`
+                            : null,
+                        formatCurrency(summary.refunds.amount)
+                            ? `Total: ${formatCurrency(-summary.refunds.amount)}`
+                            : null
+                    ]),
+                    name: payout.id
                 });
                 clearingNet -= summary.refunds.amount;
             }
@@ -478,12 +520,27 @@ class PayoutSyncService {
             // Stripe fees
             const totalFees = summary.fees.stripe.amount + summary.fees.application.amount;
             if (totalFees > 0) {
+                const feeDetails = [];
+                const stripeFees = formatCurrency(summary.fees.stripe.amount);
+                const applicationFees = formatCurrency(summary.fees.application.amount);
+                if (stripeFees) {
+                    feeDetails.push(`Stripe fees: ${stripeFees}`);
+                }
+                if (applicationFees) {
+                    feeDetails.push(`Application fees: ${applicationFees}`);
+                }
+
                 jeLines.push({
                     type: 'debit',
                     accountKey: 'fees',
                     accountName: feesAccount,
                     amount: totalFees,
-                    memo: `Stripe processing fees`
+                    memo: `Stripe processing fees`,
+                    description: buildSummaryDescription('Stripe fees', [
+                        ...feeDetails,
+                        formatCurrency(totalFees) ? `Total: ${formatCurrency(totalFees)}` : null
+                    ]),
+                    name: payout.id
                 });
                 clearingNet -= totalFees;
             }
@@ -495,7 +552,16 @@ class PayoutSyncService {
                     accountKey: 'chargebacks',
                     accountName: chargebackAccount,
                     amount: summary.disputes.amount,
-                    memo: `Chargebacks - ${summary.disputes.count} disputes`
+                    memo: `Chargebacks - ${summary.disputes.count} disputes`,
+                    description: buildSummaryDescription('Chargebacks', [
+                        summary.disputes.count
+                            ? `${summary.disputes.count} dispute${summary.disputes.count === 1 ? '' : 's'}`
+                            : null,
+                        formatCurrency(summary.disputes.amount)
+                            ? `Total: ${formatCurrency(summary.disputes.amount)}`
+                            : null
+                    ]),
+                    name: payout.id
                 });
                 clearingNet -= summary.disputes.amount;
             }
@@ -503,13 +569,27 @@ class PayoutSyncService {
             // Adjustments
             if (summary.adjustments.amount !== 0) {
                 const adjustmentAmount = Math.abs(summary.adjustments.amount);
+                const adjustmentLabel = summary.adjustments.amount > 0
+                    ? 'Positive Stripe adjustments'
+                    : 'Negative Stripe adjustments';
+                const adjustmentDetails = [
+                    summary.adjustments.count
+                        ? `${summary.adjustments.count} adjustment${summary.adjustments.count === 1 ? '' : 's'}`
+                        : null,
+                    formatCurrency(summary.adjustments.amount)
+                        ? `Net: ${formatCurrency(summary.adjustments.amount)}`
+                        : null
+                ];
+
                 if (summary.adjustments.amount > 0) {
                     jeLines.push({
                         type: 'credit',
                         accountKey: 'adjustments',
                         accountName: adjustmentAccount,
                         amount: adjustmentAmount,
-                        memo: `Positive Stripe adjustments`
+                        memo: `Positive Stripe adjustments`,
+                        description: buildSummaryDescription(adjustmentLabel, adjustmentDetails),
+                        name: payout.id
                     });
                     clearingNet += adjustmentAmount;
                 } else {
@@ -518,7 +598,9 @@ class PayoutSyncService {
                         accountKey: 'adjustments',
                         accountName: adjustmentAccount,
                         amount: adjustmentAmount,
-                        memo: `Negative Stripe adjustments`
+                        memo: `Negative Stripe adjustments`,
+                        description: buildSummaryDescription(adjustmentLabel, adjustmentDetails),
+                        name: payout.id
                     });
                     clearingNet -= adjustmentAmount;
                 }
@@ -534,12 +616,22 @@ class PayoutSyncService {
         }
 
         if (clearingNet !== 0) {
+            const netFormatted = formatCurrency(clearingNet);
+            const expectedNet = typeof expectedClearing === 'number'
+                ? formatCurrency(expectedClearing)
+                : null;
             jeLines.unshift({
                 type: clearingNet > 0 ? 'debit' : 'credit',
                 accountKey: 'clearing',
                 accountName: clearingAccount,
                 amount: Math.abs(clearingNet),
-                memo: `Stripe clearing balance impact`
+                memo: `Stripe clearing balance impact`,
+                description: buildSummaryDescription('Clearing balance impact', [
+                    netFormatted ? `Net change: ${netFormatted}` : null,
+                    expectedNet ? `Expected net: ${expectedNet}` : null,
+                    formatCurrency(payout.amount) ? `Payout total: ${formatCurrency(payout.amount)}` : null
+                ]),
+                name: payout.id
             });
         }
 

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -741,7 +741,15 @@ async function runTests() {
         const feeTransaction = balanceTransactions.find(txn => txn.id === 'txn_fee_1');
         const adjustmentTransaction = balanceTransactions.find(txn => txn.id === 'txn_adjust_1');
 
-        const expectedChargeDescription = 'Donation A | Gross: $50.00, Fees: $1.50, Net: $48.50';
+        const expectedChargeDescription = [
+            'Stripe payout po_txn_mode',
+            'Currency: USD',
+            'Mode: Per transaction',
+            'Donation A',
+            'Gross: $50.00, Fees: $1.50, Net: $48.50',
+            'Transaction: txn_charge_1',
+            'Amount: $48.50'
+        ].join(' | ');
 
         const linesValid = journal &&
             clearingLine &&

--- a/tests/quickbooksProvider.test.js
+++ b/tests/quickbooksProvider.test.js
@@ -523,8 +523,21 @@ async function runTests() {
             date: new Date('2024-01-15'),
             memo: 'Test journal entry',
             lines: [
-                { type: 'debit', accountId: 'acc-1', amount: 1000, memo: 'Debit memo', description: 'Debit line' },
-                { type: 'credit', accountId: 'acc-2', amount: 1000, description: 'Credit line' }
+                {
+                    type: 'debit',
+                    accountId: 'acc-1',
+                    amount: 1000,
+                    memo: 'Debit memo',
+                    description: 'Debit line',
+                    name: 'line-debit'
+                },
+                {
+                    type: 'credit',
+                    accountId: 'acc-2',
+                    amount: 1000,
+                    description: 'Credit line',
+                    name: 'line-credit'
+                }
             ]
         };
 
@@ -533,8 +546,10 @@ async function runTests() {
         if (result.created === true &&
             result.docNumber === 'JE-2024-001' &&
             mockQBOClient.journalEntries.length === 1 &&
-            mockQBOClient.journalEntries[0].Line[0].Description === 'Debit line' &&
-            mockQBOClient.journalEntries[0].Line[1].Description === 'Credit line') {
+            mockQBOClient.journalEntries[0].Line[0].Description === 'Debit line | Debit memo | Test journal entry' &&
+            mockQBOClient.journalEntries[0].Line[0].Name === 'line-debit' &&
+            mockQBOClient.journalEntries[0].Line[1].Description === 'Credit line | Test journal entry' &&
+            mockQBOClient.journalEntries[0].Line[1].Name === 'line-credit') {
             console.log('✅ Create journal entry');
             passed++;
         } else {


### PR DESCRIPTION
## Summary
- enrich payout posting instructions to build detailed journal line descriptions and default names from the payout id
- update the QuickBooks provider to merge memo context into journal line descriptions and surface optional line names
- align QuickBooks and payout sync tests with the enhanced description and name expectations

## Testing
- `node tests/quickbooksProvider.test.js`
- `node tests/journalEntryCreation.test.js`
- `node tests/payoutSync.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68e124c0a0a0832c9ac6ad07b8dbcd01