### PR TITLE
Add customer and vendor entity refs to QuickBooks journal entries

### DIFF
--- a/services/accounting/baseAccountingProvider.js
+++ b/services/accounting/baseAccountingProvider.js
@@ -63,6 +63,24 @@ class BaseAccountingProvider {
     }
 
     /**
+     * Ensure a customer exists in the accounting system and return its reference
+     * @param {Object} customer - Customer details {displayName, email, givenName, familyName, externalId}
+     * @returns {Promise<Object>} Customer reference {id, displayName}
+     */
+    async ensureCustomer(customer) {
+        throw new Error('ensureCustomer method must be implemented by subclass');
+    }
+
+    /**
+     * Ensure a vendor exists in the accounting system and return its reference
+     * @param {Object} vendor - Vendor details {displayName, email, externalId}
+     * @returns {Promise<Object>} Vendor reference {id, displayName}
+     */
+    async ensureVendor(vendor) {
+        throw new Error('ensureVendor method must be implemented by subclass');
+    }
+
+    /**
      * Attach a document/file to an accounting transaction
      * @param {string} transactionId - Provider transaction ID
      * @param {Object} attachment - Attachment data

--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -61,13 +61,13 @@ class QuickBooksProvider extends BaseAccountingProvider {
      */
     async ensureChartOfAccounts(accounts) {
         this.logger.log('[QBO] Ensuring chart of accounts:', accounts.map(a => a.name));
-        
+
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
         }
 
         const accountMap = {};
