### PR TITLE
Ensure webhook updates CRM transaction description

### DIFF
--- a/services/crm/salesforceCrm.js
+++ b/services/crm/salesforceCrm.js
@@ -510,28 +510,73 @@ class SalesforceCrmService extends BaseCrmService {
      * @param {Object} transactionData - Transaction information to update
      * @returns {Promise<Object>} Updated transaction object
      */
-    async updateTransaction(transactionId, transactionData) {
+    async updateTransaction(transactionId, transactionData = {}) {
         await this.connect();
 
-        const { 
+        const {
             status,
             paymentMethod,
-            transactionId: stripeTransactionId
+            transactionId: stripeTransactionId,
+            amount,
+            currency,
+            description,
+            frequency,
+            category,
+            name,
+            sessionId
         } = transactionData;
 
         // Build update record with only provided fields
         const updateRecord = {};
-        
+
         if (status !== undefined) {
             updateRecord.Status__c = status;
         }
-        
+
         if (paymentMethod !== undefined) {
             updateRecord.Payment_Method__c = paymentMethod;
         }
 
         if (stripeTransactionId !== undefined) {
             updateRecord.Transaction_ID__c = stripeTransactionId;
+        }
+
+        if (typeof amount === 'number') {
+            updateRecord.Amount__c = amount / 100;
+        }
+
+        if (currency) {
+            updateRecord.Currency__c = currency.toUpperCase();
+        }
+
+        if (frequency) {
+            updateRecord.Frequency__c = frequency;
+        }
+
+        if (category) {
+            updateRecord.Category__c = category;
+        }
+
+        if (sessionId) {
+            updateRecord.Session_ID__c = sessionId;
+        }
+
+        if (name || description) {
+            updateRecord.Name = name || description;
+        }
+
+        const descriptionKeys = ['description', 'name', 'amount', 'currency', 'frequency', 'category', 'sessionId'];
+        const hasDescriptionFields = descriptionKeys.some((key) => {
+            const value = transactionData[key];
+            return value !== undefined && value !== null && value !== '';
+        });
+
+        let fullDescription = '';
+        if (hasDescriptionFields) {
+            fullDescription = this.buildTransactionDescription(transactionData);
+            if (fullDescription) {
+                updateRecord.Description__c = fullDescription;
+            }
         }
 
         // Only proceed if we have at least one field to update
@@ -546,7 +591,7 @@ class SalesforceCrmService extends BaseCrmService {
                 Id: transactionId,
                 ...updateRecord
             });
-            
+
             if (result.success) {
                 console.log(`Updated Salesforce transaction ${transactionId} with status: ${status}`);
                 const updatedTransaction = await this.conn.sobject('Transaction__c').retrieve(transactionId);
@@ -556,19 +601,20 @@ class SalesforceCrmService extends BaseCrmService {
             }
         } catch (error) {
             console.log('Custom Transaction object not available, trying Opportunity');
-            
+
             // Fallback to Opportunity record
             try {
                 // Map status to Opportunity StageName
-                let stageName = updateRecord.Status__c;
-                if (stageName === 'Completed') {
-                    stageName = 'Closed Won';
-                } else if (stageName === 'Pending') {
-                    stageName = 'Prospecting';
-                } else if (stageName === 'Failed') {
-                    stageName = 'Closed Lost';
-                } else if (stageName === 'Canceled') {
-                    stageName = 'Closed Lost';
+                let stageName = null;
+                if (status !== undefined) {
+                    stageName = status;
+                    if (stageName === 'Completed') {
+                        stageName = 'Closed Won';
+                    } else if (stageName === 'Pending') {
+                        stageName = 'Prospecting';
+                    } else if (stageName === 'Failed' || stageName === 'Canceled') {
+                        stageName = 'Closed Lost';
+                    }
                 }
 
                 const oppUpdateRecord = {};
@@ -576,11 +622,32 @@ class SalesforceCrmService extends BaseCrmService {
                     oppUpdateRecord.StageName = stageName;
                 }
 
+                if (typeof amount === 'number') {
+                    oppUpdateRecord.Amount = amount / 100;
+                }
+
+                if (name || description) {
+                    oppUpdateRecord.Name = name || description;
+                }
+
+                if (currency) {
+                    oppUpdateRecord.CurrencyIsoCode = currency.toUpperCase();
+                }
+
+                if (hasDescriptionFields && fullDescription) {
+                    oppUpdateRecord.Description = fullDescription;
+                }
+
+                if (Object.keys(oppUpdateRecord).length === 0) {
+                    console.log('No opportunity data to update');
+                    return null;
+                }
+
                 const result = await this.conn.sobject('Opportunity').update({
                     Id: transactionId,
                     ...oppUpdateRecord
                 });
-                
+
                 if (result.success) {
                     console.log(`Updated Salesforce opportunity ${transactionId}`);
                     const updatedOpportunity = await this.conn.sobject('Opportunity').retrieve(transactionId);

--- a/stripeWebhook/index.js
+++ b/stripeWebhook/index.js
@@ -316,25 +316,45 @@ const processPaymentSuccess = async (context, paymentIntent) => {
             }
             
             existingTransaction = await crmService.findTransactionByStripeId(paymentIntent.id);
-            
+
             if (existingTransaction) {
                 context.log(`Transaction ${paymentIntent.id} already exists in CRM: ${existingTransaction.Id} (found on attempt ${attempt + 1}/${maxRetries + 1})`);
-                
+
                 // Check if the existing transaction is in Pending status
                 const isPending = existingTransaction.Status__c === 'Pending' || existingTransaction.StageName === 'Pending';
-                
+
                 if (isPending) {
                     context.log(`Transaction ${existingTransaction.Id} is in Pending status, updating to Completed`);
-                    
-                    // Update the pending transaction to completed
-                    const updatedTransaction = await crmService.updateTransaction(existingTransaction.Id, {
+
+                    const normalizedCategory = normalizeTransactionCategory(transactionData.category, matchingConfig);
+                    const transactionName = generateTransactionName(normalizedCategory, matchingConfig, {
+                        amount: `$${(paymentIntent.amount / 100).toFixed(2)}`,
+                        date: new Date().toLocaleDateString(),
+                        id: paymentIntent.id
+                    });
+
+                    const updatePayload = {
                         status: 'Completed',
                         paymentMethod: determinePaymentMethod(paymentIntent),
-                        transactionId: paymentIntent.id
-                    });
-                    
+                        transactionId: paymentIntent.id,
+                        amount: paymentIntent.amount,
+                        currency: paymentIntent.currency,
+                        frequency: transactionData.frequency,
+                        category: normalizedCategory,
+                        description: transactionName,
+                        name: transactionName
+                    };
+
+                    const existingSessionId = existingTransaction.Session_ID__c || existingTransaction.SessionId;
+                    if (existingSessionId) {
+                        updatePayload.sessionId = existingSessionId;
+                    }
+
+                    // Update the pending transaction to completed
+                    const updatedTransaction = await crmService.updateTransaction(existingTransaction.Id, updatePayload);
+
                     context.log(`Updated transaction ${updatedTransaction.Id || 'N/A'} to completed status`);
-                    
+
                     // Record metrics and exit
                     metricsService.recordDecision({ action: 'update', reason: 'pending_transaction_completed' }, 0, false);
                     context.log('CRM integration completed successfully - updated pending transaction');
@@ -401,16 +421,36 @@ const processPaymentSuccess = async (context, paymentIntent) => {
                 
                 if (pendingTransaction) {
                     context.log(`Found pending transaction: ${pendingTransaction.Id} (attempt ${attempt + 1}/${maxRetries + 1}), will update to completed`);
-                    
-                    // Update the pending transaction to completed
-                    const updatedTransaction = await crmService.updateTransaction(pendingTransaction.Id, {
+
+                    const normalizedCategory = normalizeTransactionCategory(transactionData.category, matchingConfig);
+                    const transactionName = generateTransactionName(normalizedCategory, matchingConfig, {
+                        amount: `$${(paymentIntent.amount / 100).toFixed(2)}`,
+                        date: new Date().toLocaleDateString(),
+                        id: paymentIntent.id
+                    });
+
+                    const updatePayload = {
                         status: 'Completed',
                         paymentMethod: determinePaymentMethod(paymentIntent),
-                        transactionId: paymentIntent.id
-                    });
-                    
+                        transactionId: paymentIntent.id,
+                        amount: paymentIntent.amount,
+                        currency: paymentIntent.currency,
+                        frequency: transactionData.frequency,
+                        category: normalizedCategory,
+                        description: transactionName,
+                        name: transactionName
+                    };
+
+                    const sessionId = pendingTransaction.Session_ID__c || pendingTransaction.SessionId || checkoutSessionId;
+                    if (sessionId) {
+                        updatePayload.sessionId = sessionId;
+                    }
+
+                    // Update the pending transaction to completed
+                    const updatedTransaction = await crmService.updateTransaction(pendingTransaction.Id, updatePayload);
+
                     context.log(`Updated transaction ${updatedTransaction.Id || 'N/A'} to completed status`);
-                    
+
                     // Record metrics and exit early
                     metricsService.recordDecision({ action: 'update', reason: 'pending_transaction_completed' }, 0, false);
                     context.log('CRM integration completed successfully - updated pending transaction');

--- a/tests/failedCanceledTransactions.test.js
+++ b/tests/failedCanceledTransactions.test.js
@@ -37,6 +37,15 @@ class MockCrmService {
             Status__c: transactionData.status,
             Payment_Method__c: transactionData.paymentMethod
         };
+        if (transactionData.description) {
+            transaction.Description__c = transactionData.description;
+        }
+        if (transactionData.frequency) {
+            transaction.Frequency__c = transactionData.frequency;
+        }
+        if (transactionData.currency) {
+            transaction.Currency__c = transactionData.currency.toUpperCase();
+        }
         this.transactions.push(transaction);
         return transaction;
     }
@@ -46,7 +55,9 @@ class MockCrmService {
         if (!transaction) {
             throw new Error(`Transaction not found: ${transactionId}`);
         }
-        
+
+        transaction.LastUpdatePayload = { ...transactionData };
+
         if (transactionData.status) {
             transaction.Status__c = transactionData.status;
         }
@@ -56,7 +67,28 @@ class MockCrmService {
         if (transactionData.transactionId) {
             transaction.Transaction_ID__c = transactionData.transactionId;
         }
-        
+        if (typeof transactionData.amount === 'number') {
+            transaction.Amount__c = transactionData.amount / 100;
+        }
+        if (transactionData.currency) {
+            transaction.Currency__c = transactionData.currency.toUpperCase();
+        }
+        if (transactionData.description) {
+            transaction.Description__c = transactionData.description;
+        }
+        if (transactionData.name) {
+            transaction.Name = transactionData.name;
+        }
+        if (transactionData.frequency) {
+            transaction.Frequency__c = transactionData.frequency;
+        }
+        if (transactionData.category) {
+            transaction.Category__c = transactionData.category;
+        }
+        if (transactionData.sessionId) {
+            transaction.Session_ID__c = transactionData.sessionId;
+        }
+
         return transaction;
     }
 

--- a/tests/transactionCreationFlow.test.js
+++ b/tests/transactionCreationFlow.test.js
@@ -49,6 +49,15 @@ class MockCrmService {
             Status__c: transactionData.status,
             Payment_Method__c: transactionData.paymentMethod
         };
+        if (transactionData.description) {
+            transaction.Description__c = transactionData.description;
+        }
+        if (transactionData.frequency) {
+            transaction.Frequency__c = transactionData.frequency;
+        }
+        if (transactionData.currency) {
+            transaction.Currency__c = transactionData.currency.toUpperCase();
+        }
         this.transactions.push(transaction);
         return transaction;
     }
@@ -58,7 +67,9 @@ class MockCrmService {
         if (!transaction) {
             throw new Error(`Transaction not found: ${transactionId}`);
         }
-        
+
+        transaction.LastUpdatePayload = { ...transactionData };
+
         if (transactionData.status) {
             transaction.Status__c = transactionData.status;
         }
@@ -68,7 +79,28 @@ class MockCrmService {
         if (transactionData.transactionId) {
             transaction.Transaction_ID__c = transactionData.transactionId;
         }
-        
+        if (typeof transactionData.amount === 'number') {
+            transaction.Amount__c = transactionData.amount / 100;
+        }
+        if (transactionData.currency) {
+            transaction.Currency__c = transactionData.currency.toUpperCase();
+        }
+        if (transactionData.description) {
+            transaction.Description__c = transactionData.description;
+        }
+        if (transactionData.name) {
+            transaction.Name = transactionData.name;
+        }
+        if (transactionData.frequency) {
+            transaction.Frequency__c = transactionData.frequency;
+        }
+        if (transactionData.category) {
+            transaction.Category__c = transactionData.category;
+        }
+        if (transactionData.sessionId) {
+            transaction.Session_ID__c = transactionData.sessionId;
+        }
+
         return transaction;
     }
 
@@ -220,10 +252,18 @@ function runTransactionCreationTests() {
     // Test 3: payment_intent.succeeded updates pending transaction
     test('payment_intent.succeeded webhook updates pending transaction to completed', async () => {
         const crmService = new MockCrmService();
-        
+        const matchingConfig = loadConfig();
+
         const sessionId = 'cs_test_789';
         const paymentIntentId = 'pi_test_789';
-        
+        const category = 'General Fund';
+        const normalizedCategory = normalizeTransactionCategory(category, matchingConfig);
+        const transactionName = generateTransactionName(normalizedCategory, matchingConfig, {
+            amount: '$50.00',
+            date: new Date().toLocaleDateString(),
+            id: paymentIntentId
+        });
+
         // Create pending transaction (from processDonation)
         const pendingTransaction = {
             Id: 'a00789',
@@ -241,14 +281,21 @@ function runTransactionCreationTests() {
         if (!foundTransaction) {
             throw new Error('Expected to find pending transaction');
         }
-        
+
         // Update the transaction
         const updatedTransaction = await crmService.updateTransaction(foundTransaction.Id, {
             status: 'Completed',
             paymentMethod: 'Credit Card',
-            transactionId: paymentIntentId
+            transactionId: paymentIntentId,
+            amount: 5000,
+            currency: 'usd',
+            frequency: 'onetime',
+            category: normalizedCategory,
+            description: transactionName,
+            name: transactionName,
+            sessionId: sessionId
         });
-        
+
         // Verify update
         if (updatedTransaction.Status__c !== 'Completed') {
             throw new Error(`Expected status 'Completed', got '${updatedTransaction.Status__c}'`);
@@ -259,7 +306,31 @@ function runTransactionCreationTests() {
         if (updatedTransaction.Transaction_ID__c !== paymentIntentId) {
             throw new Error(`Expected transaction ID '${paymentIntentId}', got '${updatedTransaction.Transaction_ID__c}'`);
         }
-        
+        if (updatedTransaction.Name !== transactionName) {
+            throw new Error('Transaction name should be updated');
+        }
+        if (updatedTransaction.Description__c !== transactionName) {
+            throw new Error('Description should reflect updated details');
+        }
+        if (updatedTransaction.Amount__c !== 50) {
+            throw new Error(`Expected amount 50, got '${updatedTransaction.Amount__c}'`);
+        }
+        if (updatedTransaction.Currency__c !== 'USD') {
+            throw new Error(`Expected currency 'USD', got '${updatedTransaction.Currency__c}'`);
+        }
+        if (updatedTransaction.Frequency__c !== 'onetime') {
+            throw new Error(`Expected frequency 'onetime', got '${updatedTransaction.Frequency__c}'`);
+        }
+        if (updatedTransaction.Category__c !== normalizedCategory) {
+            throw new Error('Category should remain consistent');
+        }
+        if (updatedTransaction.Session_ID__c !== sessionId) {
+            throw new Error('Session ID should remain associated with transaction');
+        }
+        if (!updatedTransaction.LastUpdatePayload || updatedTransaction.LastUpdatePayload.description !== transactionName) {
+            throw new Error('Last update payload should track description details');
+        }
+
         // Verify still only one transaction
         if (crmService.transactions.length !== 1) {
             throw new Error(`Expected 1 transaction, got ${crmService.transactions.length}`);
@@ -320,19 +391,56 @@ function runTransactionCreationTests() {
         if (!txnToUpdate) {
             throw new Error('payment_intent.succeeded should find transaction by session ID');
         }
-        
+
+        const completedName = generateTransactionName(normalizedCategory, matchingConfig, {
+            amount: '$50.00',
+            date: new Date().toLocaleDateString(),
+            id: paymentIntentId
+        });
+
         const completedTxn = await crmService.updateTransaction(txnToUpdate.Id, {
             status: 'Completed',
             paymentMethod: 'Credit Card',
-            transactionId: paymentIntentId
+            transactionId: paymentIntentId,
+            amount: 5000,
+            currency: 'usd',
+            frequency: 'onetime',
+            category: normalizedCategory,
+            description: completedName,
+            name: completedName,
+            sessionId: sessionId
         });
-        
+
         // Verify final state
         if (completedTxn.Status__c !== 'Completed') {
             throw new Error(`Expected final status 'Completed', got '${completedTxn.Status__c}'`);
         }
         if (completedTxn.Transaction_ID__c !== paymentIntentId) {
             throw new Error(`Expected transaction ID '${paymentIntentId}', got '${completedTxn.Transaction_ID__c}'`);
+        }
+        if (completedTxn.Name !== completedName) {
+            throw new Error('Completed transaction name should match generated value');
+        }
+        if (completedTxn.Description__c !== completedName) {
+            throw new Error('Completed transaction description should be updated');
+        }
+        if (completedTxn.Amount__c !== 50) {
+            throw new Error(`Expected completed amount 50, got '${completedTxn.Amount__c}'`);
+        }
+        if (completedTxn.Currency__c !== 'USD') {
+            throw new Error(`Expected completed currency 'USD', got '${completedTxn.Currency__c}'`);
+        }
+        if (completedTxn.Frequency__c !== 'onetime') {
+            throw new Error(`Expected completed frequency 'onetime', got '${completedTxn.Frequency__c}'`);
+        }
+        if (completedTxn.Category__c !== normalizedCategory) {
+            throw new Error('Completed transaction category should remain consistent');
+        }
+        if (completedTxn.Session_ID__c !== sessionId) {
+            throw new Error('Completed transaction should retain session ID');
+        }
+        if (!completedTxn.LastUpdatePayload || completedTxn.LastUpdatePayload.description !== completedName) {
+            throw new Error('Completed transaction should record last update payload');
         }
         if (crmService.transactions.length !== 1) {
             throw new Error(`Expected exactly 1 transaction, got ${crmService.transactions.length}`);


### PR DESCRIPTION
## Summary
- update the Stripe webhook to send full transaction details when completing pending CRM records so the generated description is populated
- enhance the Salesforce CRM update flow to rebuild description, name, and supporting fields when new metadata is supplied
- expand transaction flow tests to cover enriched updates and adjust CRM mocks to track description payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e31fe1f210832c81c662032e1f906b