### PR TITLE
Remove transaction mode from journal descriptions

### DIFF
--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -439,7 +439,6 @@ class PayoutSyncService {
             const parts = [
                 `Stripe payout ${payout.id}`,
                 summary.currency ? `Currency: ${summary.currency.toUpperCase()}` : null,
-                `Mode: ${transactionLineMode === 'per-transaction' ? 'Per transaction' : 'Summary'}`,
                 label,
                 ...details
             ];

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -744,7 +744,6 @@ async function runTests() {
         const expectedChargeDescription = [
             'Stripe payout po_txn_mode',
             'Currency: USD',
-            'Mode: Per transaction',
             'Donation A',
             'Gross: $50.00, Fees: $1.50, Net: $48.50',
             'Transaction: txn_charge_1',


### PR DESCRIPTION
## Summary
- stop including the transaction mode text when building journal entry descriptions
- adjust the payout sync per-transaction test to match the new description format

## Testing
- node tests/payoutSync.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e172dd979c832ca401dfbb03c4acbb