-        
+
         for (const account of accounts) {
             try {
                 // Search for existing account by name using findAccounts
@@ -114,11 +114,246 @@ class QuickBooksProvider extends BaseAccountingProvider {
     }
 
     /**
+     * Ensure a customer exists in QuickBooks and return its reference
+     */
+    async ensureCustomer(customer) {
+        if (!this.qbo) {
+            throw new Error('QuickBooks client not initialized. Check configuration.');
+        }
+
+        const displayNameSource = customer.displayName || customer.name || customer.email || customer.externalId || 'Stripe Customer';
+        const displayName = displayNameSource.toString().trim().substring(0, 99) || 'Stripe Customer';
+        const normalizedEmail = customer.email ? customer.email.toString().trim().toLowerCase() : null;
+        const normalizedDisplayName = displayName.toLowerCase();
+        const existingCustomers = [];
+
+        const uniqueById = (list) => {
+            const seen = new Set();
+            return list.filter(item => {
+                if (!item || !item.Id) {
+                    return false;
+                }
+                if (seen.has(item.Id)) {
+                    return false;
+                }
+                seen.add(item.Id);
+                return true;
+            });
+        };
+
+        try {
+            if (normalizedEmail) {
+                const emailMatches = await this._executeWithTokenRefresh(() =>
+                    new Promise((resolve, reject) => {
+                        this.qbo.findCustomers([
+                            { field: 'PrimaryEmailAddr', operator: '=', value: normalizedEmail }
+                        ], (err, data) => {
+                            if (err) reject(err);
+                            else resolve((data.QueryResponse && data.QueryResponse.Customer) || []);
+                        });
+                    })
+                );
+
+                existingCustomers.push(...emailMatches);
+            }
+
+            if (existingCustomers.length === 0 && normalizedDisplayName) {
+                const nameMatches = await this._executeWithTokenRefresh(() =>
+                    new Promise((resolve, reject) => {
+                        this.qbo.findCustomers({ DisplayName: displayName }, (err, data) => {
+                            if (err) reject(err);
+                            else resolve((data.QueryResponse && data.QueryResponse.Customer) || []);
+                        });
+                    })
+                );
+
+                existingCustomers.push(...nameMatches);
+            }
+        } catch (error) {
+            this.logger.error('[QBO] Error searching for customer:', error.message);
+            throw new Error(`Failed to look up customer "${displayName}": ${error.message}`);
+        }
+
+        const customers = uniqueById(existingCustomers);
+        const matchedCustomer = customers.find(cust => {
+            if (!cust) {
+                return false;
+            }
+
+            const emailMatch = normalizedEmail && cust.PrimaryEmailAddr && cust.PrimaryEmailAddr.Address &&
+                cust.PrimaryEmailAddr.Address.toString().trim().toLowerCase() === normalizedEmail;
+            const nameMatch = cust.DisplayName && cust.DisplayName.toString().trim().toLowerCase() === normalizedDisplayName;
+            return emailMatch || nameMatch;
+        });
+
+        if (matchedCustomer) {
+            this.logger.log(`[QBO] Found existing customer: ${matchedCustomer.DisplayName} (ID: ${matchedCustomer.Id})`);
+            return {
+                id: matchedCustomer.Id,
+                displayName: matchedCustomer.DisplayName || displayName
+            };
+        }
+
+        const newCustomer = {
+            DisplayName: displayName
+        };
+
+        if (customer.givenName) {
+            newCustomer.GivenName = customer.givenName;
+        }
+        if (customer.familyName) {
+            newCustomer.FamilyName = customer.familyName;
+        }
+        if (normalizedEmail) {
+            newCustomer.PrimaryEmailAddr = { Address: customer.email.toString().trim() };
+        }
+        if (customer.externalId) {
+            newCustomer.Notes = `Stripe Customer ID: ${customer.externalId}`;
+        }
+
+        try {
+            const created = await this._executeWithTokenRefresh(() =>
+                new Promise((resolve, reject) => {
+                    this.qbo.createCustomer(newCustomer, (err, data) => {
+                        if (err) reject(err);
+                        else resolve(data);
+                    });
+                })
+            );
+
+            this.logger.log(`[QBO] Created customer: ${created.DisplayName || displayName} (ID: ${created.Id})`);
+
+            return {
+                id: created.Id,
+                displayName: created.DisplayName || displayName
+            };
+        } catch (error) {
+            this.logger.error('[QBO] Error creating customer:', error.message);
+            throw new Error(`Failed to create customer "${displayName}": ${error.message}`);
+        }
+    }
+
+    /**
+     * Ensure a vendor exists in QuickBooks and return its reference
+     */
+    async ensureVendor(vendor) {
+        if (!this.qbo) {
+            throw new Error('QuickBooks client not initialized. Check configuration.');
+        }
+
+        const displayNameSource = vendor.displayName || vendor.name || 'Stripe';
+        const displayName = displayNameSource.toString().trim().substring(0, 99) || 'Stripe';
+        const normalizedEmail = vendor.email ? vendor.email.toString().trim().toLowerCase() : null;
+        const normalizedDisplayName = displayName.toLowerCase();
+
+        const uniqueById = (list) => {
+            const seen = new Set();
+            return list.filter(item => {
+                if (!item || !item.Id) {
+                    return false;
+                }
+                if (seen.has(item.Id)) {
+                    return false;
+                }
+                seen.add(item.Id);
+                return true;
+            });
+        };
+
+        let existingVendors = [];
+
+        try {
+            if (normalizedEmail) {
+                const emailMatches = await this._executeWithTokenRefresh(() =>
+                    new Promise((resolve, reject) => {
+                        this.qbo.findVendors([
+                            { field: 'PrimaryEmailAddr', operator: '=', value: normalizedEmail }
+                        ], (err, data) => {
+                            if (err) reject(err);
+                            else resolve((data.QueryResponse && data.QueryResponse.Vendor) || []);
+                        });
+                    })
+                );
+
+                existingVendors.push(...emailMatches);
+            }
+
+            if (existingVendors.length === 0 && normalizedDisplayName) {
+                const nameMatches = await this._executeWithTokenRefresh(() =>
+                    new Promise((resolve, reject) => {
+                        this.qbo.findVendors({ DisplayName: displayName }, (err, data) => {
+                            if (err) reject(err);
+                            else resolve((data.QueryResponse && data.QueryResponse.Vendor) || []);
+                        });
+                    })
+                );
+
+                existingVendors.push(...nameMatches);
+            }
+        } catch (error) {
+            this.logger.error('[QBO] Error searching for vendor:', error.message);
+            throw new Error(`Failed to look up vendor "${displayName}": ${error.message}`);
+        }
+
+        const vendors = uniqueById(existingVendors);
+        const matchedVendor = vendors.find(v => {
+            if (!v) {
+                return false;
+            }
+
+            const emailMatch = normalizedEmail && v.PrimaryEmailAddr && v.PrimaryEmailAddr.Address &&
+                v.PrimaryEmailAddr.Address.toString().trim().toLowerCase() === normalizedEmail;
+            const nameMatch = v.DisplayName && v.DisplayName.toString().trim().toLowerCase() === normalizedDisplayName;
+            return emailMatch || nameMatch;
+        });
+
+        if (matchedVendor) {
+            this.logger.log(`[QBO] Found existing vendor: ${matchedVendor.DisplayName} (ID: ${matchedVendor.Id})`);
+            return {
+                id: matchedVendor.Id,
+                displayName: matchedVendor.DisplayName || displayName
+            };
+        }
+
+        const newVendor = {
+            DisplayName: displayName
+        };
+
+        if (normalizedEmail) {
+            newVendor.PrimaryEmailAddr = { Address: vendor.email.toString().trim() };
+        }
+        if (vendor.externalId) {
+            newVendor.Other1 = vendor.externalId;
+        }
+
+        try {
+            const created = await this._executeWithTokenRefresh(() =>
+                new Promise((resolve, reject) => {
+                    this.qbo.createVendor(newVendor, (err, data) => {
+                        if (err) reject(err);
+                        else resolve(data);
+                    });
+                })
+            );
+
+            this.logger.log(`[QBO] Created vendor: ${created.DisplayName || displayName} (ID: ${created.Id})`);
+
+            return {
+                id: created.Id,
+                displayName: created.DisplayName || displayName
+            };
+        } catch (error) {
+            this.logger.error('[QBO] Error creating vendor:', error.message);
+            throw new Error(`Failed to create vendor "${displayName}": ${error.message}`);
+        }
+    }
+
+    /**
      * Upsert a journal entry (idempotent)
      */
     async upsertJournalEntry(journalEntry) {
         this.logger.log('[QBO] Upserting journal entry:', journalEntry.docNumber);
-        
+
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
         }

--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -459,7 +459,8 @@ class PayoutSyncService {
                     refundsAccount,
                     feesAccount,
                     chargebackAccount,
-                    adjustmentAccount
+                    adjustmentAccount,
+                    clearingAccount
                 });
 
                 if (!Array.isArray(lines) || lines.length === 0) {
@@ -470,6 +471,9 @@ class PayoutSyncService {
                     line.description = buildSummaryDescription(line.description || line.memo || 'Stripe transaction', [
                         line.metadata && line.metadata.balanceTransactionId
                             ? `Transaction: ${line.metadata.balanceTransactionId}`
+                            : null,
+                        line.metadata && (line.metadata.chargeId || line.metadata.paymentIntentId || line.metadata.source)
+                            ? `Source: ${line.metadata.chargeId || line.metadata.paymentIntentId || line.metadata.source}`
                             : null,
                         formatCurrency(line.amount) ? `Amount: ${formatCurrency(line.amount)}` : null,
                         line.metadata && line.metadata.component
@@ -550,8 +554,14 @@ class PayoutSyncService {
                         ...feeDetails,
                         formatCurrency(totalFees) ? `Total: ${formatCurrency(totalFees)}` : null
                     ]),
-                    name: this._resolveEntityName(null, 'payout'),
-                    entityContext: 'payout'
+                    name: 'Stripe',
+                    entityContext: 'payout',
+                    entity: {
+                        type: 'Vendor',
+                        name: 'Stripe',
+                        displayName: 'Stripe',
+                        externalId: 'stripe'
+                    }
                 });
                 clearingNet -= totalFees;
             }
@@ -779,6 +789,97 @@ class PayoutSyncService {
             }
         }
 
