### PR TITLE
Ensure QBO journal entries populate line names

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -236,25 +236,28 @@ class QuickBooksProvider extends BaseAccountingProvider {
                             || line.entityType
                             || (line.entityContext === 'transaction' ? 'Customer' : 'Other');
 
-                        if (entityId) {
+                        if (entityId || (entityName && entityName.trim().length > 0)) {
+                            const trimmedName = typeof entityName === 'string' ? entityName.trim() : '';
+
                             jeLine.JournalEntryLineDetail.Entity = {
                                 Type: entityType,
-                                EntityRef: {
-                                    value: entityId
-                                }
+                                EntityRef: {}
                             };
 
-                            if (entityName) {
-                                jeLine.JournalEntryLineDetail.Entity.EntityRef.name = entityName;
+                            if (entityId) {
+                                jeLine.JournalEntryLineDetail.Entity.EntityRef.value = entityId;
                             }
-                        } else if (entityName) {
-                            this.logger.warn(
-                                `[QBO] Skipping entity reference for journal line ${index + 1} (${entityName}) - missing entity identifier`
-                            );
 
-                            if (typeof jeLine.Description === 'string') {
-                                const trimmedName = entityName.trim();
-                                if (trimmedName.length > 0 && !jeLine.Description.includes(trimmedName)) {
+                            if (trimmedName.length > 0) {
+                                jeLine.JournalEntryLineDetail.Entity.EntityRef.name = trimmedName;
+
+                                if (!entityId) {
+                                    this.logger.warn(
+                                        `[QBO] Journal line ${index + 1} using entity name without identifier: ${trimmedName}`
+                                    );
+                                }
+
+                                if (typeof jeLine.Description === 'string' && !jeLine.Description.includes(trimmedName)) {
                                     jeLine.Description = jeLine.Description.length > 0
                                         ? `${jeLine.Description} | ${trimmedName}`
                                         : trimmedName;

--- a/tests/journalEntryCreation.test.js
+++ b/tests/journalEntryCreation.test.js
@@ -271,7 +271,7 @@ async function runTests() {
                 throw new Error('Some journal entry lines missing AccountRef.value');
             }
 
-            const entityPresence = createdJE.Line.map(line =>
+            const entityNames = createdJE.Line.map(line =>
                 line.JournalEntryLineDetail &&
                 line.JournalEntryLineDetail.Entity &&
                 line.JournalEntryLineDetail.Entity.EntityRef
@@ -279,9 +279,12 @@ async function runTests() {
                     : null
             );
 
-            const hasEntityRefs = entityPresence.some(value => value !== null && value !== undefined);
-            if (hasEntityRefs) {
-                throw new Error(`Unexpected entity references on journal lines: ${entityPresence.join(', ')}`);
+            const expectedEntityNames = ['Stripe Payout', 'Stripe Payout', 'Stripe Payout'];
+            const entityNamesMatch = entityNames.length === expectedEntityNames.length &&
+                entityNames.every((name, idx) => name === expectedEntityNames[idx]);
+
+            if (!entityNamesMatch) {
+                throw new Error(`Journal line entity names mismatch. Expected ${expectedEntityNames.join(', ')}, got ${entityNames.join(', ')}`);
             }
 
             const descriptions = createdJE.Line.map(line => line.Description || '');
@@ -425,8 +428,12 @@ async function runTests() {
                     : null
             );
 
-            if (entitySummary.some(value => value !== null && value !== undefined)) {
-                throw new Error(`Unexpected entity references on per-transaction JE: ${entitySummary.join(', ')}`);
+            const expectedSummary = ['Stripe Payout', 'Alice Customer', 'Alice Customer'];
+            const summaryMatches = entitySummary.length === expectedSummary.length &&
+                entitySummary.every((name, idx) => name === expectedSummary[idx]);
+
+            if (!summaryMatches) {
+                throw new Error(`Per-transaction JE entity names mismatch. Expected ${expectedSummary.join(', ')}, got ${entitySummary.join(', ')}`);
             }
 
             const descriptions = created.Line.map(line => line.Description || '');


### PR DESCRIPTION
## Summary
- update the QuickBooks provider to include entity names on journal entry lines even when only the customer name is available
- adjust the journal entry integration tests to expect the populated payout and customer names in QBO journal entries

## Testing
- node tests/journalEntryCreation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e147c6c4ac832c891df4f17871b4ee