### PR TITLE
Sanitize QuickBooks vendor payloads

### DIFF
--- a/services/accounting/quickbooksProvider.js
+++ b/services/accounting/quickbooksProvider.js
@@ -1,6 +1,9 @@
 const BaseAccountingProvider = require('./baseAccountingProvider');
 const QuickBooks = require('node-quickbooks');
 
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/i;
+const MAX_VENDOR_ACCOUNT_NUMBER_LENGTH = 30;
+
 /**
  * QuickBooks Online (QBO) Accounting Provider
  * Implements accounting operations for QuickBooks Online using the QuickBooks API
@@ -54,6 +57,48 @@ class QuickBooksProvider extends BaseAccountingProvider {
             }
             throw error;
         }
+    }
+
+    _normalizeEmail(value) {
+        if (value === null || value === undefined) {
+            return null;
+        }
+
+        const email = value.toString().trim();
+
+        if (email.length === 0) {
+            return null;
+        }
+
+        if (!EMAIL_REGEX.test(email)) {
+            if (this.logger && typeof this.logger.warn === 'function') {
+                this.logger.warn(`[QBO] Skipping invalid email address: ${email}`);
+            }
+            return null;
+        }
+
+        return email.toLowerCase();
+    }
+
+    _sanitizeVendorExternalId(externalId) {
+        if (externalId === null || externalId === undefined) {
+            return null;
+        }
+
+        const value = externalId.toString().trim();
+
+        if (value.length === 0) {
+            return null;
+        }
+
+        if (value.length > MAX_VENDOR_ACCOUNT_NUMBER_LENGTH) {
+            if (this.logger && typeof this.logger.warn === 'function') {
+                this.logger.warn(`[QBO] Truncating vendor external ID to ${MAX_VENDOR_ACCOUNT_NUMBER_LENGTH} characters`);
+            }
+            return value.substring(0, MAX_VENDOR_ACCOUNT_NUMBER_LENGTH);
+        }
+
+        return value;
     }
 
     _extractQboErrorMessage(error, fallback = 'Unknown QuickBooks error') {
@@ -162,7 +207,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
 
         const displayNameSource = customer.displayName || customer.name || customer.email || customer.externalId || 'Stripe Customer';
         const displayName = displayNameSource.toString().trim().substring(0, 99) || 'Stripe Customer';
-        const normalizedEmail = customer.email ? customer.email.toString().trim().toLowerCase() : null;
+        const normalizedEmail = this._normalizeEmail(customer.email);
         const normalizedDisplayName = displayName.toLowerCase();
         const existingCustomers = [];
 
@@ -244,7 +289,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
             newCustomer.FamilyName = customer.familyName;
         }
         if (normalizedEmail) {
-            newCustomer.PrimaryEmailAddr = { Address: customer.email.toString().trim() };
+            newCustomer.PrimaryEmailAddr = { Address: normalizedEmail };
         }
         if (customer.externalId) {
             newCustomer.Notes = `Stripe Customer ID: ${customer.externalId}`;
@@ -283,7 +328,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
 
         const displayNameSource = vendor.displayName || vendor.name || 'Stripe';
         const displayName = displayNameSource.toString().trim().substring(0, 99) || 'Stripe';
-        const normalizedEmail = vendor.email ? vendor.email.toString().trim().toLowerCase() : null;
+        const normalizedEmail = this._normalizeEmail(vendor.email);
         const normalizedDisplayName = displayName.toLowerCase();
 
         const uniqueById = (list) => {
@@ -360,10 +405,12 @@ class QuickBooksProvider extends BaseAccountingProvider {
         };
 
         if (normalizedEmail) {
-            newVendor.PrimaryEmailAddr = { Address: vendor.email.toString().trim() };
+            newVendor.PrimaryEmailAddr = { Address: normalizedEmail };
         }
-        if (vendor.externalId) {
-            newVendor.Other1 = vendor.externalId;
+
+        const sanitizedExternalId = this._sanitizeVendorExternalId(vendor.externalId);
+        if (sanitizedExternalId) {
+            newVendor.AcctNum = sanitizedExternalId;
         }
 
         try {

--- a/tests/quickbooksProvider.test.js
+++ b/tests/quickbooksProvider.test.js
@@ -19,6 +19,8 @@ class MockQBOClient {
         this.journalEntries = [];
         this.transfers = [];
         this.deposits = [];
+        this.customers = [];
+        this.vendors = [];
         this.companyInfo = {
             CompanyName: 'Test Company',
             Id: 'test-company-123'
@@ -30,6 +32,8 @@ class MockQBOClient {
             access_token: 'new-access-token',
             refresh_token: 'new-refresh-token'
         };
+        this.lastCustomerPayload = null;
+        this.lastVendorPayload = null;
     }
 
     reset() {
@@ -37,6 +41,8 @@ class MockQBOClient {
         this.journalEntries = [];
         this.transfers = [];
         this.deposits = [];
+        this.customers = [];
+        this.vendors = [];
         this.shouldFailAuth = false;
         this.tokenRefreshCount = 0;
         this.refreshError = null;
@@ -44,6 +50,8 @@ class MockQBOClient {
             access_token: 'new-access-token',
             refresh_token: 'new-refresh-token'
         };
+        this.lastCustomerPayload = null;
+        this.lastVendorPayload = null;
     }
 
     query(queryStr, callback) {
@@ -134,6 +142,65 @@ class MockQBOClient {
         }
     }
 
+    findCustomers(criteria, callback) {
+        if (this.shouldFailAuth) {
+            return callback({ fault: { type: 'AUTHENTICATION' } });
+        }
+
+        let filteredCustomers = this.customers.slice();
+
+        if (Array.isArray(criteria)) {
+            criteria.forEach(c => {
+                if (!c || typeof c !== 'object') {
+                    return;
+                }
+
+                if (c.field === 'PrimaryEmailAddr' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredCustomers = filteredCustomers.filter(customer =>
+                        customer.PrimaryEmailAddr &&
+                        customer.PrimaryEmailAddr.Address &&
+                        customer.PrimaryEmailAddr.Address.toLowerCase() === target
+                    );
+                }
+
+                if (c.field === 'DisplayName' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredCustomers = filteredCustomers.filter(customer =>
+                        customer.DisplayName && customer.DisplayName.toLowerCase() === target
+                    );
+                }
+            });
+        } else if (criteria && typeof criteria === 'object') {
+            if (criteria.DisplayName) {
+                const target = criteria.DisplayName.toLowerCase();
+                filteredCustomers = filteredCustomers.filter(customer =>
+                    customer.DisplayName && customer.DisplayName.toLowerCase() === target
+                );
+            }
+        }
+
+        callback(null, { QueryResponse: { Customer: filteredCustomers } });
+    }
+
+    createCustomer(customer, callback) {
+        if (this.shouldFailAuth) {
+            return callback({ fault: { type: 'AUTHENTICATION' } });
+        }
+
+        const newCustomer = {
+            Id: `customer-${this.customers.length + 1}`,
+            DisplayName: customer.DisplayName,
+            PrimaryEmailAddr: customer.PrimaryEmailAddr || null,
+            GivenName: customer.GivenName || null,
+            FamilyName: customer.FamilyName || null
+        };
+
+        this.customers.push(newCustomer);
+        this.lastCustomerPayload = customer;
+        callback(null, newCustomer);
+    }
+
     createJournalEntry(je, callback) {
         if (this.shouldFailAuth) {
             return callback({ fault: { type: 'AUTHENTICATION' } });
@@ -166,6 +233,64 @@ class MockQBOClient {
         };
         this.transfers.push(newTransfer);
         callback(null, newTransfer);
+    }
+
+    findVendors(criteria, callback) {
+        if (this.shouldFailAuth) {
+            return callback({ fault: { type: 'AUTHENTICATION' } });
+        }
+
+        let filteredVendors = this.vendors.slice();
+
+        if (Array.isArray(criteria)) {
+            criteria.forEach(c => {
+                if (!c || typeof c !== 'object') {
+                    return;
+                }
+
+                if (c.field === 'PrimaryEmailAddr' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredVendors = filteredVendors.filter(vendor =>
+                        vendor.PrimaryEmailAddr &&
+                        vendor.PrimaryEmailAddr.Address &&
+                        vendor.PrimaryEmailAddr.Address.toLowerCase() === target
+                    );
+                }
+
+                if (c.field === 'DisplayName' && typeof c.value === 'string') {
+                    const target = c.value.toLowerCase();
+                    filteredVendors = filteredVendors.filter(vendor =>
+                        vendor.DisplayName && vendor.DisplayName.toLowerCase() === target
+                    );
+                }
+            });
+        } else if (criteria && typeof criteria === 'object') {
+            if (criteria.DisplayName) {
+                const target = criteria.DisplayName.toLowerCase();
+                filteredVendors = filteredVendors.filter(vendor =>
+                    vendor.DisplayName && vendor.DisplayName.toLowerCase() === target
+                );
+            }
+        }
+
+        callback(null, { QueryResponse: { Vendor: filteredVendors } });
+    }
+
+    createVendor(vendor, callback) {
+        if (this.shouldFailAuth) {
+            return callback({ fault: { type: 'AUTHENTICATION' } });
+        }
+
+        const newVendor = {
+            Id: `vendor-${this.vendors.length + 1}`,
+            DisplayName: vendor.DisplayName,
+            PrimaryEmailAddr: vendor.PrimaryEmailAddr || null,
+            AcctNum: vendor.AcctNum || null
+        };
+
+        this.vendors.push(newVendor);
+        this.lastVendorPayload = vendor;
+        callback(null, newVendor);
     }
 
     createDeposit(deposit, callback) {
@@ -1012,6 +1137,56 @@ async function runTests() {
             console.log('❌ Token refresh failure - unexpected error:', error.message);
             failed++;
         }
+    }
+
+    // Test 17: Ensure vendor creation sanitizes invalid fields
+    try {
+        mockQBOClient.reset();
+
+        const config = {
+            companyId: 'test-company-123',
+            environment: 'sandbox',
+            oauthTokens: {
+                accessToken: 'test-access-token',
+                refreshToken: 'test-refresh-token'
+            }
+        };
+
+        const provider = new QuickBooksProvider(config);
+
+        const longExternalId = 'acct_' + '1234567890'.repeat(4);
+
+        const vendorRef = await provider.ensureVendor({
+            displayName: 'Stripe',
+            email: 'not-an-email',
+            externalId: longExternalId
+        });
+
+        const payload = mockQBOClient.lastVendorPayload;
+        const storedVendor = mockQBOClient.vendors[0];
+
+        const expectedAcctNum = longExternalId.substring(0, 30);
+
+        if (vendorRef &&
+            vendorRef.id === 'vendor-1' &&
+            payload &&
+            !payload.PrimaryEmailAddr &&
+            payload.AcctNum === expectedAcctNum &&
+            storedVendor &&
+            storedVendor.AcctNum === expectedAcctNum &&
+            storedVendor.PrimaryEmailAddr === null) {
+            console.log('✅ Ensure vendor creation sanitizes invalid fields');
+            passed++;
+        } else {
+            console.log('❌ Ensure vendor creation sanitizes invalid fields failed');
+            console.log('   Vendor ref:', vendorRef);
+            console.log('   Payload:', payload);
+            console.log('   Stored vendor:', storedVendor);
+            failed++;
+        }
+    } catch (error) {
+        console.log('❌ Ensure vendor creation sanitizes invalid fields - error:', error.message);
+        failed++;
     }
 
     // Print summary


### PR DESCRIPTION
## Summary
- validate and normalize emails before syncing QuickBooks customers and vendors and truncate long vendor external IDs
- switch vendor external IDs to AcctNum and add targeted warnings to avoid unsupported payload fields
- expand the QuickBooks provider test harness with vendor/customer mocks and a sanitization regression test

## Testing
- npm test *(fails: existing per-transaction payout journal mode scenario)*
- node tests/quickbooksProvider.test.js
- node tests/journalEntryCreation.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e15b550104832c8e384345a4eeb734