+        const normalizeKey = (value) => {
+            if (value === undefined || value === null) {
+                return null;
+            }
+            if (typeof value === 'string') {
+                const trimmed = value.trim();
+                return trimmed.length > 0 ? trimmed.toLowerCase() : null;
+            }
+            return value.toString().trim().toLowerCase();
+        };
+
+        const buildCustomerKey = (entity) => {
+            if (!entity || typeof entity !== 'object') {
+                return null;
+            }
+            return normalizeKey(entity.stripeCustomerId)
+                || normalizeKey(entity.externalId)
+                || normalizeKey(entity.email)
+                || normalizeKey(entity.name);
+        };
+
+        const buildVendorKey = (entity) => {
+            if (!entity || typeof entity !== 'object') {
+                return null;
+            }
+            return normalizeKey(entity.externalId)
+                || normalizeKey(entity.name)
+                || 'vendor-stripe';
+        };
+
+        const customersToEnsure = new Map();
+        const vendorsToEnsure = new Map();
+
+        for (const doc of postingInstructions.documents) {
+            if (doc.type !== 'journal' || !Array.isArray(doc.lines)) {
+                continue;
+            }
+
+            for (const line of doc.lines) {
+                if (!line || typeof line !== 'object') {
+                    continue;
+                }
+
+                if (line.entity && line.entity.type === 'Customer') {
+                    const key = buildCustomerKey(line.entity);
+                    if (key && !customersToEnsure.has(key)) {
+                        customersToEnsure.set(key, line.entity);
+                    }
+                } else if (line.entity && line.entity.type === 'Vendor') {
+                    const key = buildVendorKey(line.entity) || 'vendor-stripe';
+                    if (!vendorsToEnsure.has(key)) {
+                        vendorsToEnsure.set(key, line.entity);
+                    }
+                }
+            }
+        }
+
+        const customerRefMap = {};
+        for (const [key, entity] of customersToEnsure.entries()) {
+            const displayName = entity.name || entity.displayName || (entity.email ? entity.email.split('@')[0] : 'Stripe Customer');
+            try {
+                const customerRef = await this.accountingProvider.ensureCustomer({
+                    displayName,
+                    email: entity.email || null,
+                    givenName: entity.givenName || null,
+                    familyName: entity.familyName || null,
+                    externalId: entity.stripeCustomerId || entity.externalId || null
+                });
+                customerRefMap[key] = customerRef.id;
+            } catch (error) {
+                this.logger.error(`[PayoutSync] Failed to ensure customer ${displayName}:`, error.message);
+                throw new Error(`Failed to ensure customer "${displayName}": ${error.message}`);
+            }
+        }
+
+        const vendorRefMap = {};
+        for (const [key, entity] of vendorsToEnsure.entries()) {
+            const displayName = entity.name || entity.displayName || 'Stripe';
+            try {
+                const vendorRef = await this.accountingProvider.ensureVendor({
+                    displayName,
+                    email: entity.email || null,
+                    externalId: entity.externalId || entity.stripeCustomerId || null
+                });
+                vendorRefMap[key] = vendorRef.id;
+            } catch (error) {
+                this.logger.error(`[PayoutSync] Failed to ensure vendor ${displayName}:`, error.message);
+                throw new Error(`Failed to ensure vendor "${displayName}": ${error.message}`);
+            }
+        }
+
         for (const doc of postingInstructions.documents) {
             let result = null;
 
@@ -791,10 +892,34 @@ class PayoutSyncService {
                             if (!accountId) {
                                 throw new Error(`Account ID not found for account: ${line.accountName}. Available accounts: ${Object.keys(accountMap).join(', ')}`);
                             }
-                            return {
+                            const mappedLine = {
                                 ...line,
                                 accountId
                             };
+
+                            if (line.entity && line.entity.type === 'Customer') {
+                                const key = buildCustomerKey(line.entity);
+                                const customerId = key ? customerRefMap[key] : null;
+                                if (customerId) {
+                                    mappedLine.entityRef = {
+                                        type: 'Customer',
+                                        value: customerId,
+                                        name: line.entity.name || line.name || this._resolveEntityName(null, 'transaction')
+                                    };
+                                }
+                            } else if (line.entity && line.entity.type === 'Vendor') {
+                                const key = buildVendorKey(line.entity) || 'vendor-stripe';
+                                const vendorId = vendorRefMap[key];
+                                if (vendorId) {
+                                    mappedLine.entityRef = {
+                                        type: 'Vendor',
+                                        value: vendorId,
+                                        name: line.entity.name || 'Stripe'
+                                    };
+                                }
+                            }
+
+                            return mappedLine;
                         });
 
                         this.logger.log(`[PayoutSync] Creating journal entry with ${linesWithAccountIds.length} lines`);
@@ -1206,6 +1331,167 @@ class PayoutSyncService {
     }
 
     /**
+     * Attempt to extract a customer email from a Stripe balance transaction
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {string|null}
+     * @private
+     */
+    _extractTransactionCustomerEmail(txn) {
+        if (!txn || typeof txn !== 'object') {
+            return null;
+        }
+
+        const candidates = [];
+
+        const pushCandidate = (value) => {
+            if (typeof value === 'string') {
+                const trimmed = value.trim();
+                if (trimmed.length > 0) {
+                    candidates.push(trimmed);
+                }
+            }
+        };
+
+        pushCandidate(txn.customer_email);
+        pushCandidate(txn.customerEmail);
+
+        if (txn.customer && typeof txn.customer === 'object') {
+            pushCandidate(txn.customer.email);
+        }
+
+        if (txn.customer_details && typeof txn.customer_details === 'object') {
+            pushCandidate(txn.customer_details.email);
+        }
+
+        if (txn.billing_details && typeof txn.billing_details === 'object') {
+            pushCandidate(txn.billing_details.email);
+        }
+
+        if (txn.source && typeof txn.source === 'object') {
+            if (txn.source.billing_details && typeof txn.source.billing_details === 'object') {
+                pushCandidate(txn.source.billing_details.email);
+            }
+            if (txn.source.customer && typeof txn.source.customer === 'object') {
+                pushCandidate(txn.source.customer.email);
+            }
+        }
+
+        if (txn.metadata && typeof txn.metadata === 'object') {
+            const metadataEmailFields = ['customer_email', 'customerEmail', 'email'];
+            for (const field of metadataEmailFields) {
+                pushCandidate(txn.metadata[field]);
+            }
+        }
+
+        if (Array.isArray(txn.receipt_emails)) {
+            txn.receipt_emails.forEach(pushCandidate);
+        }
+
+        return candidates.length > 0 ? candidates[0] : null;
+    }
+
+    /**
+     * Attempt to extract a Stripe customer identifier from a balance transaction
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {string|null}
+     * @private
+     */
+    _extractTransactionCustomerId(txn) {
+        if (!txn || typeof txn !== 'object') {
+            return null;
+        }
+
+        const candidates = [];
+
+        const addCandidate = (value) => {
+            if (typeof value === 'string' && value.trim().length > 0) {
+                candidates.push(value.trim());
+            }
+        };
+
+        addCandidate(txn.customer);
+        addCandidate(txn.customer_id);
+        addCandidate(txn.customerId);
+
+        if (txn.customer && typeof txn.customer === 'object') {
+            addCandidate(txn.customer.id);
+        }
+
+        if (txn.customer_details && typeof txn.customer_details === 'object') {
+            addCandidate(txn.customer_details.id);
+        }
+
+        if (txn.source && typeof txn.source === 'object') {
+            if (typeof txn.source.customer === 'string') {
+                addCandidate(txn.source.customer);
+            } else if (txn.source.customer && typeof txn.source.customer === 'object') {
+                addCandidate(txn.source.customer.id);
+            }
+        }
+
+        if (txn.metadata && typeof txn.metadata === 'object') {
+            const metadataFields = ['stripe_customer_id', 'stripeCustomerId', 'customer_id'];
+            for (const field of metadataFields) {
+                addCandidate(txn.metadata[field]);
+            }
+        }
+
+        return candidates.length > 0 ? candidates[0] : null;
+    }
+
+    /**
+     * Split a full name into given and family name components
+     * @param {string|null} fullName - Full name string
+     * @returns {{givenName: string|null, familyName: string|null}}
+     * @private
+     */
+    _splitName(fullName) {
+        if (!fullName || typeof fullName !== 'string') {
+            return { givenName: null, familyName: null };
+        }
+
+        const trimmed = fullName.trim();
+        if (trimmed.length === 0) {
+            return { givenName: null, familyName: null };
+        }
+
+        const parts = trimmed.split(/\s+/);
+        if (parts.length === 1) {
+            return { givenName: parts[0], familyName: null };
+        }
+
+        const givenName = parts.slice(0, parts.length - 1).join(' ');
+        const familyName = parts[parts.length - 1];
+        return { givenName, familyName };
+    }
+
+    /**
+     * Extract normalized customer details from a Stripe balance transaction
+     * @param {Object} txn - Stripe balance transaction
+     * @returns {Object|null}
+     * @private
+     */
+    _extractTransactionCustomerDetails(txn) {
+        const name = this._extractTransactionCustomerName(txn);
+        const email = this._extractTransactionCustomerEmail(txn);
+        const stripeCustomerId = this._extractTransactionCustomerId(txn);
+
+        if (!name && !email && !stripeCustomerId) {
+            return null;
+        }
+
+        const { givenName, familyName } = this._splitName(name);
+
+        return {
+            name: name || null,
+            email: email || null,
+            stripeCustomerId: stripeCustomerId || null,
+            givenName: givenName || null,
+            familyName: familyName || null
+        };
+    }
+
+    /**
      * Resolve the entity name for a journal line based on context
      * @param {string|null} customerName - Extracted customer name
      * @param {'transaction'|'payout'} context - Context for the line
@@ -1306,20 +1592,83 @@ class PayoutSyncService {
             return [];
         }
 
-        const { revenueAccount, refundsAccount, feesAccount, chargebackAccount, adjustmentAccount } = accounts;
+        const {
+            revenueAccount,
+            refundsAccount,
+            feesAccount,
+            chargebackAccount,
+            adjustmentAccount,
+            clearingAccount
+        } = accounts;
+
         const memo = this._buildTransactionMemo(txn);
         const baseDescription = this._buildTransactionDescription(txn);
         const baseMetadata = { ...this._buildTransactionMetadata(txn) };
-        const customerName = this._extractTransactionCustomerName(txn);
-        if (customerName) {
-            baseMetadata.customerName = customerName;
+
+        const extractedCustomerName = this._extractTransactionCustomerName(txn);
+        const customerDetails = this._extractTransactionCustomerDetails(txn);
+
+        if (extractedCustomerName && !baseMetadata.customerName) {
+            baseMetadata.customerName = extractedCustomerName;
         }
 
-        const name = this._resolveEntityName(customerName, 'transaction');
+        if (customerDetails && customerDetails.name) {
+            baseMetadata.customerName = customerDetails.name;
+        }
+
+        if (customerDetails && customerDetails.email) {
+            baseMetadata.customerEmail = customerDetails.email;
+        }
+
+        if (customerDetails && customerDetails.stripeCustomerId) {
+            baseMetadata.stripeCustomerId = customerDetails.stripeCustomerId;
+        }
+
+        if (typeof txn.source === 'string') {
+            baseMetadata.chargeId = txn.source;
+        } else if (txn.source && typeof txn.source === 'object' && typeof txn.source.id === 'string') {
+            baseMetadata.chargeId = txn.source.id;
+        }
+
+        if (txn.payment_intent && typeof txn.payment_intent === 'string') {
+            baseMetadata.paymentIntentId = txn.payment_intent;
+        }
+
+        const defaultLineName = this._resolveEntityName(
+            customerDetails && customerDetails.name ? customerDetails.name : extractedCustomerName,
+            'transaction'
+        );
+
+        const customerEntity = customerDetails ? {
+            type: 'Customer',
+            name: customerDetails.name || defaultLineName,
+            email: customerDetails.email || null,
+            stripeCustomerId: customerDetails.stripeCustomerId || null,
+            givenName: customerDetails.givenName || null,
+            familyName: customerDetails.familyName || null
+        } : null;
+
+        const stripeVendorEntity = {
+            type: 'Vendor',
+            name: 'Stripe',
+            displayName: 'Stripe',
+            externalId: 'stripe'
+        };
+
         const defaultRawAmount = typeof txn.net === 'number' ? txn.net : txn.amount;
         const lines = [];
 
-        const appendLine = ({ type, accountKey, accountName, rawAmount, component = null, description = null, metadataOverrides = {} }) => {
+        const appendLine = ({
+            type,
+            accountKey,
+            accountName,
+            rawAmount,
+            component = null,
+            description = null,
+            metadataOverrides = {},
+            entity = null,
+            nameOverride
+        }) => {
             if (!accountName || typeof rawAmount !== 'number' || Number.isNaN(rawAmount) || rawAmount === 0) {
                 return;
             }
@@ -1343,6 +1692,10 @@ class PayoutSyncService {
                 }
             });
 
+            const resolvedName = typeof nameOverride !== 'undefined'
+                ? nameOverride
+                : (entity && entity.name ? entity.name : defaultLineName);
+
             lines.push({
                 type,
                 accountKey,
@@ -1350,8 +1703,9 @@ class PayoutSyncService {
                 amount: normalizedAmount,
                 memo,
                 description: finalDescription || memo || null,
-                name,
+                name: resolvedName,
                 entityContext: 'transaction',
+                entity: entity || null,
                 metadata: lineMetadata
             });
         };
@@ -1361,6 +1715,23 @@ class PayoutSyncService {
                 return;
             }
             appendLine({ type, accountKey, accountName, rawAmount: defaultRawAmount });
+        };
+
+        const appendClearingLine = (netAmount) => {
+            if (!clearingAccount || typeof netAmount !== 'number' || Number.isNaN(netAmount) || netAmount === 0) {
+                return;
+            }
+
+            appendLine({
+                type: netAmount >= 0 ? 'debit' : 'credit',
+                accountKey: 'clearing',
+                accountName: clearingAccount,
+                rawAmount: netAmount,
+                component: 'Net to Stripe Clearing',
+                metadataOverrides: { netAmount },
+                entity: null,
+                nameOverride: null
+            });
         };
 
         switch (txn.type) {
@@ -1373,6 +1744,7 @@ class PayoutSyncService {
                         accountName: revenueAccount,
                         rawAmount: txn.amount,
                         component: 'Gross amount',
+                        entity: customerEntity,
                         metadataOverrides: { grossAmount: txn.amount }
                     });
                 }
@@ -1384,9 +1756,18 @@ class PayoutSyncService {
                         accountName: feesAccount,
                         rawAmount: txn.fee,
                         component: 'Processing fees',
-                        metadataOverrides: { feeAmount: txn.fee }
+                        entity: stripeVendorEntity,
+                        metadataOverrides: { feeAmount: txn.fee, vendor: 'Stripe' }
                     });
                 }
+
+                const netAmount = typeof txn.net === 'number'
+                    ? txn.net
+                    : (typeof txn.amount === 'number'
+                        ? txn.amount - (typeof txn.fee === 'number' ? txn.fee : 0)
+                        : 0);
+
+                appendClearingLine(netAmount);
 
                 if (lines.length === 0) {
                     makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'revenue', revenueAccount);
@@ -1414,9 +1795,18 @@ class PayoutSyncService {
                         accountName: feesAccount,
                         rawAmount: txn.fee,
                         component: 'Processing fees',
-                        metadataOverrides: { feeAmount: txn.fee }
+                        entity: stripeVendorEntity,
+                        metadataOverrides: { feeAmount: txn.fee, vendor: 'Stripe' }
                     });
                 }
+
+                const refundNet = typeof txn.net === 'number'
+                    ? txn.net
+                    : (typeof txn.amount === 'number'
+                        ? txn.amount - (typeof txn.fee === 'number' ? txn.fee : 0)
+                        : 0);
+
+                appendClearingLine(refundNet);
 
                 if (lines.length === 0) {
                     makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'refunds', refundsAccount);
@@ -1425,13 +1815,39 @@ class PayoutSyncService {
             }
 
             case 'stripe_fee':
-            case 'application_fee':
-                makeDefaultLine('debit', 'fees', feesAccount);
+            case 'application_fee': {
+                if (typeof defaultRawAmount === 'number' && defaultRawAmount !== 0) {
+                    appendLine({
+                        type: defaultRawAmount >= 0 ? 'debit' : 'credit',
+                        accountKey: 'fees',
+                        accountName: feesAccount,
+                        rawAmount: defaultRawAmount,
+                        component: 'Processing fees',
+                        entity: stripeVendorEntity,
+                        metadataOverrides: { feeAmount: defaultRawAmount, vendor: 'Stripe' }
+                    });
+                } else {
+                    makeDefaultLine('debit', 'fees', feesAccount);
+                }
                 break;
+            }
 
-            case 'application_fee_refund':
-                makeDefaultLine(defaultRawAmount >= 0 ? 'debit' : 'credit', 'fees', feesAccount);
+            case 'application_fee_refund': {
+                if (typeof defaultRawAmount === 'number' && defaultRawAmount !== 0) {
+                    appendLine({
+                        type: defaultRawAmount >= 0 ? 'debit' : 'credit',
+                        accountKey: 'fees',
+                        accountName: feesAccount,
+                        rawAmount: defaultRawAmount,
+                        component: 'Processing fees',
+                        entity: stripeVendorEntity,
+                        metadataOverrides: { feeAmount: defaultRawAmount, vendor: 'Stripe' }
+                    });
+                } else {
+                    makeDefaultLine(defaultRawAmount >= 0 ? 'debit' : 'credit', 'fees', feesAccount);
+                }
                 break;
+            }
 
             case 'adjustment':
                 makeDefaultLine(defaultRawAmount >= 0 ? 'credit' : 'debit', 'adjustments', adjustmentAccount);

--- a/tests/journalEntryCreation.test.js
+++ b/tests/journalEntryCreation.test.js
@@ -18,6 +18,8 @@ class MockQBOClient {
         this.accounts = [];
         this.journalEntries = [];
         this.transfers = [];
+        this.customers = [];
+        this.vendors = [];
     }
 
     findAccounts(criteria, callback) {
@@ -42,6 +44,92 @@ class MockQBOClient {
         };
         this.accounts.push(newAccount);
         callback(null, newAccount);
+    }
+
+    findCustomers(criteria, callback) {
+        let filteredCustomers = this.customers.slice();
+
+        if (Array.isArray(criteria)) {
+            criteria.forEach(c => {
+                if (c.field === 'PrimaryEmailAddr' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredCustomers = filteredCustomers.filter(customer =>
+                        customer.PrimaryEmailAddr &&
+                        customer.PrimaryEmailAddr.Address &&
+                        customer.PrimaryEmailAddr.Address.toLowerCase() === target
+                    );
+                }
+                if (c.field === 'DisplayName' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredCustomers = filteredCustomers.filter(customer =>
+                        customer.DisplayName && customer.DisplayName.toLowerCase() === target
+                    );
+                }
+            });
+        } else if (criteria && typeof criteria === 'object') {
+            if (criteria.DisplayName) {
+                const target = criteria.DisplayName.toLowerCase();
+                filteredCustomers = filteredCustomers.filter(customer =>
+                    customer.DisplayName && customer.DisplayName.toLowerCase() === target
+                );
+            }
+        }
+
+        callback(null, { QueryResponse: { Customer: filteredCustomers } });
+    }
+
+    createCustomer(customer, callback) {
+        const newCustomer = {
+            Id: `customer-${this.customers.length + 1}`,
+            DisplayName: customer.DisplayName,
+            PrimaryEmailAddr: customer.PrimaryEmailAddr || null,
+            GivenName: customer.GivenName || null,
+            FamilyName: customer.FamilyName || null
+        };
+        this.customers.push(newCustomer);
+        callback(null, newCustomer);
+    }
+
+    findVendors(criteria, callback) {
+        let filteredVendors = this.vendors.slice();
+
+        if (Array.isArray(criteria)) {
+            criteria.forEach(c => {
+                if (c.field === 'PrimaryEmailAddr' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredVendors = filteredVendors.filter(vendor =>
+                        vendor.PrimaryEmailAddr &&
+                        vendor.PrimaryEmailAddr.Address &&
+                        vendor.PrimaryEmailAddr.Address.toLowerCase() === target
+                    );
+                }
+                if (c.field === 'DisplayName' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredVendors = filteredVendors.filter(vendor =>
+                        vendor.DisplayName && vendor.DisplayName.toLowerCase() === target
+                    );
+                }
+            });
+        } else if (criteria && typeof criteria === 'object') {
+            if (criteria.DisplayName) {
+                const target = criteria.DisplayName.toLowerCase();
+                filteredVendors = filteredVendors.filter(vendor =>
+                    vendor.DisplayName && vendor.DisplayName.toLowerCase() === target
+                );
+            }
+        }
+
+        callback(null, { QueryResponse: { Vendor: filteredVendors } });
+    }
+
+    createVendor(vendor, callback) {
+        const newVendor = {
+            Id: `vendor-${this.vendors.length + 1}`,
+            DisplayName: vendor.DisplayName,
+            PrimaryEmailAddr: vendor.PrimaryEmailAddr || null
+        };
+        this.vendors.push(newVendor);
+        callback(null, newVendor);
     }
 
     findJournalEntries(criteria, callback) {
@@ -179,6 +267,8 @@ async function runTests() {
     try {
         mockQBOClient.accounts = [];
         mockQBOClient.journalEntries = [];
+        mockQBOClient.customers = [];
+        mockQBOClient.vendors = [];
 
         // Setup
         const config = new AccountingSyncConfig();
@@ -271,27 +361,44 @@ async function runTests() {
                 throw new Error('Some journal entry lines missing AccountRef.value');
             }
 
-            const entityPresence = createdJE.Line.map(line =>
-                line.JournalEntryLineDetail &&
-                line.JournalEntryLineDetail.Entity &&
-                line.JournalEntryLineDetail.Entity.EntityRef
-                    ? line.JournalEntryLineDetail.Entity.EntityRef.name || line.JournalEntryLineDetail.Entity.EntityRef.value
-                    : null
-            );
+            const entitySummary = createdJE.Line.map(line => {
+                const detail = line.JournalEntryLineDetail;
+                if (!detail || !detail.Entity || !detail.Entity.EntityRef) {
+                    return null;
+                }
+                return {
+                    type: detail.Entity.Type,
+                    name: detail.Entity.EntityRef.name,
+                    value: detail.Entity.EntityRef.value
+                };
+            });
 
-            const hasEntityRefs = entityPresence.some(value => value !== null && value !== undefined);
-            if (hasEntityRefs) {
-                throw new Error(`Unexpected entity references on journal lines: ${entityPresence.join(', ')}`);
+            const vendorEntities = entitySummary.filter(entity => entity && entity.type === 'Vendor');
+            if (vendorEntities.length === 0 || !vendorEntities.every(entity => entity.name === 'Stripe')) {
+                throw new Error(`Expected Stripe vendor entity on fee lines, got: ${JSON.stringify(vendorEntities)}`);
+            }
+
+            const customerEntities = entitySummary.filter(entity => entity && entity.type === 'Customer');
+            if (customerEntities.length !== 0) {
+                throw new Error('Summary journal entry should not include customer entity references');
             }
 
             const descriptions = createdJE.Line.map(line => line.Description || '');
-            if (!descriptions.every(desc => desc.includes('Stripe Payout'))) {
+            const payoutDescriptorPresent = descriptions.every(desc => {
+                const lowered = desc.toLowerCase();
+                return lowered.includes('stripe payout');
+            });
+            if (!payoutDescriptorPresent) {
                 throw new Error(`Journal line descriptions missing payout identifier: ${descriptions.join(' || ')}`);
             }
 
             // Verify accounts were created
             if (mockQBOClient.accounts.length < 2) {
                 throw new Error(`Expected at least 2 accounts to be created, got ${mockQBOClient.accounts.length}`);
+            }
+
+            if (mockQBOClient.vendors.length === 0) {
+                throw new Error('Expected Stripe vendor to be created');
             }
 
             console.log('✅ Complete payout sync flow with journal entry creation');
@@ -315,6 +422,8 @@ async function runTests() {
     try {
         mockQBOClient.accounts = [];
         mockQBOClient.journalEntries = [];
+        mockQBOClient.customers = [];
+        mockQBOClient.vendors = [];
 
         const config = new AccountingSyncConfig();
         config.config = {
@@ -401,40 +510,74 @@ async function runTests() {
         const revenueLine = jeDoc.lines.find(line => line.accountKey === 'revenue');
         const feeLine = jeDoc.lines.find(line => line.accountKey === 'fees' && line.metadata && line.metadata.component === 'Processing fees');
 
-        if (!clearingLine || clearingLine.name !== 'Stripe Payout') {
-            throw new Error(`Clearing line missing or has incorrect name: ${clearingLine ? clearingLine.name : 'none'}`);
-        }
-
         if (!revenueLine || revenueLine.name !== 'Alice Customer') {
             throw new Error(`Revenue line missing or has incorrect name: ${revenueLine ? revenueLine.name : 'none'}`);
         }
 
-        if (!feeLine || feeLine.name !== 'Alice Customer') {
-            throw new Error(`Fee line missing or has incorrect name: ${feeLine ? feeLine.name : 'none'}`);
+        if (!feeLine || !feeLine.entity || feeLine.entity.type !== 'Vendor') {
+            throw new Error('Fee line missing vendor entity');
+        }
+
+        if (!revenueLine.entity || revenueLine.entity.type !== 'Customer') {
+            throw new Error('Revenue line missing customer entity');
+        }
+
+        if (!clearingLine) {
+            throw new Error('Clearing line missing');
+        }
+
+        if (clearingLine.entity) {
+            throw new Error('Clearing line should not have an entity');
         }
 
         await payoutSyncService.postToAccounting(instructions);
 
         if (mockQBOClient.journalEntries.length === 1) {
             const created = mockQBOClient.journalEntries[0];
-            const entitySummary = created.Line.map(line =>
-                line.JournalEntryLineDetail &&
-                line.JournalEntryLineDetail.Entity &&
-                line.JournalEntryLineDetail.Entity.EntityRef
-                    ? line.JournalEntryLineDetail.Entity.EntityRef.name || line.JournalEntryLineDetail.Entity.EntityRef.value
-                    : null
-            );
+            if (created.Line.length !== 3) {
+                throw new Error(`Per-transaction JE should have 3 lines, got ${created.Line.length}`);
+            }
 
-            if (entitySummary.some(value => value !== null && value !== undefined)) {
-                throw new Error(`Unexpected entity references on per-transaction JE: ${entitySummary.join(', ')}`);
+            const entitySummary = created.Line.map(line => {
+                const detail = line.JournalEntryLineDetail;
+                if (!detail || !detail.Entity || !detail.Entity.EntityRef) {
+                    return null;
+                }
+                return {
+                    type: detail.Entity.Type,
+                    name: detail.Entity.EntityRef.name,
+                    value: detail.Entity.EntityRef.value,
+                    description: line.Description || ''
+                };
+            });
+
+            const customerEntity = entitySummary.find(entity => entity && entity.type === 'Customer');
+            if (!customerEntity || customerEntity.name !== 'Alice Customer') {
+                throw new Error(`Customer entity missing or incorrect: ${JSON.stringify(customerEntity)}`);
+            }
+
+            const vendorEntities = entitySummary.filter(entity => entity && entity.type === 'Vendor');
+            if (vendorEntities.length !== 1 || vendorEntities[0].name !== 'Stripe') {
+                throw new Error(`Expected Stripe vendor entity on fee line, got: ${JSON.stringify(vendorEntities)}`);
+            }
+
+            const clearingEntities = created.Line
+                .filter(line => (line.Description || '').includes('Net to Stripe Clearing'))
+                .map(line => line.JournalEntryLineDetail && line.JournalEntryLineDetail.Entity && line.JournalEntryLineDetail.Entity.EntityRef)
+                .filter(Boolean);
+            if (clearingEntities.length > 0) {
+                throw new Error('Clearing line should not include an EntityRef');
             }
 
             const descriptions = created.Line.map(line => line.Description || '');
-            const hasPayoutDescriptor = descriptions.some(desc => desc.includes('Stripe Payout'));
-            const hasCustomerDescriptor = descriptions.filter(desc => desc.includes('Alice Customer')).length === 2;
+            const hasPayoutDescriptor = descriptions.some(desc => desc.toLowerCase().includes('stripe payout'));
 
-            if (!hasPayoutDescriptor || !hasCustomerDescriptor) {
-                throw new Error(`Journal entry descriptions missing expected identifiers: ${descriptions.join(' || ')}`);
+            if (!hasPayoutDescriptor) {
+                throw new Error(`Journal entry descriptions missing payout identifier: ${descriptions.join(' || ')}`);
+            }
+
+            if (mockQBOClient.customers.length === 0) {
+                throw new Error('Expected QuickBooks customer to be created');
             }
 
             console.log('✅ Per-transaction journal entry retains customer names in instructions without invalid QBO entity refs');


### PR DESCRIPTION
## Summary
- add customer and vendor support to the accounting provider interface and QuickBooks implementation so QBO entity records can be created or reused
- enrich payout journal instructions with customer metadata, vendor tagging for Stripe fees, and per-transaction clearing lines before posting to QuickBooks
- update the posting workflow to resolve or create customers and the Stripe vendor before submitting journal lines, and extend integration tests to cover the new entity references

## Testing
- node tests/journalEntryCreation.test.js
- node tests/amountConversion.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e14e9d1a60832c88a664aa4d12bdf5