### PR TITLE
Split per-transaction journal entry lines and add QBO entity names

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -216,6 +216,19 @@ class QuickBooksProvider extends BaseAccountingProvider {
                         }
                     };
 
+                    if (line.name) {
+                        const entityType = line.entityContext === 'transaction'
+                            ? 'Customer'
+                            : 'Other';
+
+                        jeLine.JournalEntryLineDetail.Entity = {
+                            Type: entityType,
+                            EntityRef: {
+                                name: line.name
+                            }
+                        };
+                    }
+
                     return jeLine;
                 })
             };

--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -454,7 +454,7 @@ class PayoutSyncService {
                     continue;
                 }
 
-                const line = this._mapTransactionToJournalLine(txn, {
+                const lines = this._mapTransactionToJournalLines(txn, {
                     revenueAccount,
                     refundsAccount,
                     feesAccount,
@@ -462,14 +462,22 @@ class PayoutSyncService {
                     adjustmentAccount
                 });
 
-                if (line) {
+                if (!Array.isArray(lines) || lines.length === 0) {
+                    continue;
+                }
+
+                for (const line of lines) {
                     line.description = buildSummaryDescription(line.description || line.memo || 'Stripe transaction', [
                         line.metadata && line.metadata.balanceTransactionId
                             ? `Transaction: ${line.metadata.balanceTransactionId}`
                             : null,
-                        formatCurrency(line.amount) ? `Amount: ${formatCurrency(line.amount)}` : null
+                        formatCurrency(line.amount) ? `Amount: ${formatCurrency(line.amount)}` : null,
+                        line.metadata && line.metadata.component
+                            ? `Component: ${line.metadata.component}`
+                            : null
                     ]);
-                    line.name = line.name || payout.id;
+                    line.name = line.name || this._resolveEntityName(null, 'transaction');
+                    line.entityContext = line.entityContext || 'transaction';
                     jeLines.push(line);
                     clearingNet += line.type === 'credit' ? line.amount : -line.amount;
                 }
@@ -491,7 +499,8 @@ class PayoutSyncService {
                             ? `Gross: ${formatCurrency(summary.charges.grossAmount)}`
                             : null
                     ]),
-                    name: payout.id
+                    name: this._resolveEntityName(null, 'payout'),
+                    entityContext: 'payout'
                 });
                 clearingNet += summary.charges.grossAmount;
             }
@@ -512,7 +521,8 @@ class PayoutSyncService {
                             ? `Total: ${formatCurrency(-summary.refunds.amount)}`
                             : null
                     ]),
-                    name: payout.id
+                    name: this._resolveEntityName(null, 'payout'),
+                    entityContext: 'payout'
                 });
                 clearingNet -= summary.refunds.amount;
             }
@@ -540,7 +550,8 @@ class PayoutSyncService {
                         ...feeDetails,
                         formatCurrency(totalFees) ? `Total: ${formatCurrency(totalFees)}` : null
                     ]),
-                    name: payout.id
+                    name: this._resolveEntityName(null, 'payout'),
+                    entityContext: 'payout'
                 });
                 clearingNet -= totalFees;
             }
@@ -561,7 +572,8 @@ class PayoutSyncService {
                             ? `Total: ${formatCurrency(summary.disputes.amount)}`
                             : null
                     ]),
-                    name: payout.id
+                    name: this._resolveEntityName(null, 'payout'),
+                    entityContext: 'payout'
                 });
                 clearingNet -= summary.disputes.amount;
             }
@@ -589,7 +601,8 @@ class PayoutSyncService {
                         amount: adjustmentAmount,
                         memo: `Positive Stripe adjustments`,
                         description: buildSummaryDescription(adjustmentLabel, adjustmentDetails),
-                        name: payout.id
+                        name: this._resolveEntityName(null, 'payout'),
+                        entityContext: 'payout'
                     });
                     clearingNet += adjustmentAmount;
                 } else {
@@ -600,7 +613,8 @@ class PayoutSyncService {
                         amount: adjustmentAmount,
                         memo: `Negative Stripe adjustments`,
                         description: buildSummaryDescription(adjustmentLabel, adjustmentDetails),
-                        name: payout.id
+                        name: this._resolveEntityName(null, 'payout'),
+                        entityContext: 'payout'
                     });
                     clearingNet -= adjustmentAmount;
                 }
@@ -631,7 +645,8 @@ class PayoutSyncService {
                     expectedNet ? `Expected net: ${expectedNet}` : null,
                     formatCurrency(payout.amount) ? `Payout total: ${formatCurrency(payout.amount)}` : null
                 ]),
