### PR TITLE
Add Stripe clearing sync service for QBO

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,63 @@ The system includes advanced customer-contact association with configurable matc
 | `CONTACT_MATCH_REVIEW_ENABLED` | Enable review task creation for uncertain matches | `true` | `false` |
 | `REVIEW_DEEP_LINK_BASE_URL` | Base URL for deep links in review tasks | `https://example.com/admin` | Your admin URL |
 
+### Stripe → QuickBooks Online configuration
+
+The Stripe clearing sync relies on the following accounting environment variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `ACCT_REVENUE_ID` | Income account credited for successful charges |
+| `ACCT_STRIPE_FEES_ID` | Expense account debited for Stripe fees and dispute fees |
+| `ACCT_REFUNDS_CONTRA_REV_ID` | Contra-revenue account debited for refunds and disputes |
+| `ACCT_STRIPE_CLEARING_ID` | Bank-type clearing account that accumulates Stripe balance activity |
+| `ACCT_OPERATING_BANK_ID` | Destination bank account for Stripe payouts |
+| `VENDOR_STRIPE_ID` | Optional QuickBooks Vendor ID for Stripe (auto-created when omitted) |
+| `COMPANY_HOME_CURRENCY` | Home currency used for FX conversions |
+| `STRIPE_QBO_STATE_PATH` | Optional path for the durable idempotency store (defaults to `.data/stripe-qbo-state.json`) |
+
+The new module under `services/accounting/stripe-qbo` exposes composable functions that follow the Single Responsibility Principle:
+
+```javascript
+const stripe = require('stripe')(process.env.STRIPE_TEST_SECRET_KEY);
+const quickBooksProvider = /* existing QBO provider instance */;
+const {
+    fetchStripeChargesSince,
+    resolveQboCustomer,
+    ensureStripeVendor,
+    buildChargeJE,
+    postJEIfNew,
+    postTransferIfNew,
+    ProcessedStripeStore
+} = require('./services/accounting/stripe-qbo');
+
+async function syncSince(isoDate) {
+    const store = new ProcessedStripeStore();
+    const vendor = await ensureStripeVendor(quickBooksProvider);
+    const charges = await fetchStripeChargesSince(stripe, isoDate);
+
+    for (const charge of charges) {
+        const customer = await resolveQboCustomer(charge, quickBooksProvider);
+        const { journalEntry, attachments } = buildChargeJE(charge, {
+            revenueId: process.env.ACCT_REVENUE_ID,
+            stripeFeesId: process.env.ACCT_STRIPE_FEES_ID,
+            refundsContraId: process.env.ACCT_REFUNDS_CONTRA_REV_ID,
+            stripeClearingId: process.env.ACCT_STRIPE_CLEARING_ID
+        }, vendor, customer, { companyHomeCurrency: process.env.COMPANY_HOME_CURRENCY });
+
+        await postJEIfNew(journalEntry, quickBooksProvider, {
+            store,
+            stripeId: charge.id,
+            attachments
+        });
+    }
+}
+```
+
+For payouts, use `postTransferIfNew(payout, quickBooksProvider, { accounts, store })` after confirming the clearing account balances with `reconcilePayout(payout, mappedTransactions)`. The `ProcessedStripeStore` persists processed Stripe IDs to disk, ensuring webhook replays and manual backfills stay idempotent across process restarts.
+
+Run `node tests/stripeQboSync.test.js` to exercise the charge, refund, dispute, fee, payout, attachment, and idempotency scenarios that underpin the clearing workflow.
+
 ## API Usage
 
 ### Payment Processing Endpoint

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "processTransaction/index.js",
   "scripts": {
     "start": "func start",
-    "test": "node tests/integration.test.js && node tests/transactionCreationFlow.test.js && node tests/failedCanceledTransactions.test.js && node tests/payoutSync.test.js && node tests/payoutCrmIntegration.test.js && node tests/payoutSyncFix.test.js && node tests/manualPayoutSync.test.js && node tests/payoutDateRangeFix.test.js && node tests/connectedAccountPayoutFix.test.js && node tests/payoutArrivalDateFix.test.js && node tests/payoutSyncLogicCorrection.test.js && node tests/payoutAdvanceExclusion.test.js && node tests/productionScenarioSimulation.test.js && node tests/manualPayoutDateWindow.test.js && node tests/quickbooksProvider.test.js && node tests/journalEntryCreation.test.js && node tests/amountConversion.test.js"
+    "test": "node tests/integration.test.js && node tests/transactionCreationFlow.test.js && node tests/failedCanceledTransactions.test.js && node tests/payoutSync.test.js && node tests/payoutCrmIntegration.test.js && node tests/payoutSyncFix.test.js && node tests/manualPayoutSync.test.js && node tests/payoutDateRangeFix.test.js && node tests/connectedAccountPayoutFix.test.js && node tests/payoutArrivalDateFix.test.js && node tests/payoutSyncLogicCorrection.test.js && node tests/payoutAdvanceExclusion.test.js && node tests/productionScenarioSimulation.test.js && node tests/manualPayoutDateWindow.test.js && node tests/quickbooksProvider.test.js && node tests/journalEntryCreation.test.js && node tests/amountConversion.test.js && node tests/stripeQboSync.test.js"
   },
   "dependencies": {
     "@azure/functions": "^4.5.0",

--- a/services/accounting/stripe-qbo/attachments.js
+++ b/services/accounting/stripe-qbo/attachments.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const MAX_ATTACHMENT_BYTES = 1.5 * 1024 * 1024; // 1.5MB guardrail
+
+function serializeArtifact(artifact) {
+    if (artifact === null || artifact === undefined) {
+        return null;
+    }
+
+    if (typeof artifact === 'string') {
+        return artifact.trim().length > 0 ? artifact.trim() : null;
+    }
+
+    try {
+        return JSON.stringify(artifact, null, 2);
+    } catch (error) {
+        return null;
+    }
+}
+
+function buildAttachment(artifact, index) {
+    const serialized = serializeArtifact(artifact);
+    if (!serialized) {
+        return null;
+    }
+
+    const buffer = Buffer.from(serialized, 'utf8');
+    if (buffer.length > MAX_ATTACHMENT_BYTES) {
+        return null;
+    }
+
+    const suffix = typeof artifact === 'string' ? 'url' : 'json';
+    const fileName = `stripe-artifact-${index + 1}.${suffix === 'url' ? 'txt' : 'json'}`;
+
+    return {
+        fileName,
+        contentType: suffix === 'url' ? 'text/plain' : 'application/json',
+        data: buffer.toString('base64')
+    };
+}
+
+async function attachStripeArtifacts(quickbooksProvider, transactionId, artifacts = [], options = {}) {
+    if (!transactionId) {
+        throw new Error('A QuickBooks transaction ID is required to attach artifacts');
+    }
+
+    if (!quickbooksProvider || typeof quickbooksProvider.attachDocument !== 'function') {
+        throw new Error('QuickBooks provider with attachDocument is required to attach artifacts');
+    }
+
+    const logger = options.logger || console;
+    const attachments = artifacts
+        .map((artifact, index) => buildAttachment(artifact, index))
+        .filter(Boolean);
+
+    const results = [];
+
+    for (const attachment of attachments) {
+        try {
+            const response = await quickbooksProvider.attachDocument(transactionId, attachment);
+            results.push(response);
+        } catch (error) {
+            logger.error('[Stripe→QBO] Failed to attach artifact', {
+                transactionId,
+                fileName: attachment?.fileName,
+                error: error.message
+            });
+        }
+    }
+
+    if (results.length === 0 && attachments.length > 0) {
+        logger.warn('[Stripe→QBO] No attachments were successfully linked to QBO transaction', {
+            transactionId
+        });
+    }
+
+    return results;
+}
+
+module.exports = {
+    attachStripeArtifacts,
+    buildAttachment,
+    MAX_ATTACHMENT_BYTES
+};

--- a/services/accounting/stripe-qbo/customerResolver.js
+++ b/services/accounting/stripe-qbo/customerResolver.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const UNKNOWN_DONOR_NAME = 'Unknown Donor (Stripe)';
+
+function sanitizeString(value) {
+    if (value === null || value === undefined) {
+        return null;
+    }
+
+    const text = value.toString().trim();
+    return text.length > 0 ? text : null;
+}
+
+function extractCustomerDetails(charge) {
+    const billing = charge && charge.billing_details ? charge.billing_details : {};
+    const expandedCustomer = typeof charge?.customer === 'object' && charge.customer !== null
+        ? charge.customer
+        : null;
+
+    const billingName = sanitizeString(billing.name);
+    const billingEmail = sanitizeString(billing.email);
+
+    const expandedName = sanitizeString(expandedCustomer?.name);
+    const expandedEmail = sanitizeString(expandedCustomer?.email);
+
+    const preferredName = billingName || expandedName;
+    const preferredEmail = billingEmail || expandedEmail;
+
+    return {
+        name: preferredName,
+        email: preferredEmail,
+        fallbackNeeded: !preferredName && !preferredEmail,
+        expandedCustomerId: expandedCustomer?.id || (typeof charge?.customer === 'string' ? charge.customer : null)
+    };
+}
+
+async function resolveQboCustomer(charge, quickbooksProvider, options = {}) {
+    if (!quickbooksProvider || typeof quickbooksProvider.ensureCustomer !== 'function') {
+        throw new Error('A QuickBooks provider with ensureCustomer is required to resolve customers');
+    }
+
+    const logger = options.logger || console;
+    const customerDetails = extractCustomerDetails(charge);
+
+    const payload = {
+        displayName: customerDetails.name || customerDetails.email || UNKNOWN_DONOR_NAME,
+        email: customerDetails.email,
+        externalId: customerDetails.expandedCustomerId || charge?.customer || null,
+        givenName: sanitizeString(charge?.billing_details?.name?.split?.(' ')?.[0]) || null,
+        familyName: sanitizeString(charge?.billing_details?.name?.split?.(' ')?.slice(1).join(' ')) || null
+    };
+
+    let qboCustomer;
+    let isFallback = false;
+
+    try {
+        if (customerDetails.fallbackNeeded) {
+            isFallback = true;
+            qboCustomer = await quickbooksProvider.ensureCustomer({
+                displayName: UNKNOWN_DONOR_NAME,
+                email: null,
+                externalId: 'stripe-unknown-donor'
+            });
+        } else {
+            qboCustomer = await quickbooksProvider.ensureCustomer(payload);
+        }
+    } catch (error) {
+        logger.error('[Stripe→QBO] Failed to ensure QuickBooks customer', {
+            chargeId: charge?.id,
+            error: error.message
+        });
+        throw error;
+    }
+
+    if (!qboCustomer || !qboCustomer.id) {
+        throw new Error('QuickBooks customer resolution returned an invalid response');
+    }
+
+    return {
+        id: qboCustomer.id,
+        displayName: qboCustomer.displayName || qboCustomer.DisplayName || payload.displayName,
+        email: customerDetails.email || null,
+        isFallback
+    };
+}
+
+module.exports = {
+    resolveQboCustomer,
+    UNKNOWN_DONOR_NAME,
+    _extractCustomerDetails: extractCustomerDetails
+};

--- a/services/accounting/stripe-qbo/fetchStripe.js
+++ b/services/accounting/stripe-qbo/fetchStripe.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const DEFAULT_LIMIT = 100;
+const MAX_AUTOPAGE = 1000;
+
+function normalizeSince(since) {
+    if (since === undefined || since === null) {
+        throw new Error('A since value is required to fetch Stripe resources');
+    }
+
+    if (typeof since === 'number') {
+        if (since > 1000000000000) { // milliseconds
+            return Math.floor(since / 1000);
+        }
+        return Math.floor(since);
+    }
+
+    if (since instanceof Date) {
+        return Math.floor(since.getTime() / 1000);
+    }
+
+    if (typeof since === 'string') {
+        const parsed = new Date(since);
+        if (Number.isNaN(parsed.getTime())) {
+            throw new Error(`Invalid since date string: ${since}`);
+        }
+        return Math.floor(parsed.getTime() / 1000);
+    }
+
+    throw new Error(`Unsupported since value: ${since}`);
+}
+
+async function fetchAll(stripeListFn, params, logger = console) {
+    const items = [];
+    let startingAfter;
+    let page = 0;
+
+    do {
+        page += 1;
+        const response = await stripeListFn({ ...params, starting_after: startingAfter });
+
+        if (!response || !Array.isArray(response.data)) {
+            throw new Error('Unexpected response from Stripe list API');
+        }
+
+        response.data.forEach(item => items.push(item));
+
+        if (!response.has_more) {
+            break;
+        }
+
+        if (response.data.length === 0) {
+            logger.warn('[Stripe] Pagination halted because response was empty while has_more=true');
+            break;
+        }
+
+        startingAfter = response.data[response.data.length - 1].id;
+
+        if (page >= MAX_AUTOPAGE) {
+            logger.warn(`[Stripe] Reached pagination guardrail of ${MAX_AUTOPAGE} pages – stopping early`);
+            break;
+        }
+    } while (true);
+
+    return items;
+}
+
+function createListFetcher({ listFn, baseParams }) {
+    return async (since, options = {}) => {
+        if (!listFn || typeof listFn !== 'function') {
+            throw new Error('A Stripe list function must be provided');
+        }
+
+        const sinceEpoch = normalizeSince(since);
+        const limit = options.limit || DEFAULT_LIMIT;
+        const logger = options.logger || console;
+
+        const { createdField, expand: baseExpandParam, ...restBaseParams } = baseParams || {};
+
+        const baseExpand = Array.isArray(baseExpandParam) ? baseExpandParam : [];
+        const { expand: optionExpandParam, ...restOptionParams } = options.params || {};
+        const optionExpand = Array.isArray(optionExpandParam) ? optionExpandParam : [];
+        const expand = Array.from(new Set([...baseExpand, ...optionExpand]));
+
+        const params = {
+            limit,
+            ...restBaseParams,
+            ...restOptionParams,
+            expand,
+            created: createdField === 'arrival_date'
+                ? undefined
+                : { gte: sinceEpoch }
+        };
+
+        if (createdField === 'arrival_date') {
+            params.arrival_date = { gte: sinceEpoch };
+        }
+
+        return fetchAll(listFn, params, logger);
+    };
+}
+
+function buildChargeFetcher(stripe) {
+    return createListFetcher({
+        listFn: stripe.charges.list.bind(stripe.charges),
+        baseParams: {
+            expand: ['data.customer', 'data.balance_transaction']
+        }
+    });
+}
+
+function buildRefundFetcher(stripe) {
+    return createListFetcher({
+        listFn: stripe.refunds.list.bind(stripe.refunds),
+        baseParams: {
+            expand: ['data.balance_transaction']
+        }
+    });
+}
+
+function buildDisputeFetcher(stripe) {
+    return createListFetcher({
+        listFn: stripe.disputes.list.bind(stripe.disputes),
+        baseParams: {
+            expand: ['data.balance_transactions']
+        }
+    });
+}
+
+function buildPayoutFetcher(stripe) {
+    return createListFetcher({
+        listFn: stripe.payouts.list.bind(stripe.payouts),
+        baseParams: {
+            expand: ['data.destination'],
+            createdField: 'arrival_date'
+        }
+    });
+}
+
+async function fetchStripeChargesSince(stripe, since, options) {
+    if (!stripe || !stripe.charges || typeof stripe.charges.list !== 'function') {
+        throw new Error('Stripe client with charges.list is required');
+    }
+    const fetcher = buildChargeFetcher(stripe);
+    return fetcher(since, options);
+}
+
+async function fetchStripeRefundsSince(stripe, since, options) {
+    if (!stripe || !stripe.refunds || typeof stripe.refunds.list !== 'function') {
+        throw new Error('Stripe client with refunds.list is required');
+    }
+    const fetcher = buildRefundFetcher(stripe);
+    return fetcher(since, options);
+}
+
+async function fetchStripeDisputesSince(stripe, since, options) {
+    if (!stripe || !stripe.disputes || typeof stripe.disputes.list !== 'function') {
+        throw new Error('Stripe client with disputes.list is required');
+    }
+    const fetcher = buildDisputeFetcher(stripe);
+    return fetcher(since, options);
+}
+
+async function fetchStripePayoutsSince(stripe, since, options) {
+    if (!stripe || !stripe.payouts || typeof stripe.payouts.list !== 'function') {
+        throw new Error('Stripe client with payouts.list is required');
+    }
+    const fetcher = buildPayoutFetcher(stripe);
+    return fetcher(since, options);
+}
+
+module.exports = {
+    fetchStripeChargesSince,
+    fetchStripeRefundsSince,
+    fetchStripeDisputesSince,
+    fetchStripePayoutsSince,
+    normalizeSince
+};

--- a/services/accounting/stripe-qbo/idempotencyStore.js
+++ b/services/accounting/stripe-qbo/idempotencyStore.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const fs = require('fs/promises');
+const path = require('path');
+
+class ProcessedStripeStore {
+    constructor(options = {}) {
+        this.storagePath = options.storagePath
+            || process.env.STRIPE_QBO_STATE_PATH
+            || path.join(process.cwd(), '.data', 'stripe-qbo-state.json');
+        this.logger = options.logger || console;
+        this.fs = options.fs || fs;
+        this.records = new Map();
+        this.loaded = false;
+        this.persistPromise = null;
+    }
+
+    async _ensureLoaded() {
+        if (this.loaded) {
+            return;
+        }
+
+        try {
+            const contents = await this.fs.readFile(this.storagePath, 'utf8');
+            const parsed = JSON.parse(contents);
+            Object.entries(parsed).forEach(([stripeId, record]) => {
+                if (record && stripeId) {
+                    this.records.set(stripeId, record);
+                }
+            });
+            this.loaded = true;
+        } catch (error) {
+            if (error.code === 'ENOENT') {
+                await this._persist();
+                this.loaded = true;
+                return;
+            }
+
+            this.logger.error('[Stripe→QBO] Failed to load idempotency store', {
+                storagePath: this.storagePath,
+                error: error.message
+            });
+            throw error;
+        }
+    }
+
+    async _persist() {
+        if (!this.persistPromise) {
+            this.persistPromise = (async () => {
+                const payload = Object.fromEntries(this.records.entries());
+                await this.fs.mkdir(path.dirname(this.storagePath), { recursive: true });
+                await this.fs.writeFile(this.storagePath, JSON.stringify(payload, null, 2), 'utf8');
+                return payload;
+            })()
+                .finally(() => {
+                    this.persistPromise = null;
+                });
+        }
+
+        return this.persistPromise;
+    }
+
+    async alreadyProcessed(stripeId) {
+        if (!stripeId) {
+            return false;
+        }
+
+        await this._ensureLoaded();
+        return this.records.has(stripeId);
+    }
+
+    async get(stripeId) {
+        if (!stripeId) {
+            return null;
+        }
+
+        await this._ensureLoaded();
+        return this.records.get(stripeId) || null;
+    }
+
+    async recordProcessed(record) {
+        if (!record || !record.stripeId) {
+            throw new Error('recordProcessed requires a stripeId');
+        }
+
+        await this._ensureLoaded();
+
+        const stored = {
+            stripeId: record.stripeId,
+            qboEntityId: record.qboEntityId || null,
+            qboDocNumber: record.qboDocNumber || null,
+            type: record.type || 'unknown',
+            processedAt: new Date().toISOString(),
+            memo: record.memo || null,
+            payoutId: record.payoutId || null,
+            metadata: record.metadata || {}
+        };
+
+        this.records.set(record.stripeId, stored);
+        await this._persist();
+        return stored;
+    }
+}
+
+module.exports = {
+    ProcessedStripeStore
+};

--- a/services/accounting/stripe-qbo/index.js
+++ b/services/accounting/stripe-qbo/index.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const { fetchStripeChargesSince, fetchStripeRefundsSince, fetchStripeDisputesSince, fetchStripePayoutsSince } = require('./fetchStripe');
+const { resolveQboCustomer, UNKNOWN_DONOR_NAME } = require('./customerResolver');
+const { ensureStripeVendor } = require('./vendor');
+const { mapBalanceTxnToEntries, buildChargeJE, computeClearingImpact, computeAmounts, buildMemo, formatDate } = require('./transactions');
+const { attachStripeArtifacts } = require('./attachments');
+const { ProcessedStripeStore } = require('./idempotencyStore');
+const { postTransferIfNew, reconcilePayout, convertPayoutAmount } = require('./payouts');
+
+const defaultStore = new ProcessedStripeStore();
+
+async function postJEIfNew(journalEntry, quickbooksProvider, options = {}) {
+    if (!journalEntry || !journalEntry.docNumber) {
+        throw new Error('Journal entry with docNumber is required');
+    }
+    if (!quickbooksProvider || typeof quickbooksProvider.upsertJournalEntry !== 'function') {
+        throw new Error('QuickBooks provider with upsertJournalEntry is required');
+    }
+
+    const store = options.store || defaultStore;
+    const logger = options.logger || console;
+    const stripeId = options.stripeId || (journalEntry.docNumber.startsWith('STRIPE-')
+        ? journalEntry.docNumber.substring(7)
+        : journalEntry.docNumber);
+
+    if (store && stripeId && typeof store.alreadyProcessed === 'function') {
+        const processed = await store.alreadyProcessed(stripeId);
+        if (processed) {
+            logger.log('[Stripe→QBO] Skipping journal entry because it was already processed', {
+                stripeId,
+                docNumber: journalEntry.docNumber
+            });
+            return { status: 'skipped', reason: 'duplicate', docNumber: journalEntry.docNumber };
+        }
+    }
+
+    const result = await quickbooksProvider.upsertJournalEntry(journalEntry);
+
+    if (store && stripeId && typeof store.recordProcessed === 'function') {
+        await store.recordProcessed({
+            stripeId,
+            qboEntityId: result.id,
+            qboDocNumber: journalEntry.docNumber,
+            type: 'journal_entry',
+            payoutId: options.payoutId || null,
+            memo: journalEntry.memo || null,
+            metadata: options.metadata || {}
+        });
+    }
+
+    if (options.attachments && options.attachments.length > 0) {
+        await attachStripeArtifacts(quickbooksProvider, result.id, options.attachments, { logger });
+    }
+
+    return {
+        status: result.created ? 'created' : 'exists',
+        docNumber: journalEntry.docNumber,
+        qboEntityId: result.id
+    };
+}
+
+async function recordProcessed(mapping, store = defaultStore) {
+    if (!store || typeof store.recordProcessed !== 'function') {
+        throw new Error('A store with recordProcessed is required');
+    }
+    return store.recordProcessed(mapping);
+}
+
+async function alreadyProcessed(stripeId, store = defaultStore) {
+    if (!store || typeof store.alreadyProcessed !== 'function') {
+        throw new Error('A store with alreadyProcessed is required');
+    }
+    return store.alreadyProcessed(stripeId);
+}
+
+module.exports = {
+    fetchStripeChargesSince,
+    fetchStripeRefundsSince,
+    fetchStripeDisputesSince,
+    fetchStripePayoutsSince,
+    resolveQboCustomer,
+    ensureStripeVendor,
+    mapBalanceTxnToEntries,
+    buildChargeJE,
+    postJEIfNew,
+    postTransferIfNew,
+    reconcilePayout,
+    attachStripeArtifacts,
+    recordProcessed,
+    alreadyProcessed,
+    computeClearingImpact,
+    computeAmounts,
+    buildMemo,
+    convertPayoutAmount,
+    ProcessedStripeStore,
+    formatDate,
+    UNKNOWN_DONOR_NAME
+};

--- a/services/accounting/stripe-qbo/payouts.js
+++ b/services/accounting/stripe-qbo/payouts.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const { computeAmounts, formatDate } = require('./transactions');
+
+const CENT_TOLERANCE = 1;
+
+function normalizeHomeCurrency(options) {
+    return options.companyHomeCurrency || process.env.COMPANY_HOME_CURRENCY || null;
+}
+
+function convertPayoutAmount(payout, homeCurrency) {
+    if (!payout || typeof payout.amount !== 'number') {
+        throw new Error('Payout amount is required');
+    }
+
+    const pseudoBalanceTxn = {
+        amount: payout.amount,
+        currency: payout.currency,
+        fee: 0,
+        net: payout.amount,
+        exchange_rate: payout.exchange_rate
+    };
+
+    const { gross } = computeAmounts(pseudoBalanceTxn, homeCurrency);
+    return Math.abs(gross);
+}
+
+async function postTransferIfNew(payout, quickbooksProvider, options = {}) {
+    if (!payout || !payout.id) {
+        throw new Error('Payout with id is required to create transfer');
+    }
+    if (!quickbooksProvider || typeof quickbooksProvider.upsertTransfer !== 'function') {
+        throw new Error('QuickBooks provider with upsertTransfer is required');
+    }
+
+    const accounts = options.accounts || {};
+    if (!accounts.stripeClearingId) {
+        throw new Error('Stripe clearing account ID is required');
+    }
+    if (!accounts.operatingBankId) {
+        throw new Error('Operating bank account ID is required');
+    }
+
+    const store = options.store;
+    if (store && typeof store.alreadyProcessed === 'function') {
+        const processed = await store.alreadyProcessed(payout.id);
+        if (processed) {
+            return { status: 'skipped', reason: 'duplicate', payoutId: payout.id };
+        }
+    }
+
+    const homeCurrency = normalizeHomeCurrency(options);
+    const amount = convertPayoutAmount(payout, homeCurrency);
+    if (amount <= 0) {
+        throw new Error('Payout amount must be positive');
+    }
+
+    const timestampMs = (payout.arrival_date || payout.created || Math.floor(Date.now() / 1000)) * 1000;
+    const docNumber = `STRIPE-PO-${payout.id}`;
+    const memo = `stripe:payout=${payout.id}`;
+    const note = `Stripe payout ${payout.id} → Operating Bank`;
+
+    const transfer = {
+        docNumber,
+        fromAccountId: accounts.stripeClearingId,
+        toAccountId: accounts.operatingBankId,
+        amount,
+        date: formatDate(timestampMs, options.timezone),
+        memo: `${note} | ${memo}`
+    };
+
+    const result = await quickbooksProvider.upsertTransfer(transfer);
+
+    if (store && typeof store.recordProcessed === 'function') {
+        await store.recordProcessed({
+            stripeId: payout.id,
+            qboEntityId: result.id,
+            qboDocNumber: docNumber,
+            type: 'payout',
+            payoutId: payout.id,
+            memo
+        });
+    }
+
+    return {
+        status: result.created ? 'created' : 'exists',
+        payoutId: payout.id,
+        qboEntityId: result.id,
+        docNumber
+    };
+}
+
+function reconcilePayout(payout, mappedTransactions = [], options = {}) {
+    if (!payout || !payout.id) {
+        throw new Error('Payout with id is required for reconciliation');
+    }
+    if (!Array.isArray(mappedTransactions)) {
+        throw new Error('mappedTransactions must be an array');
+    }
+
+    const homeCurrency = normalizeHomeCurrency(options);
+    const payoutAmount = convertPayoutAmount(payout, homeCurrency);
+    const clearingImpact = mappedTransactions.reduce((sum, txn) => sum + (txn?.clearingImpact || 0), 0);
+    const difference = Math.abs(clearingImpact - payoutAmount);
+
+    if (difference > CENT_TOLERANCE) {
+        const error = new Error(`Clearing impact ${clearingImpact} does not reconcile to payout amount ${payoutAmount}`);
+        error.details = {
+            payoutId: payout.id,
+            clearingImpact,
+            payoutAmount,
+            difference
+        };
+        throw error;
+    }
+
+    return {
+        payoutId: payout.id,
+        payoutAmount,
+        clearingImpact,
+        difference
+    };
+}
+
+module.exports = {
+    postTransferIfNew,
+    reconcilePayout,
+    convertPayoutAmount
+};

--- a/services/accounting/stripe-qbo/transactions.js
+++ b/services/accounting/stripe-qbo/transactions.js
@@ -1,0 +1,682 @@
+'use strict';
+
+const { UNKNOWN_DONOR_NAME } = require('./customerResolver');
+
+const CENT_TOLERANCE = 1; // one cent
+
+function formatDate(timestamp, timezone) {
+    const date = new Date(timestamp);
+
+    if (!timezone || timezone === 'UTC') {
+        return date.toISOString().slice(0, 10);
+    }
+
+    const formatter = new Intl.DateTimeFormat('en-CA', {
+        timeZone: timezone,
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+    });
+
+    const parts = formatter.format(date).split('-');
+    if (parts.length === 3) {
+        return `${parts[0]}-${parts[1]}-${parts[2]}`;
+    }
+
+    // Fallback to UTC formatting if unexpected locale result
+    return date.toISOString().slice(0, 10);
+}
+
+function ensureAccounts(accounts = {}) {
+    const required = ['revenueId', 'stripeFeesId', 'refundsContraId', 'stripeClearingId'];
+    required.forEach(key => {
+        if (!accounts[key]) {
+            throw new Error(`Missing required account configuration: ${key}`);
+        }
+    });
+    return accounts;
+}
+
+function toCurrencyCode(value, fallback) {
+    if (!value) {
+        return fallback || null;
+    }
+    return value.toString().trim().toUpperCase();
+}
+
+function convertToHomeCurrency(amount, currency, homeCurrency, exchangeRate = 1) {
+    if (typeof amount !== 'number' || Number.isNaN(amount)) {
+        return 0;
+    }
+
+    if (!currency) {
+        return Math.round(amount);
+    }
+
+    const normalizedCurrency = currency.toUpperCase();
+    const normalizedHome = toCurrencyCode(homeCurrency, normalizedCurrency);
+
+    if (!normalizedHome || normalizedCurrency === normalizedHome) {
+        return Math.round(amount);
+    }
+
+    if (!exchangeRate || Number.isNaN(exchangeRate)) {
+        throw new Error(`Exchange rate required to convert ${normalizedCurrency} to ${normalizedHome}`);
+    }
+
+    const converted = amount * exchangeRate;
+    return Math.round(converted);
+}
+
+function computeAmounts(balanceTransaction, companyHomeCurrency) {
+    const currency = toCurrencyCode(balanceTransaction.currency, companyHomeCurrency);
+    const exchangeRate = balanceTransaction.exchange_rate || 1;
+
+    const rawAmount = typeof balanceTransaction.amount === 'number'
+        ? balanceTransaction.amount
+        : 0;
+    const rawFee = typeof balanceTransaction.fee === 'number'
+        ? balanceTransaction.fee
+        : (Array.isArray(balanceTransaction.fee_details)
+            ? balanceTransaction.fee_details.reduce((sum, fee) => sum + (fee.amount || 0), 0)
+            : 0);
+    const rawNet = typeof balanceTransaction.net === 'number'
+        ? balanceTransaction.net
+        : rawAmount - rawFee;
+
+    const gross = convertToHomeCurrency(rawAmount, currency, companyHomeCurrency, exchangeRate);
+    const fee = convertToHomeCurrency(rawFee, currency, companyHomeCurrency, exchangeRate);
+    const net = convertToHomeCurrency(rawNet, currency, companyHomeCurrency, exchangeRate);
+
+    return {
+        gross,
+        fee,
+        net,
+        rawAmount,
+        rawFee,
+        rawNet,
+        currency,
+        homeCurrency: toCurrencyCode(companyHomeCurrency, currency),
+        exchangeRate: currency === toCurrencyCode(companyHomeCurrency, currency) ? 1 : exchangeRate
+    };
+}
+
+function validateAmounts(amounts, logger, context) {
+    const { gross, fee, net } = amounts;
+    const difference = Math.round((gross - fee) - net);
+    if (Math.abs(difference) > CENT_TOLERANCE) {
+        const message = '[Stripe→QBO] Balance transaction amounts do not reconcile to net';
+        logger.warn(message, {
+            balanceTransactionId: context?.balanceTransactionId,
+            gross,
+            fee,
+            net,
+            difference
+        });
+    }
+}
+
+function createLine({ type, accountId, amount, description, entityRef, memo }) {
+    if (!accountId) {
+        throw new Error('AccountId is required for journal entry line');
+    }
+
+    const cents = Math.round(Math.abs(amount));
+    if (cents === 0) {
+        return null;
+    }
+
+    const line = {
+        type,
+        accountId,
+        amount: cents,
+        description,
+        memo: memo || description || ''
+    };
+
+    if (entityRef && entityRef.value) {
+        line.entityRef = { ...entityRef };
+    }
+
+    return line;
+}
+
+function computeClearingImpact(lines, clearingAccountId) {
+    return lines
+        .filter(line => line && line.accountId === clearingAccountId)
+        .reduce((sum, line) => sum + (line.type === 'debit' ? line.amount : -line.amount), 0);
+}
+
+function buildMemo({ charge, paymentIntentId, balanceTransactionId, payoutId, customerId, exchangeRate }) {
+    const memoParts = [
+        `stripe:ch=${charge || '-'}`,
+        `pi=${paymentIntentId || '-'}`,
+        `bt=${balanceTransactionId || '-'}`,
+        `payout=${payoutId || '-'}`,
+        `customer=${customerId || 'guest'}`
+    ];
+
+    if (exchangeRate && Math.abs(exchangeRate - 1) > 0.00001) {
+        memoParts.push(`fx=${exchangeRate}`);
+    }
+
+    return memoParts.join(';');
+}
+
+function resolveAdjustmentAccount(balanceTransaction, accounts = {}) {
+    const adjustments = accounts.adjustments || {};
+    const candidates = [
+        balanceTransaction.reporting_category,
+        balanceTransaction.type,
+        balanceTransaction.source_type,
+        'default'
+    ];
+
+    for (const key of candidates) {
+        if (!key) {
+            continue;
+        }
+        const normalized = key.toString();
+        if (adjustments[normalized]) {
+            return adjustments[normalized];
+        }
+    }
+
+    throw new Error(`No adjustment account configured for balance transaction type ${balanceTransaction.type}`);
+}
+
+function describeChargeLine({ chargeId, paymentIntentId, customerName, metadata }) {
+    const campaign = metadata?.campaign || '-';
+    const source = metadata?.source_form || '-';
+    const donorName = customerName || UNKNOWN_DONOR_NAME;
+    return `Donation from ${donorName} — Stripe charge ${chargeId} (PI ${paymentIntentId || '-'}) | Campaign: ${campaign} | Source: ${source}`;
+}
+
+function describeFeeLine({ chargeId, balanceTransactionId }) {
+    return `Stripe processing fee — charge ${chargeId}, balance txn ${balanceTransactionId}`;
+}
+
+function describeClearingLine({ chargeId, paymentIntentId }) {
+    return `Net to Stripe Clearing — charge ${chargeId} (PI ${paymentIntentId || '-'})`;
+}
+
+function describeRefundLine({ chargeId, refundId, balanceTransactionId }) {
+    return `Refund issued — charge ${chargeId} (refund ${refundId || '-'}, balance txn ${balanceTransactionId})`;
+}
+
+function describeDisputeLine({ disputeId, chargeId, balanceTransactionId }) {
+    return `Dispute loss — charge ${chargeId} (dispute ${disputeId || '-'}, balance txn ${balanceTransactionId})`;
+}
+
+function describeFeeRefundLine({ chargeId, referenceId, balanceTransactionId }) {
+    return `Stripe fee refund — charge ${chargeId || '-'} (ref ${referenceId || '-'}, balance txn ${balanceTransactionId})`;
+}
+
+function describeAdjustmentLine(balanceTransaction) {
+    const descriptor = balanceTransaction.description || balanceTransaction.reporting_category || balanceTransaction.type;
+    return `Stripe ${descriptor} adjustment — balance txn ${balanceTransaction.id}`;
+}
+
+function mapCharge(balanceTransaction, context) {
+    const { charge } = context;
+    if (!charge) {
+        throw new Error('Charge context is required to map charge balance transactions');
+    }
+
+    const accounts = ensureAccounts(context.accounts);
+    const vendor = context.vendor;
+    const customer = context.customer;
+    if (!vendor || !vendor.id) {
+        throw new Error('Stripe vendor reference is required for fee postings');
+    }
+    if (!customer || !customer.id) {
+        throw new Error('Customer reference is required for revenue postings');
+    }
+
+    const logger = context.logger || console;
+    const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
+    validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
+
+    const paymentIntentId = charge.payment_intent || charge.payment_intent_id || null;
+    const memo = buildMemo({
+        charge: charge.id,
+        paymentIntentId,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout,
+        customerId: customer.id,
+        exchangeRate: amounts.exchangeRate
+    });
+
+    const revenueLine = createLine({
+        type: 'credit',
+        accountId: accounts.revenueId,
+        amount: amounts.gross,
+        description: describeChargeLine({
+            chargeId: charge.id,
+            paymentIntentId,
+            customerName: customer.displayName,
+            metadata: charge.metadata || {}
+        }),
+        entityRef: {
+            type: 'Customer',
+            value: customer.id,
+            name: customer.displayName
+        },
+        memo
+    });
+
+    const feeLine = createLine({
+        type: 'debit',
+        accountId: accounts.stripeFeesId,
+        amount: amounts.fee,
+        description: describeFeeLine({
+            chargeId: charge.id,
+            balanceTransactionId: balanceTransaction.id
+        }),
+        entityRef: {
+            type: 'Vendor',
+            value: vendor.id,
+            name: vendor.name || 'Stripe'
+        },
+        memo
+    });
+
+    const clearingLine = createLine({
+        type: amounts.net >= 0 ? 'debit' : 'credit',
+        accountId: accounts.stripeClearingId,
+        amount: amounts.net,
+        description: describeClearingLine({
+            chargeId: charge.id,
+            paymentIntentId
+        }),
+        memo
+    });
+
+    const lines = [revenueLine, feeLine, clearingLine].filter(Boolean);
+
+    return {
+        type: 'charge',
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout || null,
+        lines,
+        memo,
+        amounts,
+        clearingImpact: computeClearingImpact(lines, accounts.stripeClearingId),
+        attachments: [charge.receipt_url].filter(Boolean)
+    };
+}
+
+function createFeeLine(amounts, accounts, vendor, context, descriptionBuilder) {
+    if (!amounts.fee) {
+        return null;
+    }
+
+    const type = amounts.fee >= 0 ? 'debit' : 'credit';
+    const description = descriptionBuilder();
+    return createLine({
+        type,
+        accountId: accounts.stripeFeesId,
+        amount: amounts.fee,
+        description,
+        entityRef: vendor
+            ? { type: 'Vendor', value: vendor.id, name: vendor.name || 'Stripe' }
+            : null,
+        memo: context.memo
+    });
+}
+
+function mapRefund(balanceTransaction, context) {
+    const accounts = ensureAccounts(context.accounts);
+    const logger = context.logger || console;
+    const vendor = context.vendor;
+    const refund = context.refund || {};
+    const charge = context.charge || {};
+    const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
+    validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
+
+    const chargeId = charge.id || refund.charge || balanceTransaction.source || '-';
+    const memo = buildMemo({
+        charge: chargeId,
+        paymentIntentId: refund.payment_intent || charge.payment_intent || null,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout,
+        customerId: context.customer?.id,
+        exchangeRate: amounts.exchangeRate
+    });
+
+    const refundLine = createLine({
+        type: 'debit',
+        accountId: accounts.refundsContraId,
+        amount: amounts.gross,
+        description: describeRefundLine({
+            chargeId,
+            refundId: refund.id || balanceTransaction.source,
+            balanceTransactionId: balanceTransaction.id
+        }),
+        memo
+    });
+
+    const feeLine = createFeeLine(amounts, accounts, vendor && vendor.id ? {
+        type: 'Vendor',
+        value: vendor.id,
+        name: vendor.name || 'Stripe'
+    } : null, { memo }, () => describeFeeLine({
+        chargeId,
+        balanceTransactionId: balanceTransaction.id
+    }));
+
+    const clearingLine = createLine({
+        type: amounts.net >= 0 ? 'debit' : 'credit',
+        accountId: accounts.stripeClearingId,
+        amount: amounts.net,
+        description: `Clearing impact — refund ${refund.id || balanceTransaction.source || '-'}`,
+        memo
+    });
+
+    const lines = [refundLine, feeLine, clearingLine].filter(Boolean);
+
+    return {
+        type: 'refund',
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout || null,
+        lines,
+        memo,
+        amounts,
+        clearingImpact: computeClearingImpact(lines, accounts.stripeClearingId)
+    };
+}
+
+function mapDispute(balanceTransaction, context) {
+    const accounts = ensureAccounts(context.accounts);
+    const logger = context.logger || console;
+    const vendor = context.vendor;
+    const dispute = context.dispute || {};
+    const charge = context.charge || {};
+
+    const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
+    validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
+
+    const chargeId = charge.id || dispute.charge || dispute.charge_id || '-';
+    const memo = buildMemo({
+        charge: chargeId,
+        paymentIntentId: dispute.payment_intent || charge.payment_intent || null,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout,
+        customerId: context.customer?.id,
+        exchangeRate: amounts.exchangeRate
+    });
+
+    const disputeLine = createLine({
+        type: 'debit',
+        accountId: accounts.refundsContraId,
+        amount: amounts.gross,
+        description: describeDisputeLine({
+            disputeId: dispute.id || balanceTransaction.source,
+            chargeId,
+            balanceTransactionId: balanceTransaction.id
+        }),
+        memo
+    });
+
+    const feeLine = createFeeLine(amounts, accounts, vendor && vendor.id ? {
+        type: 'Vendor',
+        value: vendor.id,
+        name: vendor.name || 'Stripe'
+    } : null, { memo }, () => `Stripe dispute fee — balance txn ${balanceTransaction.id}`);
+
+    const clearingLine = createLine({
+        type: amounts.net >= 0 ? 'debit' : 'credit',
+        accountId: accounts.stripeClearingId,
+        amount: amounts.net,
+        description: `Clearing impact — dispute ${dispute.id || balanceTransaction.source || '-'}`,
+        memo
+    });
+
+    const lines = [disputeLine, feeLine, clearingLine].filter(Boolean);
+
+    return {
+        type: 'dispute',
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout || null,
+        lines,
+        memo,
+        amounts,
+        clearingImpact: computeClearingImpact(lines, accounts.stripeClearingId)
+    };
+}
+
+function mapFee(balanceTransaction, context) {
+    const accounts = ensureAccounts(context.accounts);
+    const vendor = context.vendor;
+    const logger = context.logger || console;
+    const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
+    validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
+
+    const memo = buildMemo({
+        charge: balanceTransaction.source || '-',
+        paymentIntentId: null,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout,
+        customerId: context.customer?.id,
+        exchangeRate: amounts.exchangeRate
+    });
+
+    const feeAmount = amounts.gross;
+    const feeLine = createLine({
+        type: feeAmount >= 0 ? 'credit' : 'debit',
+        accountId: accounts.stripeFeesId,
+        amount: feeAmount,
+        description: describeFeeLine({
+            chargeId: balanceTransaction.source || '-',
+            balanceTransactionId: balanceTransaction.id
+        }),
+        entityRef: vendor && vendor.id ? {
+            type: 'Vendor',
+            value: vendor.id,
+            name: vendor.name || 'Stripe'
+        } : null,
+        memo
+    });
+
+    const clearingLine = createLine({
+        type: amounts.net >= 0 ? 'debit' : 'credit',
+        accountId: accounts.stripeClearingId,
+        amount: amounts.net,
+        description: `Clearing impact — fee ${balanceTransaction.id}`,
+        memo
+    });
+
+    const lines = [feeLine, clearingLine].filter(Boolean);
+
+    return {
+        type: balanceTransaction.type,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout || null,
+        lines,
+        memo,
+        amounts,
+        clearingImpact: computeClearingImpact(lines, accounts.stripeClearingId)
+    };
+}
+
+function mapFeeRefund(balanceTransaction, context) {
+    const accounts = ensureAccounts(context.accounts);
+    const vendor = context.vendor;
+    const logger = context.logger || console;
+    const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
+    validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
+
+    const memo = buildMemo({
+        charge: balanceTransaction.source || '-',
+        paymentIntentId: null,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout,
+        customerId: context.customer?.id,
+        exchangeRate: amounts.exchangeRate
+    });
+
+    const feeRefundLine = createLine({
+        type: amounts.gross >= 0 ? 'credit' : 'debit',
+        accountId: accounts.stripeFeesId,
+        amount: amounts.gross,
+        description: describeFeeRefundLine({
+            chargeId: balanceTransaction.source || '-',
+            referenceId: balanceTransaction.source_refund || balanceTransaction.source,
+            balanceTransactionId: balanceTransaction.id
+        }),
+        entityRef: vendor && vendor.id ? {
+            type: 'Vendor',
+            value: vendor.id,
+            name: vendor.name || 'Stripe'
+        } : null,
+        memo
+    });
+
+    const clearingLine = createLine({
+        type: amounts.net >= 0 ? 'debit' : 'credit',
+        accountId: accounts.stripeClearingId,
+        amount: amounts.net,
+        description: `Clearing impact — fee refund ${balanceTransaction.id}`,
+        memo
+    });
+
+    const lines = [feeRefundLine, clearingLine].filter(Boolean);
+
+    return {
+        type: balanceTransaction.type,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout || null,
+        lines,
+        memo,
+        amounts,
+        clearingImpact: computeClearingImpact(lines, accounts.stripeClearingId)
+    };
+}
+
+function mapAdjustment(balanceTransaction, context) {
+    const accounts = ensureAccounts(context.accounts);
+    const logger = context.logger || console;
+    const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
+    validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
+
+    const adjustmentAccountId = resolveAdjustmentAccount(balanceTransaction, context.accounts);
+
+    const memo = buildMemo({
+        charge: balanceTransaction.source || '-',
+        paymentIntentId: null,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout,
+        customerId: context.customer?.id,
+        exchangeRate: amounts.exchangeRate
+    });
+
+    const principalLine = createLine({
+        type: amounts.gross >= 0 ? 'credit' : 'debit',
+        accountId: adjustmentAccountId,
+        amount: amounts.gross,
+        description: describeAdjustmentLine(balanceTransaction),
+        memo
+    });
+
+    const feeLine = createFeeLine(amounts, accounts, context.vendor && context.vendor.id ? {
+        type: 'Vendor',
+        value: context.vendor.id,
+        name: context.vendor.name || 'Stripe'
+    } : null, { memo }, () => describeFeeLine({
+        chargeId: balanceTransaction.source || '-',
+        balanceTransactionId: balanceTransaction.id
+    }));
+
+    const clearingLine = createLine({
+        type: amounts.net >= 0 ? 'debit' : 'credit',
+        accountId: accounts.stripeClearingId,
+        amount: amounts.net,
+        description: `Clearing impact — adjustment ${balanceTransaction.id}`,
+        memo
+    });
+
+    const lines = [principalLine, feeLine, clearingLine].filter(Boolean);
+
+    return {
+        type: balanceTransaction.type,
+        balanceTransactionId: balanceTransaction.id,
+        payoutId: balanceTransaction.payout || null,
+        lines,
+        memo,
+        amounts,
+        clearingImpact: computeClearingImpact(lines, accounts.stripeClearingId)
+    };
+}
+
+const TYPE_HANDLERS = {
+    charge: mapCharge,
+    refund: mapRefund,
+    dispute: mapDispute,
+    fee: mapFee,
+    fee_tax: mapFee,
+    fee_refund: mapFeeRefund,
+    adjustment: mapAdjustment,
+    application_fee: mapAdjustment,
+    platform_fees: mapAdjustment,
+    tax: mapAdjustment
+};
+
+function mapBalanceTxnToEntries(balanceTransaction, context = {}) {
+    if (!balanceTransaction) {
+        throw new Error('Balance transaction is required');
+    }
+
+    if (!balanceTransaction.type) {
+        throw new Error('Balance transaction type is required');
+    }
+
+    const handler = TYPE_HANDLERS[balanceTransaction.type];
+    if (!handler) {
+        throw new Error(`Unsupported balance transaction type: ${balanceTransaction.type}`);
+    }
+
+    return handler(balanceTransaction, context);
+}
+
+function buildChargeJE(charge, accounts, vendor, customer, options = {}) {
+    const balanceTransaction = charge?.balance_transaction;
+    if (!balanceTransaction) {
+        throw new Error('Charge must include expanded balance_transaction');
+    }
+
+    const context = {
+        accounts,
+        vendor,
+        customer,
+        charge,
+        companyHomeCurrency: options.companyHomeCurrency || process.env.COMPANY_HOME_CURRENCY,
+        logger: options.logger || console
+    };
+
+    const mapped = mapCharge(balanceTransaction, context);
+    const timestampMs = (charge.created || Math.floor(Date.now() / 1000)) * 1000;
+    const dateStr = formatDate(timestampMs, options.timezone);
+
+    const journalEntry = {
+        docNumber: `STRIPE-${charge.id}`,
+        date: dateStr,
+        memo: mapped.memo,
+        lines: mapped.lines
+    };
+
+    return {
+        journalEntry,
+        attachments: mapped.attachments,
+        clearingImpact: mapped.clearingImpact,
+        amounts: mapped.amounts
+    };
+}
+
+module.exports = {
+    mapBalanceTxnToEntries,
+    buildChargeJE,
+    computeClearingImpact,
+    computeAmounts,
+    buildMemo,
+    formatDate
+};

--- a/services/accounting/stripe-qbo/vendor.js
+++ b/services/accounting/stripe-qbo/vendor.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const DEFAULT_STRIPE_VENDOR = {
+    displayName: 'Stripe',
+    email: 'support@stripe.com',
+    externalId: 'stripe-platform'
+};
+
+async function ensureStripeVendor(quickbooksProvider, options = {}) {
+    if (!quickbooksProvider || typeof quickbooksProvider.ensureVendor !== 'function') {
+        throw new Error('A QuickBooks provider with ensureVendor is required to resolve the Stripe vendor');
+    }
+
+    const logger = options.logger || console;
+    const configuredVendorId = options.vendorId || process.env.VENDOR_STRIPE_ID;
+
+    if (configuredVendorId) {
+        return {
+            id: configuredVendorId,
+            name: options.vendorName || 'Stripe',
+            type: 'Vendor'
+        };
+    }
+
+    const vendorPayload = {
+        ...DEFAULT_STRIPE_VENDOR,
+        ...options.vendor
+    };
+
+    const vendor = await quickbooksProvider.ensureVendor(vendorPayload);
+
+    if (!vendor || !vendor.id) {
+        const error = new Error('Unable to ensure Stripe vendor in QuickBooks');
+        logger.error('[Stripe→QBO] Vendor resolution failed', error.message);
+        throw error;
+    }
+
+    return {
+        id: vendor.id,
+        name: vendor.displayName || vendor.DisplayName || vendorPayload.displayName,
+        type: 'Vendor'
+    };
+}
+
+module.exports = {
+    ensureStripeVendor
+};

--- a/tests/stripeQboSync.test.js
+++ b/tests/stripeQboSync.test.js
@@ -1,0 +1,433 @@
+const assert = require('assert');
+const os = require('os');
+const path = require('path');
+const fs = require('fs/promises');
+
+const {
+    resolveQboCustomer,
+    buildChargeJE,
+    mapBalanceTxnToEntries,
+    postJEIfNew,
+    postTransferIfNew,
+    reconcilePayout,
+    attachStripeArtifacts,
+    ProcessedStripeStore,
+    ensureStripeVendor,
+    convertPayoutAmount
+} = require('../services/accounting/stripe-qbo');
+
+const accounts = {
+    revenueId: 'acct-revenue',
+    stripeFeesId: 'acct-fees',
+    refundsContraId: 'acct-refunds',
+    stripeClearingId: 'acct-clearing',
+    operatingBankId: 'acct-operating',
+    adjustments: {
+        default: 'acct-adjustments',
+        tax: 'acct-tax'
+    }
+};
+
+class MockQuickBooksProvider {
+    constructor() {
+        this.customersByEmail = new Map();
+        this.upsertedJournalEntries = [];
+        this.attachments = [];
+        this.transfers = [];
+    }
+
+    async ensureCustomer(payload) {
+        if (payload.email && this.customersByEmail.has(payload.email)) {
+            return this.customersByEmail.get(payload.email);
+        }
+        const record = {
+            id: payload.email ? `cust-${payload.email}` : 'cust-unknown',
+            displayName: payload.displayName
+        };
+        if (payload.email) {
+            this.customersByEmail.set(payload.email, record);
+        }
+        return record;
+    }
+
+    async ensureVendor(payload) {
+        return {
+            id: payload.externalId || 'vendor-stripe',
+            displayName: payload.displayName
+        };
+    }
+
+    async upsertJournalEntry(journalEntry) {
+        const existing = this.upsertedJournalEntries.find(entry => entry.docNumber === journalEntry.docNumber);
+        if (existing) {
+            return { id: existing.id, docNumber: existing.docNumber, created: false };
+        }
+        const record = {
+            ...journalEntry,
+            id: `je-${this.upsertedJournalEntries.length + 1}`
+        };
+        this.upsertedJournalEntries.push(record);
+        return { id: record.id, docNumber: record.docNumber, created: true };
+    }
+
+    async upsertTransfer(transfer) {
+        const existing = this.transfers.find(t => t.docNumber === transfer.docNumber);
+        if (existing) {
+            return { id: existing.id, created: false };
+        }
+        const created = {
+            ...transfer,
+            id: `transfer-${this.transfers.length + 1}`
+        };
+        this.transfers.push(created);
+        return { id: created.id, created: true };
+    }
+
+    async attachDocument(transactionId, attachment) {
+        this.attachments.push({ transactionId, attachment });
+        return { id: `att-${this.attachments.length}`, fileName: attachment.fileName };
+    }
+}
+
+async function runTest(name, fn) {
+    try {
+        await fn();
+        console.log(`✅ ${name}`);
+    } catch (error) {
+        console.error(`❌ ${name}`);
+        throw error;
+    }
+}
+
+async function testResolveQboCustomer() {
+    const provider = new MockQuickBooksProvider();
+
+    const charge = {
+        id: 'ch_123',
+        billing_details: {
+            name: 'Ada Lovelace',
+            email: 'ada@example.com'
+        },
+        customer: {
+            id: 'cus_123',
+            name: 'Augusta Ada',
+            email: 'ada@example.com'
+        }
+    };
+
+    const resolved = await resolveQboCustomer(charge, provider);
+    assert.strictEqual(resolved.id, 'cust-ada@example.com');
+    assert.strictEqual(resolved.isFallback, false);
+    assert.strictEqual(resolved.displayName, 'Ada Lovelace');
+
+    const fallbackCharge = { id: 'ch_456', billing_details: {} };
+    const fallback = await resolveQboCustomer(fallbackCharge, provider);
+    assert.strictEqual(fallback.isFallback, true);
+    assert.strictEqual(fallback.displayName, 'Unknown Donor (Stripe)');
+}
+
+async function testBuildChargeJournalEntry() {
+    const provider = new MockQuickBooksProvider();
+    const vendor = await ensureStripeVendor(provider, { vendorId: 'vendor-stripe', vendorName: 'Stripe' });
+    const charge = {
+        id: 'ch_789',
+        created: 1700000000,
+        payment_intent: 'pi_123',
+        metadata: {
+            campaign: 'Giving Tuesday',
+            source_form: 'Landing Page'
+        },
+        receipt_url: 'https://stripe.test/receipt/ch_789',
+        balance_transaction: {
+            id: 'bt_123',
+            type: 'charge',
+            amount: 25000,
+            fee: 725,
+            net: 24275,
+            currency: 'usd',
+            payout: 'po_123'
+        },
+        billing_details: {
+            name: 'Grace Hopper',
+            email: 'grace@example.com'
+        }
+    };
+
+    const customer = {
+        id: 'cust-1',
+        displayName: 'Grace Hopper'
+    };
+
+    const { journalEntry, attachments, amounts } = buildChargeJE(charge, accounts, vendor, customer, {
+        companyHomeCurrency: 'USD',
+        timezone: 'America/New_York'
+    });
+
+    assert.strictEqual(journalEntry.docNumber, 'STRIPE-ch_789');
+    assert.ok(journalEntry.memo.includes('stripe:ch=ch_789'));
+    assert.ok(journalEntry.memo.includes('bt=bt_123'));
+    assert.ok(journalEntry.memo.includes('pi=pi_123'));
+    assert.strictEqual(attachments.length, 1);
+    assert.ok(attachments[0].includes('https://stripe.test/receipt/ch_789'));
+
+    const totalDebits = journalEntry.lines.filter(l => l.type === 'debit').reduce((sum, line) => sum + line.amount, 0);
+    const totalCredits = journalEntry.lines.filter(l => l.type === 'credit').reduce((sum, line) => sum + line.amount, 0);
+    assert.strictEqual(totalDebits, totalCredits);
+    assert.strictEqual(amounts.gross, 25000);
+    assert.strictEqual(amounts.fee, 725);
+    assert.strictEqual(amounts.net, 24275);
+
+    const revenueLine = journalEntry.lines.find(line => line.accountId === accounts.revenueId);
+    assert.strictEqual(revenueLine.entityRef.type, 'Customer');
+    assert.strictEqual(revenueLine.entityRef.value, customer.id);
+
+    const feeLine = journalEntry.lines.find(line => line.accountId === accounts.stripeFeesId);
+    assert.strictEqual(feeLine.entityRef.type, 'Vendor');
+    assert.strictEqual(feeLine.entityRef.value, vendor.id);
+
+    const clearingLine = journalEntry.lines.find(line => line.accountId === accounts.stripeClearingId);
+    assert.strictEqual(typeof clearingLine.entityRef, 'undefined');
+}
+
+async function testBalanceTransactionMappings() {
+    const vendor = { id: 'vendor-stripe', name: 'Stripe', type: 'Vendor' };
+
+    const refundBT = {
+        id: 'bt_ref',
+        type: 'refund',
+        amount: -1500,
+        fee: 50,
+        net: -1550,
+        currency: 'usd',
+        payout: 'po_123'
+    };
+    const refundMapped = mapBalanceTxnToEntries(refundBT, {
+        accounts,
+        vendor,
+        refund: { id: 're_1', charge: 'ch_789' },
+        charge: { id: 'ch_789', payment_intent: 'pi_123' }
+    });
+    assert.strictEqual(refundMapped.lines.length, 3);
+    const refundClearing = refundMapped.lines.find(line => line.accountId === accounts.stripeClearingId);
+    assert.strictEqual(refundClearing.type, 'credit');
+
+    const disputeBT = {
+        id: 'bt_dp',
+        type: 'dispute',
+        amount: -2000,
+        fee: 150,
+        net: -2150,
+        currency: 'usd',
+        payout: 'po_123'
+    };
+    const disputeMapped = mapBalanceTxnToEntries(disputeBT, {
+        accounts,
+        vendor,
+        dispute: { id: 'dp_1', charge: 'ch_789' },
+        charge: { id: 'ch_789', payment_intent: 'pi_123' }
+    });
+    assert.strictEqual(disputeMapped.lines.length, 3);
+    const disputeFeeLine = disputeMapped.lines.find(line => line.accountId === accounts.stripeFeesId);
+    assert.strictEqual(disputeFeeLine.type, 'debit');
+
+    const feeBT = {
+        id: 'bt_fee',
+        type: 'fee',
+        amount: -300,
+        fee: 0,
+        net: -300,
+        currency: 'usd',
+        payout: 'po_123'
+    };
+    const feeMapped = mapBalanceTxnToEntries(feeBT, { accounts, vendor });
+    assert.strictEqual(feeMapped.lines.length, 2);
+    assert.strictEqual(feeMapped.lines[0].type, 'debit');
+
+    const feeRefundBT = {
+        id: 'bt_fee_ref',
+        type: 'fee_refund',
+        amount: 100,
+        fee: 0,
+        net: 100,
+        currency: 'usd',
+        payout: 'po_123'
+    };
+    const feeRefundMapped = mapBalanceTxnToEntries(feeRefundBT, { accounts, vendor });
+    assert.strictEqual(feeRefundMapped.lines[0].type, 'credit');
+    assert.strictEqual(feeRefundMapped.lines[1].type, 'debit');
+
+    const adjustmentBT = {
+        id: 'bt_adj',
+        type: 'adjustment',
+        amount: 500,
+        fee: 0,
+        net: 500,
+        currency: 'usd'
+    };
+    const adjustmentMapped = mapBalanceTxnToEntries(adjustmentBT, { accounts, vendor });
+    assert.strictEqual(adjustmentMapped.lines[0].accountId, accounts.adjustments.default);
+    assert.strictEqual(adjustmentMapped.lines[0].type, 'credit');
+}
+
+async function testPayoutReconciliationAndTransfer() {
+    const provider = new MockQuickBooksProvider();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stripe-qbo-store-'));
+    const store = new ProcessedStripeStore({ storagePath: path.join(tmpDir, 'state.json') });
+
+    const chargeBT = {
+        id: 'bt_charge',
+        type: 'charge',
+        amount: 30000,
+        fee: 900,
+        net: 29100,
+        currency: 'usd',
+        payout: 'po_partial'
+    };
+    const chargeMapped = mapBalanceTxnToEntries(chargeBT, {
+        accounts,
+        vendor: { id: 'vendor-stripe', name: 'Stripe' },
+        charge: {
+            id: 'ch_partial',
+            payment_intent: 'pi_partial',
+            metadata: {}
+        },
+        customer: { id: 'cust-partial', displayName: 'Partial Donor' }
+    });
+
+    const refundBT = {
+        id: 'bt_refund_partial',
+        type: 'refund',
+        amount: -5000,
+        fee: 0,
+        net: -5000,
+        currency: 'usd',
+        payout: 'po_partial'
+    };
+    const refundMapped = mapBalanceTxnToEntries(refundBT, {
+        accounts,
+        vendor: { id: 'vendor-stripe', name: 'Stripe' },
+        refund: { id: 're_partial', charge: 'ch_partial' },
+        charge: { id: 'ch_partial', payment_intent: 'pi_partial' }
+    });
+
+    const payout = {
+        id: 'po_partial',
+        amount: 24100,
+        currency: 'usd',
+        arrival_date: 1700100000
+    };
+
+    const reconciliation = reconcilePayout(payout, [chargeMapped, refundMapped], { companyHomeCurrency: 'USD' });
+    assert.strictEqual(reconciliation.payoutAmount, 24100);
+    assert.strictEqual(reconciliation.clearingImpact, 24100);
+
+    const transferResult = await postTransferIfNew(payout, provider, {
+        accounts,
+        store,
+        companyHomeCurrency: 'USD'
+    });
+    assert.strictEqual(transferResult.status, 'created');
+
+    const transferReplay = await postTransferIfNew(payout, provider, {
+        accounts,
+        store,
+        companyHomeCurrency: 'USD'
+    });
+    assert.strictEqual(transferReplay.status, 'skipped');
+}
+
+async function testJournalEntryIdempotencyWithAttachments() {
+    const provider = new MockQuickBooksProvider();
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'stripe-qbo-store-'));
+    const store = new ProcessedStripeStore({ storagePath: path.join(tmpDir, 'state.json') });
+
+    const journalEntry = {
+        docNumber: 'STRIPE-ch_12345',
+        date: '2023-11-15',
+        memo: 'stripe:ch=ch_12345;pi=pi_12345;bt=bt_12345;payout=po_1;customer=cust_1',
+        lines: [
+            { type: 'credit', accountId: accounts.revenueId, amount: 10000 },
+            { type: 'debit', accountId: accounts.stripeFeesId, amount: 300, entityRef: { type: 'Vendor', value: 'vendor-stripe' } },
+            { type: 'debit', accountId: accounts.stripeClearingId, amount: 9700 }
+        ]
+    };
+
+    const first = await postJEIfNew(journalEntry, provider, {
+        store,
+        attachments: ['https://stripe.test/receipt/ch_12345']
+    });
+    assert.strictEqual(first.status, 'created');
+    assert.strictEqual(provider.attachments.length, 1);
+
+    const second = await postJEIfNew(journalEntry, provider, { store });
+    assert.strictEqual(second.status, 'skipped');
+}
+
+async function testMulticurrencyConversion() {
+    const provider = new MockQuickBooksProvider();
+    const vendor = { id: 'vendor-stripe', name: 'Stripe' };
+    const customer = { id: 'cust-eur', displayName: 'Euro Donor' };
+
+    const charge = {
+        id: 'ch_eur',
+        created: 1700200000,
+        payment_intent: 'pi_eur',
+        metadata: {},
+        balance_transaction: {
+            id: 'bt_eur',
+            type: 'charge',
+            amount: 10000,
+            fee: 300,
+            net: 9700,
+            currency: 'eur',
+            exchange_rate: 1.1
+        }
+    };
+
+    const { journalEntry, amounts } = buildChargeJE(charge, accounts, vendor, customer, {
+        companyHomeCurrency: 'USD'
+    });
+
+    assert.ok(journalEntry.memo.includes('fx=1.1'));
+    assert.strictEqual(amounts.gross, 11000);
+    assert.strictEqual(amounts.fee, 330);
+    assert.strictEqual(amounts.net, 10670);
+    const debits = journalEntry.lines.filter(line => line.type === 'debit').reduce((sum, line) => sum + line.amount, 0);
+    const credits = journalEntry.lines.filter(line => line.type === 'credit').reduce((sum, line) => sum + line.amount, 0);
+    assert.strictEqual(debits, credits);
+}
+
+async function testAttachmentsHelper() {
+    const provider = new MockQuickBooksProvider();
+    await attachStripeArtifacts(provider, 'je-123', [
+        'https://stripe.test/receipt/ch_1',
+        { charge: 'ch_1', amount: 1000 }
+    ]);
+    assert.strictEqual(provider.attachments.length, 2);
+}
+
+async function testConvertPayoutAmount() {
+    const payout = { amount: 10000, currency: 'usd' };
+    const amount = convertPayoutAmount(payout, 'USD');
+    assert.strictEqual(amount, 10000);
+
+    const fxPayout = { amount: 10000, currency: 'eur', exchange_rate: 1.2 };
+    const fxAmount = convertPayoutAmount(fxPayout, 'USD');
+    assert.strictEqual(fxAmount, 12000);
+}
+
+(async () => {
+    await runTest('Resolves customers with fallback handling', testResolveQboCustomer);
+    await runTest('Builds balanced charge journal entry with correct EntityRefs', testBuildChargeJournalEntry);
+    await runTest('Maps refunds, disputes, fees, fee refunds, and adjustments correctly', testBalanceTransactionMappings);
+    await runTest('Reconciles payout clearing impact and posts transfer idempotently', testPayoutReconciliationAndTransfer);
+    await runTest('Prevents duplicate journal entries and stores attachments', testJournalEntryIdempotencyWithAttachments);
+    await runTest('Handles multicurrency conversion with memo tagging', testMulticurrencyConversion);
+    await runTest('Creates Stripe artifact attachments', testAttachmentsHelper);
+    await runTest('Converts payout amounts respecting FX rates', testConvertPayoutAmount);
+
+    console.log('All Stripe ↔ QBO sync tests passed');
+})().catch(error => {
+    console.error(error);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a Stripe→QBO sync toolkit that fetches Stripe data, resolves customers and vendors, and builds journal entries, payout transfers, and attachments with idempotent posting helpers
- implement durable file-backed Stripe idempotency store plus payout reconciliation utilities and expose Single Responsibility Principle driven modules
- document accounting configuration and provide targeted Stripe↔QBO unit tests covering charges, refunds, disputes, fees, FX, attachments, and transfers

## Testing
- node tests/stripeQboSync.test.js
- npm test *(fails: Per-transaction journal line mode failed in tests/payoutSync.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68e162609298832c92654b342c111259