### PR TITLE
Fetch operating bank account names directly from Stripe

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -176,11 +176,12 @@ QBO_ACCESS_TOKEN=your_token
 
 # Account mappings
 ACCOUNTING_STRIPE_CLEARING_ACCOUNT=Stripe Clearing
-ACCOUNTING_OPERATING_BANK_ACCOUNT=Operating Bank
 ACCOUNTING_REVENUE_ACCOUNT=Revenue
 ACCOUNTING_REFUNDS_ACCOUNT=Refunds
 ACCOUNTING_STRIPE_FEE_ACCOUNT=Stripe Fees
 ```
+
+> ℹ️ The operating bank account name is determined automatically from the Stripe payout destination.
 
 ### Recommended Additional
 

--- a/PAYOUT_SYNC_SETUP.md
+++ b/PAYOUT_SYNC_SETUP.md
@@ -124,7 +124,6 @@ STRIPE_ACCOUNTS=acct_123:live:sk_live_...,acct_456:test:sk_test_...
 ```bash
 # Primary accounts
 ACCOUNTING_STRIPE_CLEARING_ACCOUNT=Stripe Clearing
-ACCOUNTING_OPERATING_BANK_ACCOUNT=Operating Bank
 ACCOUNTING_REVENUE_ACCOUNT=Revenue
 ACCOUNTING_REFUNDS_ACCOUNT=Refunds
 ACCOUNTING_STRIPE_FEE_ACCOUNT=Stripe Fees
@@ -134,6 +133,8 @@ ACCOUNTING_ADJUSTMENT_ACCOUNT=Adjustments
 # Revenue mapping by category (optional)
 ACCOUNTING_REVENUE_MAPPING=General Giving:Revenue - Donations,Building Fund:Revenue - Building
 ```
+
+> ℹ️ The operating bank account name is retrieved automatically from Stripe when payouts are processed.
 
 ### Posting Policy
 

--- a/PAYOUT_SYNC_TROUBLESHOOTING.md
+++ b/PAYOUT_SYNC_TROUBLESHOOTING.md
@@ -37,13 +37,15 @@ STRIPE_LIVE_SECRET_KEY=sk_live_...  # for live mode
 ### Optional Account Mappings
 ```
 ACCOUNTING_STRIPE_CLEARING_ACCOUNT=Stripe Clearing
-ACCOUNTING_OPERATING_BANK_ACCOUNT=Operating Bank
 ACCOUNTING_REVENUE_ACCOUNT=Revenue
 ACCOUNTING_REFUNDS_ACCOUNT=Refunds
 ACCOUNTING_STRIPE_FEE_ACCOUNT=Stripe Fees
 ACCOUNTING_CHARGEBACK_ACCOUNT=Chargebacks
 ACCOUNTING_ADJUSTMENT_ACCOUNT=Adjustments
 ```
+
+> ℹ️ The operating bank account name is automatically synced from Stripe; you only need to provide the clearing and revenue
+> accounts.
 
 ## Diagnostic Log Messages
 

--- a/QUICKBOOKS_SETUP.md
+++ b/QUICKBOOKS_SETUP.md
@@ -74,13 +74,15 @@ ACCOUNTING_PROVIDER=quickbooks
 
 # Account Mappings
 ACCOUNTING_STRIPE_CLEARING_ACCOUNT=Stripe Clearing
-ACCOUNTING_OPERATING_BANK_ACCOUNT=Operating Bank
 ACCOUNTING_REVENUE_ACCOUNT=Revenue
 ACCOUNTING_REFUNDS_ACCOUNT=Refunds
 ACCOUNTING_STRIPE_FEE_ACCOUNT=Stripe Fees
 ACCOUNTING_CHARGEBACK_ACCOUNT=Chargebacks
 ACCOUNTING_ADJUSTMENT_ACCOUNT=Adjustments
 ```
+
+> ℹ️ The operating bank account name is fetched directly from Stripe based on the payout destination; no environment variable
+> is required.
 
 ### Optional Variables
 

