### PR TITLE
Enhance CRM transactions with Stripe event details

### DIFF
--- a/processTransaction/index.js
+++ b/processTransaction/index.js
@@ -2,6 +2,7 @@ const { randomUUID } = require('crypto');
 const Stripe = require('stripe');
 const sgMail = require('@sendgrid/mail');
 const CrmFactory = require('../services/crm/crmFactory');
+const { mapStripeStatusToCrmStatus, buildStripeTransactionDetails } = require('../services/crm/stripeTransactionUtils');
 const { loadConfig, normalizeTransactionCategory, generateTransactionName } = require('../config/contactMatching');
 
 const TRUTHY_VALUES = new Set(['true', '1', 'yes', 'y', 'on']);
@@ -289,18 +290,39 @@ const createPendingTransaction = async (context, session, contactId, transaction
             id: session.id
         });
 
+        const stripeDetails = buildStripeTransactionDetails(session, {
+            eventType: 'checkout.session.created',
+            eventCreated: session.created,
+            livemode: session.livemode,
+            source: 'processTransaction.createPending'
+        }) || {};
+
+        const stripeStatus = stripeDetails?.summary?.payment_status || stripeDetails?.summary?.status ||
+            session.payment_status || session.status || 'pending';
+        const crmStatus = mapStripeStatusToCrmStatus(stripeStatus, 'Pending');
+
         const txnData = {
             amount: transactionData.amount,
-            currency: 'usd',
+            currency: transactionData.currency || session.currency || 'usd',
             paymentMethod: 'Pending',
-            transactionId: null, // Will be set when payment_intent.succeeded fires
+            transactionId: session.payment_intent || null, // Will be set when payment_intent.succeeded fires
             sessionId: session.id,
-            status: 'Pending',
+            status: crmStatus,
+            stripeStatus,
             description: transactionName,
             frequency: transactionData.frequency || 'onetime',
             category: normalizedCategory,
-            name: transactionName
+            name: transactionName,
+            stripeDetails
         };
+
+        if (typeof session.amount_total === 'number') {
+            txnData.amountTotal = session.amount_total;
+        }
+
+        if (typeof session.amount_subtotal === 'number') {
+            txnData.amountSubtotal = session.amount_subtotal;
+        }
 
         const transaction = await crmService.createTransaction(contactId, txnData);
         context.log(`Created pending transaction: ${transaction.Id || 'N/A'} with name: ${transactionName}`);

--- a/services/crm/salesforceCrm.js
+++ b/services/crm/salesforceCrm.js
@@ -81,21 +81,43 @@ class SalesforceCrmService extends BaseCrmService {
             'name',
             'description',
             'amount',
+            'amountAuthorized',
+            'amountReceived',
+            'amountCapturable',
+            'amountTotal',
+            'amountSubtotal',
             'currency',
             'paymentMethod',
             'transactionId',
+            'stripeStatus',
             'status',
             'frequency',
             'category',
-            'sessionId'
+            'sessionId',
+            'stripeCustomerId',
+            'invoiceId',
+            'latestChargeId',
+            'applicationFeeAmount',
+            'transferData',
+            'stripeDetails'
         ];
