### PR TITLE
Redact sensitive payload information from processTransaction logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "processTransaction/index.js",
   "scripts": {
     "start": "func start",
-    "test": "node tests/integration.test.js && node tests/transactionCreationFlow.test.js && node tests/failedCanceledTransactions.test.js && node tests/payoutSync.test.js && node tests/payoutCrmIntegration.test.js && node tests/payoutSyncFix.test.js && node tests/manualPayoutSync.test.js && node tests/payoutDateRangeFix.test.js && node tests/connectedAccountPayoutFix.test.js && node tests/payoutArrivalDateFix.test.js && node tests/payoutSyncLogicCorrection.test.js && node tests/payoutAdvanceExclusion.test.js && node tests/productionScenarioSimulation.test.js && node tests/manualPayoutDateWindow.test.js && node tests/quickbooksProvider.test.js && node tests/journalEntryCreation.test.js && node tests/amountConversion.test.js && node tests/stripeQboSync.test.js"
+    "test": "node tests/integration.test.js && node tests/transactionCreationFlow.test.js && node tests/failedCanceledTransactions.test.js && node tests/payoutSync.test.js && node tests/payoutCrmIntegration.test.js && node tests/payoutSyncFix.test.js && node tests/manualPayoutSync.test.js && node tests/payoutDateRangeFix.test.js && node tests/connectedAccountPayoutFix.test.js && node tests/payoutArrivalDateFix.test.js && node tests/payoutSyncLogicCorrection.test.js && node tests/payoutAdvanceExclusion.test.js && node tests/productionScenarioSimulation.test.js && node tests/manualPayoutDateWindow.test.js && node tests/quickbooksProvider.test.js && node tests/journalEntryCreation.test.js && node tests/amountConversion.test.js && node tests/stripeQboSync.test.js && node tests/loggingSecurity.test.js"
   },
   "dependencies": {
     "@azure/functions": "^4.5.0",

--- a/processTransaction/index.js
+++ b/processTransaction/index.js
@@ -1,3 +1,4 @@
+const { randomUUID } = require('crypto');
 const Stripe = require('stripe');
 const sgMail = require('@sendgrid/mail');
 const CrmFactory = require('../services/crm/crmFactory');
@@ -416,12 +417,18 @@ const getIntervalCount = (frequency) => {
 
 // Main function handler for traditional Azure Functions model
 module.exports = async function (context, req) {
+    const requestId = randomUUID();
+    const secureDebugEnabled = process.env.SECURE_DEBUG === 'true';
+    const log = (message, extra = {}) => {
+        context.log(message, { requestId, ...extra });
+    };
+
     try {
-        context.log('Processing payment request');
-        
+        log('Processing payment request');
+
         let body = req.body;
         if (!body) {
-            context.log('No request body provided');
+            log('No request body provided');
             context.res = {
                 status: 400,
                 body: JSON.stringify({
@@ -430,27 +437,20 @@ module.exports = async function (context, req) {
             };
             return;
         }
-        
-        context.log('Request body parsed successfully:', JSON.stringify(body, null, 2));
-        
-        // Send debug email (optional, only if DEBUG_EMAIL is configured)
-        if (process.env.SENDGRID_API_KEY && process.env.DEBUG_EMAIL) {
-            try {
-                const debugMsg = {
-                    to: process.env.DEBUG_EMAIL,
-                    from: process.env.NOTIFICATION_EMAIL_FROM || 'noreply@example.com',
-                    subject: `Debug: New Payment Submission - ${body.firstname || 'Unknown'} ${body.lastname || 'Unknown'}`,
-                    html: `<p>${JSON.stringify(body, null, 2)}</p>`,
-                };
-                await sgMail.send(debugMsg);
-            } catch (debugError) {
-                context.log('Debug email failed:', debugError);
-            }
+
+        const requestSummary = createRequestSummary(body);
+        log('Request body summary', requestSummary);
+
+        if (secureDebugEnabled) {
+            log('Secure debug payload snapshot', { payload: redactSensitiveFields(body) });
         }
-        
+
         // Validate request
         const validation = validateRequest(body);
-        context.log('Validation result:', validation);
+        log('Validation result', {
+            isValid: validation.isValid,
+            hasError: Boolean(validation.error)
+        });
         if (!validation.isValid) {
             context.res = {
                 status: 400,
@@ -471,20 +471,20 @@ module.exports = async function (context, req) {
         // Get or create customer
         let customerId;
         if (existingCustomers.length === 0) {
-            context.log('Creating new Stripe customer');
+            log('Creating new Stripe customer');
             const newCustomer = await createStripeCustomer(stripe, body);
             customerId = newCustomer.id;
         } else {
-            context.log('Using existing Stripe customer');
+            log('Using existing Stripe customer');
             customerId = existingCustomers[0].id;
-            
+
             // Update existing customer with latest information
-            context.log('Updating existing Stripe customer with latest information');
+            log('Updating existing Stripe customer with latest information');
             await updateStripeCustomer(stripe, customerId, body);
         }
-        
+
         // Create checkout session
-        context.log('Creating Stripe checkout session');
+        log('Creating Stripe checkout session');
         const session = await createCheckoutSession(stripe, customerId, body);
         
         // Sync contact to CRM (Salesforce) if configured
@@ -509,11 +509,12 @@ module.exports = async function (context, req) {
             })
         };
         
-        context.log('Donation processing completed successfully');
-        
+        log('Donation processing completed successfully');
+
     } catch (error) {
-        context.log('Error processing donation:', error);
-        
+        log('Error processing donation', { error: error.message });
+        console.error('Donation processing error details:', { requestId, stack: error.stack });
+
         context.res = {
             status: 500,
             body: JSON.stringify({
@@ -522,4 +523,61 @@ module.exports = async function (context, req) {
             })
         };
     }
+};
+
+const createRequestSummary = (body) => {
+    const summary = {
+        receivedFields: Object.keys(body || {})
+    };
+
+    if (typeof body?.amount === 'number') {
+        summary.amount = body.amount;
+    }
+
+    if (typeof body?.frequency === 'string') {
+        summary.frequency = body.frequency;
+    }
+
+    if (typeof body?.livemode !== 'undefined') {
+        summary.livemode = Boolean(body.livemode);
+    }
+
+    return summary;
+};
+
+const redactSensitiveFields = (data) => {
+    if (data === null || data === undefined) {
+        return data;
+    }
+
+    if (Array.isArray(data)) {
+        return data.map(item => redactSensitiveFields(item));
+    }
+
+    if (typeof data !== 'object') {
+        return typeof data === 'string' ? '[REDACTED]' : data;
+    }
+
+    const sensitiveKeywords = ['name', 'email', 'phone', 'address', 'line1', 'line2', 'city', 'state', 'zip', 'postal', 'country', 'card', 'account', 'routing', 'ssn'];
+    const nestedRedactionKeywords = ['address'];
+
+    return Object.entries(data).reduce((accumulator, [key, value]) => {
+        const lowerKey = key.toLowerCase();
+        const shouldRedact = sensitiveKeywords.some(keyword => lowerKey.includes(keyword));
+        const requiresNestedRedaction = nestedRedactionKeywords.some(keyword => lowerKey.includes(keyword));
+
+        if (shouldRedact) {
+            if (requiresNestedRedaction && typeof value === 'object' && value !== null) {
+                accumulator[key] = redactSensitiveFields(value);
+            } else {
+                accumulator[key] = '[REDACTED]';
+            }
+        } else if (typeof value === 'object' && value !== null) {
+            accumulator[key] = redactSensitiveFields(value);
+        } else {
+            accumulator[key] = value;
+        }
+
+        return accumulator;
+    }, {});
 };

--- a/tests/loggingSecurity.test.js
+++ b/tests/loggingSecurity.test.js
@@ -1,0 +1,126 @@
+const processTransaction = require('../processTransaction');
+
+function createMockContext() {
+    const logs = [];
+    return {
+        log: (...args) => {
+            logs.push(args);
+        },
+        res: null,
+        logs
+    };
+}
+
+async function runLoggingSecurityTests() {
+    console.log('🧪 Running Logging Security Tests\n');
+
+    let testsPassed = 0;
+    let testsTotal = 0;
+
+    const originalSecureDebug = process.env.SECURE_DEBUG;
+
+    const test = async (name, fn) => {
+        testsTotal++;
+        try {
+            await fn();
+            console.log(`✅ ${name}`);
+            testsPassed++;
+        } catch (error) {
+            console.log(`❌ ${name}: ${error.message}`);
+        }
+    };
+
+    const assert = (condition, message) => {
+        if (!condition) {
+            throw new Error(message);
+        }
+    };
+
+    await test('Logs exclude sensitive payload details when secure debug disabled', async () => {
+        delete process.env.SECURE_DEBUG;
+
+        const context = createMockContext();
+        const req = {
+            body: {
+                email: 'alice@example.com',
+                firstname: 'Alice',
+                lastname: 'Doe',
+                phone: '+15555555555',
+                address: {
+                    line1: '123 Main St',
+                    postal_code: '12345'
+                },
+                amount: 5000
+            }
+        };
+
+        await processTransaction(context, req);
+
+        const combinedLogs = JSON.stringify(context.logs);
+        assert(!combinedLogs.includes('alice@example.com'), 'Email should not appear in logs');
+        assert(!combinedLogs.includes('Alice'), 'First name should not appear in logs');
+        assert(!combinedLogs.includes('Doe'), 'Last name should not appear in logs');
+        assert(!combinedLogs.includes('123 Main St'), 'Address should not appear in logs');
+
+        const debugLog = context.logs.find(([message]) => message === 'Secure debug payload snapshot');
+        assert(!debugLog, 'Secure debug log should be absent when SECURE_DEBUG is disabled');
+
+        const summaryLog = context.logs.find(([message]) => message === 'Request body summary');
+        assert(summaryLog, 'Request body summary log should exist');
+        const summaryData = summaryLog[1];
+        assert(Array.isArray(summaryData.receivedFields), 'Summary should include received fields');
+        assert(summaryData.receivedFields.includes('email'), 'Summary should list email field');
+    });
+
+    await test('Secure debug log redacts sensitive fields when enabled', async () => {
+        process.env.SECURE_DEBUG = 'true';
+
+        const context = createMockContext();
+        const req = {
+            body: {
+                email: 'bob@example.com',
+                firstname: 'Bob',
+                lastname: 'Smith',
+                phone: '+15551234567',
+                address: {
+                    line1: '456 Market St',
+                    postal_code: '67890'
+                },
+                amount: 7500
+            }
+        };
+
+        await processTransaction(context, req);
+
+        const debugLog = context.logs.find(([message]) => message === 'Secure debug payload snapshot');
+        assert(debugLog, 'Secure debug log should be present when SECURE_DEBUG is true');
+        const payload = debugLog[1].payload;
+        assert(payload.email === '[REDACTED]', 'Email should be redacted');
+        assert(payload.firstname === '[REDACTED]', 'First name should be redacted');
+        assert(payload.lastname === '[REDACTED]', 'Last name should be redacted');
+        assert(payload.phone === '[REDACTED]', 'Phone should be redacted');
+        assert(payload.address.line1 === '[REDACTED]', 'Address line should be redacted');
+        assert(payload.address.postal_code === '[REDACTED]', 'Postal code should be redacted');
+        assert(payload.amount === 7500, 'Non-sensitive amount should remain');
+    });
+
+    process.env.SECURE_DEBUG = originalSecureDebug;
+
+    console.log(`\n📊 Logging Security Test Results: ${testsPassed}/${testsTotal} tests passed`);
+
+    if (testsPassed === testsTotal) {
+        console.log('🎉 All logging security tests passed!');
+        return true;
+    }
+
+    console.log('❌ Some logging security tests failed');
+    return false;
+}
+
+if (require.main === module) {
+    runLoggingSecurityTests().then(success => {
+        process.exit(success ? 0 : 1);
+    });
+}
+
+module.exports = { runLoggingSecurityTests };


### PR DESCRIPTION
## Summary
- replace the verbose request logging with structured output tied to a generated request identifier
- remove the debug email that transmitted raw payloads and add helpers to redact sensitive fields for optional secure debugging
- add automated coverage to ensure logs omit sensitive data unless secure debugging is explicitly enabled

## Testing
- node tests/loggingSecurity.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e17f6a1038832c84b6287b2561a731