--- a/README.md
+++ b/README.md
@@ -331,11 +331,13 @@ The payment processor includes automated **Stripe Payout Sync to Accounting** wi
 3. **Set account mappings**:
    ```bash
    ACCOUNTING_STRIPE_CLEARING_ACCOUNT=Stripe Clearing
-   ACCOUNTING_OPERATING_BANK_ACCOUNT=Operating Bank
    ACCOUNTING_REVENUE_ACCOUNT=Revenue
    ACCOUNTING_REFUNDS_ACCOUNT=Refunds
    ACCOUNTING_STRIPE_FEE_ACCOUNT=Stripe Fees
    ```
+
+   > ℹ️ The operating bank account name is now pulled directly from Stripe based on the payout destination, so no environment
+   > variable is required.
 
 4. **Configure Stripe webhook** to send `payout.*` events to `/api/stripe/webhook`
 

--- a/WEBHOOK_PAYOUT_SETUP.md
+++ b/WEBHOOK_PAYOUT_SETUP.md
@@ -147,12 +147,13 @@ QBO_REFRESH_TOKEN=your_refresh_token
 
 # Account mappings (use your actual account names from QuickBooks)
 ACCOUNTING_STRIPE_CLEARING_ACCOUNT=Stripe Clearing
-ACCOUNTING_OPERATING_BANK_ACCOUNT=Operating Bank
 ACCOUNTING_REVENUE_ACCOUNT=Revenue
 ACCOUNTING_REFUNDS_ACCOUNT=Refunds
 ACCOUNTING_STRIPE_FEE_ACCOUNT=Stripe Fees
 ACCOUNTING_DISPUTE_ACCOUNT=Customer Disputes
 ```
+
+> ℹ️ The operating bank account name is now read directly from Stripe payout destinations and no longer needs to be configured.
 
 **For other providers (Xero, Sage):**
 
@@ -224,7 +225,6 @@ QBO_COMPANY_ID
 QBO_ACCESS_TOKEN
 QBO_REFRESH_TOKEN
 ACCOUNTING_STRIPE_CLEARING_ACCOUNT
-ACCOUNTING_OPERATING_BANK_ACCOUNT
 ACCOUNTING_REVENUE_ACCOUNT
 
 # CRM (Salesforce example) - Optional

--- a/services/accountingSyncConfig.js
+++ b/services/accountingSyncConfig.js
@@ -12,6 +12,9 @@ class AccountingSyncConfig {
     constructor() {
         this.config = this._loadFromEnvironment();
         this.logger = console;
+        this.accountOverrides = {
+            operatingBank: {}
+        };
     }
 
     /**
@@ -43,7 +46,7 @@ class AccountingSyncConfig {
             // Account mappings
             accounts: {
                 stripeClearingAccount: process.env.ACCOUNTING_STRIPE_CLEARING_ACCOUNT || 'Stripe Clearing',
-                operatingBankAccount: process.env.ACCOUNTING_OPERATING_BANK_ACCOUNT || 'Operating Bank',
+                operatingBankAccount: null,
                 revenueAccount: process.env.ACCOUNTING_REVENUE_ACCOUNT || 'Revenue',
                 refundsAccount: process.env.ACCOUNTING_REFUNDS_ACCOUNT || 'Refunds',
                 stripeFeeAccount: process.env.ACCOUNTING_STRIPE_FEE_ACCOUNT || 'Stripe Fees',
@@ -253,14 +256,48 @@ class AccountingSyncConfig {
             errors.push('Stripe clearing account is required');
         }
 
-        if (!this.config.accounts.operatingBankAccount) {
-            errors.push('Operating bank account is required');
-        }
-
         return {
             isValid: errors.length === 0,
             errors
         };
+    }
+
+    /**
+     * Set the operating bank account name for a Stripe account
+     * @param {string} name - Bank account name from Stripe
+     * @param {string|null} accountId - Stripe account ID (null for platform default)
+     */
+    setOperatingBankAccountName(name, accountId = null) {
+        if (!name) {
+            return;
+        }
+
+        const key = accountId || 'default';
+        this.accountOverrides.operatingBank[key] = name;
+
+        if (!accountId) {
+            this.config.accounts.operatingBankAccount = name;
+        }
+    }
+
+    /**
+     * Get the operating bank account name for a Stripe account
+     * @param {string|null} accountId - Stripe account ID (null for platform default)
+     * @returns {string|null}
+     */
+    getOperatingBankAccountName(accountId = null) {
+        const key = accountId || 'default';
+        const overrides = this.accountOverrides?.operatingBank || {};
+
+        if (overrides[key]) {
+            return overrides[key];
+        }
+
+        if (overrides.default) {
+            return overrides.default;
+        }
+
+        return this.config.accounts.operatingBankAccount || null;
     }
 
     /**

--- a/services/payoutSyncService.js
+++ b/services/payoutSyncService.js
@@ -20,6 +20,7 @@ class PayoutSyncService {
         this.reviewTaskService = reviewTaskService;
         this.crmService = crmService;
         this.logger = console;
+        this.platformAccountId = null;
     }
 
     /**
@@ -52,12 +53,17 @@ class PayoutSyncService {
         const requestOptions = stripeAccountId ? { stripeAccount: stripeAccountId } : {};
         this.logger.log(`[PayoutSync] Fetching payout from Stripe API...`);
         
-        const payout = await stripe.payouts.retrieve(payoutId, requestOptions);
+        const payoutParams = { expand: ['destination'] };
+        const payout = stripeAccountId
+            ? await stripe.payouts.retrieve(payoutId, payoutParams, requestOptions)
+            : await stripe.payouts.retrieve(payoutId, payoutParams);
         this.logger.log(`[PayoutSync] Payout retrieved: ${payout.id}, status: ${payout.status}, amount: ${payout.amount}`);
 
         if (!payout) {
             throw new Error(`Payout not found: ${payoutId}`);
         }
+
+        await this._ensureOperatingBankAccount(stripe, payout, stripeAccountId);
 
         // Fetch balance transactions for this payout
         // Strategy: Try direct payout filter first for all payouts, fallback to date range if needed
@@ -393,6 +399,109 @@ class PayoutSyncService {
     }
 
     /**
+     * Ensure the operating bank account name is populated from Stripe
+     * @param {Stripe} stripe - Stripe client instance
+     * @param {Object} payout - Stripe payout object
+     * @param {string|null} stripeAccountId - Stripe account ID (null for platform account)
+     * @private
+     */
+    async _ensureOperatingBankAccount(stripe, payout, stripeAccountId) {
+        if (!this.config || typeof this.config.setOperatingBankAccountName !== 'function') {
+            return;
+        }
+
+        if (typeof this.config.getOperatingBankAccountName === 'function') {
+            const existing = this.config.getOperatingBankAccountName(stripeAccountId);
+            if (existing) {
+                return;
+            }
+        }
+
+        const expandedName = this._extractBankAccountName(payout?.destination);
+        if (expandedName) {
+            this.config.setOperatingBankAccountName(expandedName, stripeAccountId);
+            return;
+        }
+
+        const destinationId = typeof payout?.destination === 'string' ? payout.destination : null;
+        if (!destinationId) {
+            return;
+        }
+
+        try {
+            let accountId = stripeAccountId;
+
+            if (!accountId) {
+                accountId = await this._getPlatformAccountId(stripe);
+            }
+
+            if (!accountId) {
+                return;
+            }
+
+            const externalAccount = await stripe.accounts.retrieveExternalAccount(accountId, destinationId);
+            const accountName = this._extractBankAccountName(externalAccount);
+
+            if (accountName) {
+                this.config.setOperatingBankAccountName(accountName, stripeAccountId);
+            }
+        } catch (error) {
+            this.logger.warn(`[PayoutSync] Unable to load bank account name from Stripe: ${error.message}`);
+        }
+    }
+
+    /**
+     * Extract a human-readable bank account name from Stripe destination objects
+     * @param {Object|string|null} destination - Stripe payout destination
+     * @returns {string|null}
+     * @private
+     */
+    _extractBankAccountName(destination) {
+        if (!destination || typeof destination === 'string') {
+            return null;
+        }
+
+        if (destination.object === 'bank_account') {
+            return destination.account_holder_name || destination.bank_name || null;
+        }
+
+        if (destination.object === 'card') {
+            if (destination.brand && destination.last4) {
+                return `${destination.brand} ****${destination.last4}`;
+            }
+            return destination.bank_name || destination.account_holder_name || null;
+        }
+
+        if (destination.object === 'financial_connections.account') {
+            return destination.institution_name || destination.display_name || null;
+        }
+
+        return destination.account_holder_name || destination.bank_name || null;
+    }
+
+    /**
+     * Retrieve and cache the platform Stripe account ID
+     * @param {Stripe} stripe - Stripe client instance
+     * @returns {Promise<string|null>}
+     * @private
+     */
+    async _getPlatformAccountId(stripe) {
+        if (this.platformAccountId) {
+            return this.platformAccountId;
+        }
+
+        try {
+            const account = await stripe.accounts.retrieve();
+            this.platformAccountId = account?.id || null;
+        } catch (error) {
+            this.logger.warn(`[PayoutSync] Unable to retrieve platform account ID: ${error.message}`);
+            this.platformAccountId = null;
+        }
+
+        return this.platformAccountId;
+    }
+
+    /**
      * Generate provider-neutral posting instructions
      * @param {Object} payout - Stripe payout
      * @param {Object} summary - Activity summary
@@ -413,7 +522,9 @@ class PayoutSyncService {
 
         // Determine accounts
         const clearingAccount = accountConfig.stripeClearingAccount;
-        const bankAccount = accountConfig.operatingBankAccount;
+        const bankAccount = typeof this.config.getOperatingBankAccountName === 'function'
+            ? this.config.getOperatingBankAccountName(stripeAccountId)
+            : accountConfig.operatingBankAccount;
         const revenueAccount = accountConfig.revenueAccount;
         const refundsAccount = accountConfig.refundsAccount;
         const feesAccount = accountConfig.stripeFeeAccount;

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -780,6 +780,58 @@ async function runTests() {
         failed++;
     }
 
+    // Test 9: Operating bank account name is loaded from Stripe payout destination
+    try {
+        let override = null;
+        const mockConfig = {
+            getConfig: () => ({
+                provider: 'quickbooks',
+                accounts: {
+                    stripeClearingAccount: 'Stripe Clearing',
+                    operatingBankAccount: null,
+                    revenueAccount: 'Revenue',
+                    refundsAccount: 'Refunds',
+                    stripeFeeAccount: 'Stripe Fees',
+                    chargebackAccount: 'Chargebacks',
+                    adjustmentAccount: 'Adjustments'
+                },
+                posting: { strategy: 'je-transfer' }
+            }),
+            getStripeAccount: () => null,
+            setOperatingBankAccountName: (name, accountId) => {
+                override = { name, accountId };
+            },
+            getOperatingBankAccountName: () => (override ? override.name : null)
+        };
+
+        const syncLedger = await createTestSyncLedger('payout-bank-name');
+        const provider = new MockAccountingProvider();
+        const service = new PayoutSyncService(mockConfig, provider, syncLedger);
+
+        const payout = {
+            id: 'po_bank_name',
+            destination: {
+                object: 'bank_account',
+                bank_name: 'Mission Bank',
+                account_holder_name: 'Mission Bank Operating'
+            }
+        };
+
+        await service._ensureOperatingBankAccount({}, payout, null);
+
+        if (override && override.name === 'Mission Bank Operating' && override.accountId === null) {
+            console.log('✅ Operating bank account pulled from Stripe destination');
+            passed++;
+        } else {
+            console.log('❌ Failed to load operating bank account from Stripe destination');
+            console.log('   Override value:', override);
+            failed++;
+        }
+    } catch (error) {
+        console.log('❌ Operating bank account loading - error:', error.message);
+        failed++;
+    }
+
     // Summary
     console.log(`\n📊 Payout Sync Test Results: ${passed}/${passed + failed} tests passed`);
 


### PR DESCRIPTION
## Summary
- pull the operating bank account name from Stripe payout destinations instead of an environment variable and cache it per account
- update the accounting sync configuration helpers and documentation to reflect the automatic bank account detection
- extend payout sync tests to cover the new bank account lookup behavior

## Testing
- node tests/payoutSync.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e1a3b2de2c832c9d9b2d91ff04f60c