+
+        const amountKeys = new Set([
+            'amount',
+            'amountAuthorized',
+            'amountReceived',
+            'amountCapturable',
+            'amountTotal',
+            'amountSubtotal',
+            'applicationFeeAmount'
+        ]);
 
         const entries = Object.entries(transactionData)
             .filter(([, value]) => value !== undefined && value !== null && value !== '')
             .map(([key, value]) => {
                 let formattedValue = this.formatDescriptionValue(value);
 
-                if (key === 'amount' && typeof value === 'number') {
+                if (amountKeys.has(key) && typeof value === 'number') {
                     const dollars = (value / 100).toFixed(2);
                     formattedValue = `$${dollars} (${value})`;
                 } else if (key === 'currency' && typeof value === 'string') {
@@ -513,25 +535,64 @@ class SalesforceCrmService extends BaseCrmService {
     async updateTransaction(transactionId, transactionData) {
         await this.connect();
 
-        const { 
+        const {
             status,
             paymentMethod,
-            transactionId: stripeTransactionId
+            transactionId: stripeTransactionId,
+            amount,
+            currency,
+            description,
+            frequency,
+            category,
+            name,
+            sessionId
         } = transactionData;
+
+        const fullDescription = this.buildTransactionDescription(transactionData);
 
         // Build update record with only provided fields
         const updateRecord = {};
-        
+
         if (status !== undefined) {
             updateRecord.Status__c = status;
         }
-        
+
         if (paymentMethod !== undefined) {
             updateRecord.Payment_Method__c = paymentMethod;
         }
 
         if (stripeTransactionId !== undefined) {
             updateRecord.Transaction_ID__c = stripeTransactionId;
+        }
+
+        if (typeof amount === 'number') {
+            updateRecord.Amount__c = amount / 100;
+        }
+
+        if (currency) {
+            updateRecord.Currency__c = currency;
+        }
+
+        if (frequency) {
+            updateRecord.Frequency__c = frequency;
+        }
+
+        if (category) {
+            updateRecord.Category__c = category;
+        }
+
+        if (sessionId) {
+            updateRecord.Session_ID__c = sessionId;
+        }
+
+        if (name) {
+            updateRecord.Name = name;
+        }
+
+        if (fullDescription) {
+            updateRecord.Description__c = fullDescription;
+        } else if (description) {
+            updateRecord.Description__c = description;
         }
 
         // Only proceed if we have at least one field to update
@@ -574,6 +635,20 @@ class SalesforceCrmService extends BaseCrmService {
                 const oppUpdateRecord = {};
                 if (stageName) {
                     oppUpdateRecord.StageName = stageName;
+                }
+
+                if (typeof amount === 'number') {
+                    oppUpdateRecord.Amount = amount / 100;
+                }
+
+                if (name) {
+                    oppUpdateRecord.Name = name;
+                }
+
+                if (fullDescription) {
+                    oppUpdateRecord.Description = fullDescription;
+                } else if (description) {
+                    oppUpdateRecord.Description = description;
                 }
 
                 const result = await this.conn.sobject('Opportunity').update({

--- a/services/crm/stripeTransactionUtils.js
+++ b/services/crm/stripeTransactionUtils.js
@@ -1,0 +1,216 @@
+'use strict';
+
+const STRIPE_STATUS_MAP = new Map([
+    ['succeeded', 'Completed'],
+    ['paid', 'Completed'],
+    ['processing', 'Processing'],
+    ['requires_capture', 'Pending'],
+    ['requires_payment_method', 'Pending'],
+    ['requires_action', 'Pending'],
+    ['requires_confirmation', 'Pending'],
+    ['requires_payment_intent', 'Pending'],
+    ['requires_source', 'Pending'],
+    ['requires_source_action', 'Pending'],
+    ['requires_customer_action', 'Pending'],
+    ['pending', 'Pending'],
+    ['open', 'Pending'],
+    ['complete', 'Pending'],
+    ['canceled', 'Canceled'],
+    ['cancelled', 'Canceled'],
+    ['failed', 'Failed'],
+    ['unpaid', 'Failed'],
+    ['refunded', 'Failed'],
+    ['partially_refunded', 'Processing'],
+    ['expired', 'Failed']
+]);
+
+const assignIfPresent = (target, key, value) => {
+    if (value === undefined || value === null) {
+        return;
+    }
+
+    if (typeof value === 'string') {
+        const trimmed = value.trim();
+        if (!trimmed) {
+            return;
+        }
+        target[key] = trimmed;
+        return;
+    }
+
+    if (Array.isArray(value) && value.length === 0) {
+        return;
+    }
+
+    if (typeof value === 'object') {
+        if (Object.keys(value).length === 0) {
+            return;
+        }
+    }
+
+    target[key] = value;
+};
+
+const sanitizeStripeValue = (value, seen = new WeakSet()) => {
+    if (value === null || value === undefined) {
+        return value;
+    }
+
+    const valueType = typeof value;
+
+    if (valueType === 'string' || valueType === 'number' || valueType === 'boolean') {
+        return value;
+    }
+
+    if (value instanceof Date) {
+        return value.toISOString();
+    }
+
+    if (valueType === 'function') {
+        return undefined;
+    }
+
+    if (Array.isArray(value)) {
+        return value
+            .map(item => sanitizeStripeValue(item, seen))
+            .filter(item => item !== undefined);
+    }
+
+    if (valueType === 'object') {
+        if (seen.has(value)) {
+            return '[Circular]';
+        }
+
+        seen.add(value);
+        const sanitized = {};
+
+        for (const [key, entryValue] of Object.entries(value)) {
+            if (typeof entryValue === 'function') {
+                continue;
+            }
+
+            if (key === 'last_response') {
+                continue;
+            }
+
+            const sanitizedEntry = sanitizeStripeValue(entryValue, seen);
+            if (sanitizedEntry !== undefined) {
+                sanitized[key] = sanitizedEntry;
+            }
+        }
+
+        seen.delete(value);
+        return sanitized;
+    }
+
+    return undefined;
+};
+
+const normalizeStripeStatus = (status) => {
+    if (!status) {
+        return null;
+    }
+
+    return String(status).toLowerCase();
+};
+
+const mapStripeStatusToCrmStatus = (stripeStatus, defaultStatus = 'Pending') => {
+    const normalized = normalizeStripeStatus(stripeStatus);
+
+    if (!normalized) {
+        return defaultStatus;
+    }
+
+    return STRIPE_STATUS_MAP.get(normalized) || defaultStatus;
+};
+
+const buildStripeTransactionDetails = (stripeObject, context = {}) => {
+    if (!stripeObject || typeof stripeObject !== 'object') {
+        return null;
+    }
+
+    const sanitizedStripeObject = sanitizeStripeValue(stripeObject);
+    const summary = {};
+
+    assignIfPresent(summary, 'id', stripeObject.id);
+    assignIfPresent(summary, 'object', stripeObject.object);
+
+    const status = stripeObject.status || stripeObject.payment_status;
+    assignIfPresent(summary, 'status', status);
+
+    if (typeof stripeObject.amount === 'number') {
+        assignIfPresent(summary, 'amount', stripeObject.amount);
+    }
+
+    if (typeof stripeObject.amount_received === 'number') {
+        assignIfPresent(summary, 'amount_received', stripeObject.amount_received);
+    }
+
+    if (typeof stripeObject.amount_capturable === 'number') {
+        assignIfPresent(summary, 'amount_capturable', stripeObject.amount_capturable);
+    }
+
+    if (typeof stripeObject.amount_total === 'number') {
+        assignIfPresent(summary, 'amount_total', stripeObject.amount_total);
+    }
+
+    if (typeof stripeObject.amount_subtotal === 'number') {
+        assignIfPresent(summary, 'amount_subtotal', stripeObject.amount_subtotal);
+    }
+
+    assignIfPresent(summary, 'currency', stripeObject.currency || stripeObject.default_currency);
+    assignIfPresent(summary, 'payment_status', stripeObject.payment_status);
+    assignIfPresent(summary, 'livemode', stripeObject.livemode);
+    assignIfPresent(summary, 'customer', stripeObject.customer || stripeObject.customer_details?.id || stripeObject.customer_details?.customer);
+    assignIfPresent(summary, 'payment_intent', stripeObject.payment_intent);
+    assignIfPresent(summary, 'subscription', stripeObject.subscription);
+    assignIfPresent(summary, 'latest_charge', stripeObject.latest_charge);
+    assignIfPresent(summary, 'invoice', stripeObject.invoice);
+    assignIfPresent(summary, 'created', stripeObject.created ? new Date(stripeObject.created * 1000).toISOString() : undefined);
+
+    if (Array.isArray(stripeObject.payment_method_types) && stripeObject.payment_method_types.length > 0) {
+        assignIfPresent(summary, 'payment_method_types', stripeObject.payment_method_types);
+    }
+
+    assignIfPresent(summary, 'payment_method', stripeObject.payment_method);
+    assignIfPresent(summary, 'description', stripeObject.description);
+
+    if (sanitizedStripeObject?.metadata && Object.keys(sanitizedStripeObject.metadata).length > 0) {
+        assignIfPresent(summary, 'metadata', sanitizedStripeObject.metadata);
+    }
+
+    if (sanitizedStripeObject?.status_transitions && Object.keys(sanitizedStripeObject.status_transitions).length > 0) {
+        assignIfPresent(summary, 'status_transitions', sanitizedStripeObject.status_transitions);
+    }
+
+    const eventDetails = {};
+    assignIfPresent(eventDetails, 'type', context.eventType);
+    assignIfPresent(eventDetails, 'id', context.eventId);
+    assignIfPresent(eventDetails, 'livemode', context.livemode);
+    assignIfPresent(eventDetails, 'account', context.accountId);
+    assignIfPresent(eventDetails, 'source', context.source);
+
+    if (context.eventCreated) {
+        const createdDate = typeof context.eventCreated === 'number'
+            ? new Date(context.eventCreated * 1000).toISOString()
+            : context.eventCreated;
+        assignIfPresent(eventDetails, 'created', createdDate);
+    }
+
+    const details = {
+        summary
+    };
+
+    if (Object.keys(eventDetails).length > 0) {
+        details.event = eventDetails;
+    }
+
+    assignIfPresent(details, 'stripeObject', sanitizedStripeObject);
+
+    return details;
+};
+
+module.exports = {
+    mapStripeStatusToCrmStatus,
+    buildStripeTransactionDetails
+};

--- a/stripeWebhook/index.js
+++ b/stripeWebhook/index.js
@@ -1,5 +1,6 @@
 const Stripe = require('stripe');
 const CrmFactory = require('../services/crm/crmFactory');
+const { mapStripeStatusToCrmStatus, buildStripeTransactionDetails } = require('../services/crm/stripeTransactionUtils');
 const { ContactMatcher } = require('../services/contactMatcher');
 const ReviewTaskService = require('../services/reviewTaskService');
 const IdempotencyService = require('../services/idempotencyService');
@@ -189,7 +190,7 @@ const verifyWebhookSignature = (payload, signature, endpointSecret) => {
 };
 
 // Process payment success and integrate with CRM
-const processPaymentSuccess = async (context, paymentIntent) => {
+const processPaymentSuccess = async (context, paymentIntent, eventContext = {}) => {
     // Extract customer information from payment intent first
     const customerId = paymentIntent.customer;
     if (!customerId) {
@@ -205,6 +206,21 @@ const processPaymentSuccess = async (context, paymentIntent) => {
         context.log(`Customer not found: ${customerId}`);
         return;
     }
+
+    const stripeDetails = buildStripeTransactionDetails(paymentIntent, {
+        ...eventContext,
+        source: eventContext.source || eventContext.eventType || 'payment_intent'
+    }) || {};
+
+    const stripeStatus = stripeDetails?.summary?.status || paymentIntent.status;
+    const crmStatus = mapStripeStatusToCrmStatus(stripeStatus, 'Completed');
+    const amountAuthorized = typeof paymentIntent.amount === 'number' ? paymentIntent.amount : null;
+    const amountReceived = typeof paymentIntent.amount_received === 'number'
+        ? paymentIntent.amount_received
+        : null;
+    const amountCapturable = typeof paymentIntent.amount_capturable === 'number'
+        ? paymentIntent.amount_capturable
+        : null;
 
     context.log(`Processing payment for customer: ${customer.name || 'Unknown'} (${customer.email})`);
 
@@ -294,6 +310,52 @@ const processPaymentSuccess = async (context, paymentIntent) => {
         const contactMatcher = new ContactMatcher(matchingConfig);
         const reviewTaskService = new ReviewTaskService(crmService, matchingConfig.review);
 
+        const resolvedAmount = typeof amountReceived === 'number' && amountReceived > 0
+            ? amountReceived
+            : (amountAuthorized !== null ? amountAuthorized : transactionData.amount);
+
+        const normalizedCategory = normalizeTransactionCategory(transactionData.category, matchingConfig);
+
+        const amountForName = typeof resolvedAmount === 'number'
+            ? resolvedAmount
+            : (typeof transactionData.amount === 'number' ? transactionData.amount : 0);
+
+        const transactionName = generateTransactionName(normalizedCategory, matchingConfig, {
+            amount: `$${(amountForName / 100).toFixed(2)}`,
+            date: new Date().toLocaleDateString(),
+            id: paymentIntent.id
+        });
+
+        const buildTransactionPayload = (sessionIdValue = null) => {
+            const payload = {
+                status: crmStatus,
+                paymentMethod: determinePaymentMethod(paymentIntent),
+                transactionId: paymentIntent.id,
+                amount: resolvedAmount,
+                amountAuthorized,
+                amountReceived,
+                amountCapturable,
+                currency: paymentIntent.currency,
+                description: transactionName,
+                frequency: transactionData.frequency,
+                category: normalizedCategory,
+                name: transactionName,
+                stripeStatus,
+                stripeDetails,
+                applicationFeeAmount: paymentIntent.application_fee_amount,
+                transferData: paymentIntent.transfer_data,
+                stripeCustomerId: paymentIntent.customer,
+                invoiceId: paymentIntent.invoice,
+                latestChargeId: paymentIntent.latest_charge
+            };
+
+            if (sessionIdValue) {
+                payload.sessionId = sessionIdValue;
+            }
+
+            return payload;
+        };
+
         // Early idempotency check - if this transaction was already processed, skip everything
         const idempotencyKey = idempotencyService.generateKey(transactionData);
         const existingResult = idempotencyService.getProcessedResult(idempotencyKey);
@@ -324,16 +386,15 @@ const processPaymentSuccess = async (context, paymentIntent) => {
                 const isPending = existingTransaction.Status__c === 'Pending' || existingTransaction.StageName === 'Pending';
                 
                 if (isPending) {
-                    context.log(`Transaction ${existingTransaction.Id} is in Pending status, updating to Completed`);
-                    
-                    // Update the pending transaction to completed
-                    const updatedTransaction = await crmService.updateTransaction(existingTransaction.Id, {
-                        status: 'Completed',
-                        paymentMethod: determinePaymentMethod(paymentIntent),
-                        transactionId: paymentIntent.id
-                    });
-                    
-                    context.log(`Updated transaction ${updatedTransaction.Id || 'N/A'} to completed status`);
+                    context.log(`Transaction ${existingTransaction.Id} is in Pending status, updating to ${crmStatus}`);
+
+                    // Update the pending transaction to match the latest Stripe data
+                    const updatedTransaction = await crmService.updateTransaction(
+                        existingTransaction.Id,
+                        buildTransactionPayload(existingTransaction.Session_ID__c || null)
+                    );
+
+                    context.log(`Updated transaction ${updatedTransaction.Id || 'N/A'} to ${crmStatus} status`);
                     
                     // Record metrics and exit
                     metricsService.recordDecision({ action: 'update', reason: 'pending_transaction_completed' }, 0, false);
@@ -402,14 +463,13 @@ const processPaymentSuccess = async (context, paymentIntent) => {
                 if (pendingTransaction) {
                     context.log(`Found pending transaction: ${pendingTransaction.Id} (attempt ${attempt + 1}/${maxRetries + 1}), will update to completed`);
                     
-                    // Update the pending transaction to completed
-                    const updatedTransaction = await crmService.updateTransaction(pendingTransaction.Id, {
-                        status: 'Completed',
-                        paymentMethod: determinePaymentMethod(paymentIntent),
-                        transactionId: paymentIntent.id
-                    });
-                    
-                    context.log(`Updated transaction ${updatedTransaction.Id || 'N/A'} to completed status`);
+                    // Update the pending transaction to reflect the latest Stripe state
+                    const updatedTransaction = await crmService.updateTransaction(
+                        pendingTransaction.Id,
+                        buildTransactionPayload(checkoutSessionId || pendingTransaction.Session_ID__c || null)
+                    );
+
+                    context.log(`Updated transaction ${updatedTransaction.Id || 'N/A'} to ${crmStatus} status`);
                     
                     // Record metrics and exit early
                     metricsService.recordDecision({ action: 'update', reason: 'pending_transaction_completed' }, 0, false);
@@ -522,31 +582,8 @@ const processPaymentSuccess = async (context, paymentIntent) => {
         }
 
         if (contact) {
-            // Normalize category and generate proper transaction name
-            const normalizedCategory = normalizeTransactionCategory(transactionData.category, matchingConfig);
-            const transactionName = generateTransactionName(normalizedCategory, matchingConfig, {
-                amount: `$${(paymentIntent.amount / 100).toFixed(2)}`,
-                date: new Date().toLocaleDateString(),
-                id: paymentIntent.id
-            });
-
             // Create transaction record with proper naming (no duplicate task needed)
-            const enhancedTransactionData = {
-                amount: paymentIntent.amount,
-                currency: paymentIntent.currency,
-                paymentMethod: determinePaymentMethod(paymentIntent),
-                transactionId: paymentIntent.id,
-                status: 'Completed',
-                description: transactionName, // Use new naming format
-                frequency: transactionData.frequency,
-                category: normalizedCategory,
-                name: transactionName // Explicit name field
-            };
-
-            // Include sessionId if we found one (for duplicate prevention)
-            if (checkoutSessionId) {
-                enhancedTransactionData.sessionId = checkoutSessionId;
-            }
+            const enhancedTransactionData = buildTransactionPayload(checkoutSessionId || null);
 
             const transaction = await crmService.createTransaction(contact.Id, enhancedTransactionData);
             context.log(`Created transaction: ${transaction.Id || 'N/A'} with name: ${transactionName}`);
@@ -683,7 +720,7 @@ const determinePaymentMethod = (paymentIntent) => {
 };
 
 // Helper function to prepare transaction data from checkout session
-const prepareTransactionDataFromSession = async (context, session, stripe, matchingConfig) => {
+const prepareTransactionDataFromSession = async (context, session, stripe, matchingConfig, eventContext = {}) => {
     // Extract customer information
     const customerId = session.customer;
     if (!customerId) {
@@ -728,11 +765,17 @@ const prepareTransactionDataFromSession = async (context, session, stripe, match
         id: session.id
     });
 
+    const stripeDetails = buildStripeTransactionDetails(session, {
+        ...eventContext,
+        source: eventContext.source || eventContext.eventType || 'checkout.session'
+    }) || {};
+
     return {
         transactionData,
         customer,
         normalizedCategory,
-        transactionName
+        transactionName,
+        stripeDetails
     };
 };
 
@@ -774,7 +817,7 @@ const extractProductName = async (stripe, paymentIntent) => {
 };
 
 // Process checkout session completed event
-const processCheckoutSessionCompleted = async (context, session) => {
+const processCheckoutSessionCompleted = async (context, session, eventContext = {}) => {
     try {
         context.log(`Processing checkout session completed: ${session.id}`);
         
@@ -831,8 +874,14 @@ const processCheckoutSessionCompleted = async (context, session) => {
                 }
 
                 // Prepare transaction data from session
-                const { transactionData, customer, normalizedCategory, transactionName } = 
-                    await prepareTransactionDataFromSession(context, expandedSession, stripe, matchingConfig);
+                const { transactionData, customer, normalizedCategory, transactionName, stripeDetails } =
+                    await prepareTransactionDataFromSession(
+                        context,
+                        expandedSession,
+                        stripe,
+                        matchingConfig,
+                        eventContext
+                    );
 
                 // Process contact matching
                 const result = await contactMatcher.processMatch(transactionData, async (normalized) => {
@@ -877,18 +926,44 @@ const processCheckoutSessionCompleted = async (context, session) => {
 
                 if (contact) {
                     // Create pending transaction with session information
+                    const pendingStripeStatus = stripeDetails?.summary?.payment_status ||
+                        stripeDetails?.summary?.status || session.payment_status || session.status || 'pending';
+                    const pendingCrmStatus = mapStripeStatusToCrmStatus(pendingStripeStatus, 'Pending');
+
                     const pendingTransactionData = {
                         amount: transactionData.amount,
                         currency: transactionData.currency,
                         paymentMethod: 'Pending', // Will be updated when payment completes
                         transactionId: session.payment_intent, // Store payment intent ID for lookup
                         sessionId: session.id, // Store session ID for lookup
-                        status: 'Pending',
+                        status: pendingCrmStatus,
+                        stripeStatus: pendingStripeStatus,
                         description: transactionName,
                         frequency: transactionData.frequency,
                         category: normalizedCategory,
-                        name: transactionName
+                        name: transactionName,
+                        stripeDetails
                     };
+
+                    if (typeof stripeDetails?.summary?.amount_total === 'number') {
+                        pendingTransactionData.amountTotal = stripeDetails.summary.amount_total;
+                    }
+
+                    if (typeof stripeDetails?.summary?.amount === 'number' && pendingTransactionData.amount === undefined) {
+                        pendingTransactionData.amount = stripeDetails.summary.amount;
+                    }
+
+                    if (typeof stripeDetails?.summary?.amount_subtotal === 'number') {
+                        pendingTransactionData.amountSubtotal = stripeDetails.summary.amount_subtotal;
+                    }
+
+                    if (session.mode) {
+                        pendingTransactionData.checkoutMode = session.mode;
+                    }
+
+                    if (session.subscription) {
+                        pendingTransactionData.subscriptionId = session.subscription;
+                    }
 
                     const transaction = await crmService.createTransaction(contact.Id, pendingTransactionData);
                     context.log(`Created pending transaction: ${transaction.Id || 'N/A'} with name: ${transactionName}`);
@@ -914,7 +989,16 @@ const processCheckoutSessionCompleted = async (context, session) => {
                 const invoice = await stripe.invoices.retrieve(subscription.latest_invoice);
                 if (invoice.payment_intent) {
                     const paymentIntent = await stripe.paymentIntents.retrieve(invoice.payment_intent);
-                    await processPaymentSuccess(context, paymentIntent);
+                    const subscriptionEventContext = {
+                        ...eventContext,
+                        eventType: 'subscription.initial_payment',
+                        eventId: invoice.id || eventContext.eventId,
+                        eventCreated: typeof invoice.created !== 'undefined' ? invoice.created : eventContext.eventCreated,
+                        livemode: typeof invoice.livemode === 'boolean' ? invoice.livemode : eventContext.livemode,
+                        source: 'checkout.session.completed.subscription'
+                    };
+
+                    await processPaymentSuccess(context, paymentIntent, subscriptionEventContext);
                 }
             }
         } else {
@@ -1252,7 +1336,14 @@ module.exports = async function (context, req) {
         // Handle different event types
         switch (event.type) {
             case 'payment_intent.succeeded':
-                await processPaymentSuccess(context, event.data.object);
+                await processPaymentSuccess(context, event.data.object, {
+                    eventType: event.type,
+                    eventId: event.id,
+                    eventCreated: event.created,
+                    livemode: event.livemode,
+                    accountId: stripeAccountId,
+                    source: event.type
+                });
                 break;
 
             case 'payment_intent.payment_failed':
@@ -1264,7 +1355,14 @@ module.exports = async function (context, req) {
                 break;
 
             case 'checkout.session.completed':
-                await processCheckoutSessionCompleted(context, event.data.object);
+                await processCheckoutSessionCompleted(context, event.data.object, {
+                    eventType: event.type,
+                    eventId: event.id,
+                    eventCreated: event.created,
+                    livemode: event.livemode,
+                    accountId: stripeAccountId,
+                    source: event.type
+                });
                 break;
 
             case 'invoice.payment_succeeded':
@@ -1273,7 +1371,14 @@ module.exports = async function (context, req) {
                 if (invoice.payment_intent) {
                     const stripe = initializeStripe(event.livemode);
                     const paymentIntent = await stripe.paymentIntents.retrieve(invoice.payment_intent);
-                    await processPaymentSuccess(context, paymentIntent);
+                    await processPaymentSuccess(context, paymentIntent, {
+                        eventType: event.type,
+                        eventId: event.id,
+                        eventCreated: event.created,
+                        livemode: event.livemode,
+                        accountId: stripeAccountId,
+                        source: event.type
+                    });
                 }
                 break;
 


### PR DESCRIPTION
## Summary
- add Stripe transaction utility helpers to normalize statuses and build detailed CRM payloads
- enrich checkout session handling to carry Stripe metadata, statuses, and raw details into CRM transactions
- update Salesforce CRM transaction description and update paths to capture the expanded Stripe data set

## Testing
- node tests/transactionCreationFlow.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e3118c7bd0832ca247031ce7032c28