-                name: payout.id
+                name: this._resolveEntityName(null, 'payout'),
+                entityContext: 'payout'
             });
         }
 
@@ -1118,22 +1133,119 @@ class PayoutSyncService {
     }
 
     /**
-     * Build the name to associate with a transaction line. For Stripe charges we
-     * prefer the charge identifier so it can surface in accounting Name columns.
+     * Attempt to extract a customer name from a Stripe balance transaction
      * @param {Object} txn - Stripe balance transaction
      * @returns {string|null}
      * @private
      */
-    _buildTransactionName(txn) {
+    _extractTransactionCustomerName(txn) {
         if (!txn || typeof txn !== 'object') {
             return null;
         }
 
-        if (txn.type === 'charge' || txn.type === 'payment') {
-            return txn.source || txn.id || null;
+        const candidates = [];
+
+        if (typeof txn.customer_name === 'string') {
+            candidates.push(txn.customer_name);
+        }
+        if (typeof txn.customerName === 'string') {
+            candidates.push(txn.customerName);
+        }
+
+        if (txn.customer && typeof txn.customer === 'object') {
+            if (typeof txn.customer.name === 'string') {
+                candidates.push(txn.customer.name);
+            }
+        }
+
+        if (txn.customer_details && typeof txn.customer_details === 'object') {
+            if (typeof txn.customer_details.name === 'string') {
+                candidates.push(txn.customer_details.name);
+            }
+        }
+
+        if (txn.billing_details && typeof txn.billing_details === 'object') {
+            if (typeof txn.billing_details.name === 'string') {
+                candidates.push(txn.billing_details.name);
+            }
+        }
+
+        if (txn.source && typeof txn.source === 'object') {
+            if (txn.source.billing_details && typeof txn.source.billing_details === 'object' &&
+                typeof txn.source.billing_details.name === 'string') {
+                candidates.push(txn.source.billing_details.name);
+            }
+            if (txn.source.customer && typeof txn.source.customer === 'object' &&
+                typeof txn.source.customer.name === 'string') {
+                candidates.push(txn.source.customer.name);
+            }
+        }
+
+        if (txn.metadata && typeof txn.metadata === 'object') {
+            const metadataNameFields = ['customer_name', 'customerName', 'name'];
+            for (const field of metadataNameFields) {
+                const value = txn.metadata[field];
+                if (typeof value === 'string') {
+                    candidates.push(value);
+                }
+            }
+        }
+
+        for (const candidate of candidates) {
+            if (typeof candidate !== 'string') {
+                continue;
+            }
+
+            const trimmed = candidate.trim();
+            if (trimmed.length > 0) {
+                return trimmed;
+            }
         }
 
         return null;
+    }
+
+    /**
+     * Resolve the entity name for a journal line based on context
+     * @param {string|null} customerName - Extracted customer name
+     * @param {'transaction'|'payout'} context - Context for the line
+     * @returns {string}
+     * @private
+     */
+    _resolveEntityName(customerName, context = 'transaction') {
+        if (typeof customerName === 'string' && customerName.trim().length > 0) {
+            return customerName.trim();
+        }
+
+        if (context === 'payout') {
+            return 'Stripe Payout';
+        }
+
+        return 'Stripe Transaction';
+    }
+
+    /**
+     * Append a component label to a base description without duplicates
+     * @param {string|null} description - Base description
+     * @param {string|null} componentLabel - Component label to append
+     * @returns {string|null}
+     * @private
+     */
+    _appendComponentToDescription(description, componentLabel) {
+        if (!componentLabel || typeof componentLabel !== 'string' || componentLabel.trim().length === 0) {
+            return description || null;
+        }
+
+        const trimmedComponent = componentLabel.trim();
+        if (!description || description.length === 0) {
+            return trimmedComponent;
+        }
+
+        if (description.includes(trimmedComponent)) {
+            return description;
+        }
+
+        return `${description} | ${trimmedComponent}`;
     }
 
     /**
@@ -1189,62 +1301,152 @@ class PayoutSyncService {
      * @returns {Object|null} Journal line or null if the transaction should be skipped
      * @private
      */
-    _mapTransactionToJournalLine(txn, accounts) {
+    _mapTransactionToJournalLines(txn, accounts) {
         if (!txn || typeof txn !== 'object') {
-            return null;
+            return [];
         }
 
         const { revenueAccount, refundsAccount, feesAccount, chargebackAccount, adjustmentAccount } = accounts;
         const memo = this._buildTransactionMemo(txn);
-        const description = this._buildTransactionDescription(txn);
-        const name = this._buildTransactionName(txn);
-        const metadata = this._buildTransactionMetadata(txn);
-        const rawAmount = typeof txn.net === 'number' ? txn.net : txn.amount;
-        const amount = Math.abs(rawAmount || 0);
-
-        if (!amount) {
-            return null;
+        const baseDescription = this._buildTransactionDescription(txn);
+        const baseMetadata = { ...this._buildTransactionMetadata(txn) };
+        const customerName = this._extractTransactionCustomerName(txn);
+        if (customerName) {
+            baseMetadata.customerName = customerName;
         }
 
-        const makeLine = (type, accountKey, accountName) => ({
-            type,
-            accountKey,
-            accountName,
-            amount,
-            memo,
-            description,
-            name,
-            metadata
-        });
+        const name = this._resolveEntityName(customerName, 'transaction');
+        const defaultRawAmount = typeof txn.net === 'number' ? txn.net : txn.amount;
+        const lines = [];
+
+        const appendLine = ({ type, accountKey, accountName, rawAmount, component = null, description = null, metadataOverrides = {} }) => {
+            if (!accountName || typeof rawAmount !== 'number' || Number.isNaN(rawAmount) || rawAmount === 0) {
+                return;
+            }
+
+            const normalizedAmount = Math.round(Math.abs(rawAmount));
+            if (!normalizedAmount) {
+                return;
+            }
+
+            const componentLabel = component && typeof component === 'string' ? component.trim() : null;
+            const finalDescription = this._appendComponentToDescription(description || baseDescription || memo || null, componentLabel);
+            const lineMetadata = { ...baseMetadata };
+
+            if (componentLabel) {
+                lineMetadata.component = componentLabel;
+            }
+
+            Object.entries(metadataOverrides || {}).forEach(([key, value]) => {
+                if (value !== undefined && value !== null) {
+                    lineMetadata[key] = value;
+                }
+            });
+
+            lines.push({
+                type,
+                accountKey,
+                accountName,
+                amount: normalizedAmount,
+                memo,
+                description: finalDescription || memo || null,
+                name,
+                entityContext: 'transaction',
+                metadata: lineMetadata
+            });
+        };
+
+        const makeDefaultLine = (type, accountKey, accountName) => {
+            if (typeof defaultRawAmount !== 'number' || defaultRawAmount === 0) {
+                return;
+            }
+            appendLine({ type, accountKey, accountName, rawAmount: defaultRawAmount });
+        };
 
         switch (txn.type) {
             case 'charge':
-            case 'payment':
-                return makeLine('credit', 'revenue', revenueAccount);
-            case 'refund':
-            case 'payment_refund':
-                return makeLine('debit', 'refunds', refundsAccount);
-            case 'stripe_fee':
-            case 'application_fee':
-                return makeLine('debit', 'fees', feesAccount);
-            case 'application_fee_refund':
-                return makeLine('credit', 'fees', feesAccount);
-            case 'adjustment':
-                return rawAmount >= 0
-                    ? makeLine('credit', 'adjustments', adjustmentAccount)
-                    : makeLine('debit', 'adjustments', adjustmentAccount);
-            default:
-                if (txn.type && txn.type.includes('dispute')) {
-                    return rawAmount >= 0
-                        ? makeLine('credit', 'chargebacks', chargebackAccount)
-                        : makeLine('debit', 'chargebacks', chargebackAccount);
+            case 'payment': {
+                if (typeof txn.amount === 'number' && txn.amount !== 0) {
+                    appendLine({
+                        type: 'credit',
+                        accountKey: 'revenue',
+                        accountName: revenueAccount,
+                        rawAmount: txn.amount,
+                        component: 'Gross amount',
+                        metadataOverrides: { grossAmount: txn.amount }
+                    });
                 }
 
-                // Fallback: treat as adjustment using sign of amount
-                return rawAmount >= 0
-                    ? makeLine('credit', 'adjustments', adjustmentAccount)
-                    : makeLine('debit', 'adjustments', adjustmentAccount);
+                if (typeof txn.fee === 'number' && txn.fee !== 0) {
+                    appendLine({
+                        type: txn.fee >= 0 ? 'debit' : 'credit',
+                        accountKey: 'fees',
+                        accountName: feesAccount,
+                        rawAmount: txn.fee,
+                        component: 'Processing fees',
+                        metadataOverrides: { feeAmount: txn.fee }
+                    });
+                }
+
+                if (lines.length === 0) {
+                    makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'revenue', revenueAccount);
+                }
+                break;
+            }
+
+            case 'refund':
+            case 'payment_refund': {
+                if (typeof txn.amount === 'number' && txn.amount !== 0) {
+                    appendLine({
+                        type: txn.amount >= 0 ? 'credit' : 'debit',
+                        accountKey: 'refunds',
+                        accountName: refundsAccount,
+                        rawAmount: txn.amount,
+                        component: 'Refund gross amount',
+                        metadataOverrides: { grossAmount: txn.amount }
+                    });
+                }
+
+                if (typeof txn.fee === 'number' && txn.fee !== 0) {
+                    appendLine({
+                        type: txn.fee >= 0 ? 'debit' : 'credit',
+                        accountKey: 'fees',
+                        accountName: feesAccount,
+                        rawAmount: txn.fee,
+                        component: 'Processing fees',
+                        metadataOverrides: { feeAmount: txn.fee }
+                    });
+                }
+
+                if (lines.length === 0) {
+                    makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'refunds', refundsAccount);
+                }
+                break;
+            }
+
+            case 'stripe_fee':
+            case 'application_fee':
+                makeDefaultLine('debit', 'fees', feesAccount);
+                break;
+
+            case 'application_fee_refund':
+                makeDefaultLine(defaultRawAmount >= 0 ? 'debit' : 'credit', 'fees', feesAccount);
+                break;
+
+            case 'adjustment':
+                makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'adjustments', adjustmentAccount);
+                break;
+
+            default:
+                if (txn.type && typeof txn.type === 'string' && txn.type.includes('dispute')) {
+                    makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'chargebacks', chargebackAccount);
+                } else {
+                    makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'adjustments', adjustmentAccount);
+                }
+                break;
         }
+
+        return lines;
     }
 
     /**

--- a/tests/journalEntryCreation.test.js
+++ b/tests/journalEntryCreation.test.js
@@ -271,6 +271,19 @@ async function runTests() {
                 throw new Error('Some journal entry lines missing AccountRef.value');
             }
 
+            const entityNames = createdJE.Line.map(line =>
+                line.JournalEntryLineDetail &&
+                line.JournalEntryLineDetail.Entity &&
+                line.JournalEntryLineDetail.Entity.EntityRef
+                    ? line.JournalEntryLineDetail.Entity.EntityRef.name
+                    : null
+            );
+
+            const allEntitiesMatch = entityNames.every(name => name === 'Stripe Payout');
+            if (!allEntitiesMatch) {
+                throw new Error(`Unexpected entity names on journal lines: ${entityNames.join(', ')}`);
+            }
+
             // Verify accounts were created
             if (mockQBOClient.accounts.length < 2) {
                 throw new Error(`Expected at least 2 accounts to be created, got ${mockQBOClient.accounts.length}`);
@@ -293,7 +306,139 @@ async function runTests() {
         failed++;
     }
 
-    // Test 2: Verify DocNumber validation rejects long DocNumbers
+    // Test 2: Per-transaction lines split gross/fee with customer names
+    try {
+        mockQBOClient.accounts = [];
+        mockQBOClient.journalEntries = [];
+
+        const config = new AccountingSyncConfig();
+        config.config = {
+            provider: 'quickbooks',
+            accounts: {
+                stripeClearingAccount: 'Stripe Clearing',
+                operatingBankAccount: 'Operating Bank',
+                revenueAccount: 'Revenue',
+                refundsAccount: 'Refunds',
+                stripeFeeAccount: 'Stripe Fees',
+                chargebackAccount: 'Chargebacks',
+                adjustmentAccount: 'Adjustments'
+            },
+            posting: {
+                strategy: 'je-transfer',
+                dateSource: 'arrival',
+                transactionLineMode: 'per-transaction'
+            }
+        };
+
+        const qboConfig = {
+            companyId: 'test-company-123',
+            environment: 'sandbox',
+            oauthTokens: {
+                accessToken: 'test-access-token',
+                refreshToken: 'test-refresh-token'
+            }
+        };
+
+        const provider = new QuickBooksProvider(qboConfig);
+        const syncLedger = new SyncLedger();
+        const payoutSyncService = new PayoutSyncService(config, provider, syncLedger);
+
+        const payout = {
+            id: 'po_1TestPerTxn',
+            amount: 9671,
+            arrival_date: 1716076800,
+            created: 1716076800,
+            status: 'paid',
+            currency: 'usd'
+        };
+
+        const summary = {
+            charges: { count: 1, grossAmount: 10000 },
+            refunds: { count: 0, amount: 0 },
+            fees: { stripe: { amount: 329 }, application: { amount: 0 } },
+            disputes: { count: 0, amount: 0 },
+            adjustments: { count: 0, amount: 0 },
+            total: 9671,
+            currency: 'usd'
+        };
+
+        const balanceTransactions = [{
+            id: 'txn_1ABC',
+            type: 'charge',
+            amount: 10000,
+            fee: 329,
+            net: 9671,
+            currency: 'usd',
+            description: 'Test per-transaction charge',
+            customer_details: { name: 'Alice Customer' },
+            created: 1716076800,
+            available_on: 1716076800,
+            payout: payout.id
+        }];
+
+        const instructions = payoutSyncService.generatePostingInstructions(
+            payout,
+            summary,
+            null,
+            balanceTransactions
+        );
+
+        const jeDoc = instructions.documents.find(d => d.type === 'journal');
+        if (!jeDoc) {
+            throw new Error('No journal entry document found for per-transaction mode');
+        }
+
+        if (jeDoc.lines.length !== 3) {
+            throw new Error(`Expected 3 journal lines (clearing + gross + fee), got ${jeDoc.lines.length}`);
+        }
+
+        const clearingLine = jeDoc.lines.find(line => line.accountKey === 'clearing');
+        const revenueLine = jeDoc.lines.find(line => line.accountKey === 'revenue');
+        const feeLine = jeDoc.lines.find(line => line.accountKey === 'fees' && line.metadata && line.metadata.component === 'Processing fees');
+
+        if (!clearingLine || clearingLine.name !== 'Stripe Payout') {
+            throw new Error(`Clearing line missing or has incorrect name: ${clearingLine ? clearingLine.name : 'none'}`);
+        }
+
+        if (!revenueLine || revenueLine.name !== 'Alice Customer') {
+            throw new Error(`Revenue line missing or has incorrect name: ${revenueLine ? revenueLine.name : 'none'}`);
+        }
+
+        if (!feeLine || feeLine.name !== 'Alice Customer') {
+            throw new Error(`Fee line missing or has incorrect name: ${feeLine ? feeLine.name : 'none'}`);
+        }
+
+        await payoutSyncService.postToAccounting(instructions);
+
+        if (mockQBOClient.journalEntries.length === 1) {
+            const created = mockQBOClient.journalEntries[0];
+            const nameSummary = created.Line.map(line =>
+                line.JournalEntryLineDetail &&
+                line.JournalEntryLineDetail.Entity &&
+                line.JournalEntryLineDetail.Entity.EntityRef
+                    ? line.JournalEntryLineDetail.Entity.EntityRef.name
+                    : null
+            );
+
+            const payoutNameCount = nameSummary.filter(name => name === 'Stripe Payout').length;
+            const customerNameCount = nameSummary.filter(name => name === 'Alice Customer').length;
+            if (payoutNameCount !== 1 || customerNameCount !== 2) {
+                throw new Error(`Unexpected entity names on per-transaction JE: ${nameSummary.join(', ')}`);
+            }
+
+            console.log('✅ Per-transaction journal entry splits gross and fee with customer name');
+            passed++;
+        } else {
+            console.log('❌ Per-transaction journal entry - wrong number of entries created');
+            console.log(`   Expected: 1, Got: ${mockQBOClient.journalEntries.length}`);
+            failed++;
+        }
+    } catch (error) {
+        console.log('❌ Per-transaction journal entry - error:', error.message);
+        failed++;
+    }
+
+    // Test 3: Verify DocNumber validation rejects long DocNumbers
     try {
         mockQBOClient.accounts = [];
         mockQBOClient.journalEntries = [];
@@ -338,7 +483,7 @@ async function runTests() {
         failed++;
     }
 
-    // Test 3: Verify AccountRef validation rejects missing account IDs
+    // Test 4: Verify AccountRef validation rejects missing account IDs
     try {
         mockQBOClient.accounts = [];
         mockQBOClient.journalEntries = [];


### PR DESCRIPTION
## Summary
- derive payout and transaction line names so QBO journal entries use the Stripe customer name with sensible fallbacks
- split per-transaction charge journal lines into gross revenue and processing fee components while keeping metadata
- map the derived names into QuickBooks journal entry Entity details and extend integration tests to cover the new behavior

## Testing
- node tests/journalEntryCreation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e137ca4ef8832cbc588e8ed3f6da0a