### PR TITLE
Add shared canonical types and document number helpers

### DIFF
--- a/src/services/shared/doc_numbers.ts
+++ b/src/services/shared/doc_numbers.ts
@@ -1,0 +1,33 @@
+const DEFAULT_DOCNUM_PREFIX = "stripe";
+
+const sanitizePart = (part: string): string => part.trim().replace(/\s+/g, "-");
+
+const getDocnumPrefix = (): string => {
+  const raw = process.env.DOCNUM_PREFIX ?? "";
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : DEFAULT_DOCNUM_PREFIX;
+};
+
+const formatDocnum = (type: string, ...parts: string[]): string => {
+  const sanitizedParts = parts.map((part) => sanitizePart(part));
+  return [getDocnumPrefix(), sanitizePart(type), ...sanitizedParts]
+    .filter((segment) => segment.length > 0)
+    .join("-");
+};
+
+export const docnum_salesreceipt = (chargeId: string): string =>
+  formatDocnum("salesreceipt", chargeId);
+
+export const docnum_refund = (refundId: string): string =>
+  formatDocnum("refund", refundId);
+
+export const docnum_fee_tx = (balanceTransactionId: string): string =>
+  formatDocnum("fee-tx", balanceTransactionId);
+
+export const docnum_fee_daily = (
+  yyyymmdd: string,
+  currency: string
+): string => formatDocnum("fee-daily", yyyymmdd, currency);
+
+export const docnum_payout = (payoutId: string): string =>
+  formatDocnum("payout", payoutId);

--- a/src/services/shared/types.ts
+++ b/src/services/shared/types.ts
@@ -1,5 +1,106 @@
+import { z } from "zod";
 import { Env } from "../../config/env";
 
 export interface ServiceContext {
   env: Env;
 }
+
+const isoDateTimeString = z.string().datetime({ offset: true });
+
+export const MoneySchema = z.object({
+  amount: z.number().int(),
+  currency: z.string().min(1),
+});
+
+export type Money = z.infer<typeof MoneySchema>;
+
+export const isMoney = (value: unknown): value is Money =>
+  MoneySchema.safeParse(value).success;
+
+export const PaymentSchema = z.object({
+  chargeId: z.string().min(1),
+  customerId: z.string().min(1).optional(),
+  invoiceId: z.string().min(1).optional(),
+  created: isoDateTimeString,
+  amount: MoneySchema,
+  net: MoneySchema.optional(),
+  fee: MoneySchema.optional(),
+  description: z.string().optional(),
+  metadata: z.record(z.string()).optional(),
+});
+
+export type Payment = z.infer<typeof PaymentSchema>;
+
+export const isPayment = (value: unknown): value is Payment =>
+  PaymentSchema.safeParse(value).success;
+
+export const RefundSchema = z.object({
+  refundId: z.string().min(1),
+  chargeId: z.string().min(1),
+  created: isoDateTimeString,
+  amount: MoneySchema,
+  status: z.string().min(1).optional(),
+  reason: z.string().optional(),
+  metadata: z.record(z.string()).optional(),
+});
+
+export type Refund = z.infer<typeof RefundSchema>;
+
+export const isRefund = (value: unknown): value is Refund =>
+  RefundSchema.safeParse(value).success;
+
+export const DisputeSchema = z.object({
+  disputeId: z.string().min(1),
+  chargeId: z.string().min(1),
+  created: isoDateTimeString,
+  amount: MoneySchema,
+  status: z.string().min(1),
+  reason: z.string().optional(),
+  evidenceDueBy: isoDateTimeString.optional(),
+  metadata: z.record(z.string()).optional(),
+});
+
+export type Dispute = z.infer<typeof DisputeSchema>;
+
+export const isDispute = (value: unknown): value is Dispute =>
+  DisputeSchema.safeParse(value).success;
+
+export const PayoutSchema = z.object({
+  payoutId: z.string().min(1),
+  amount: MoneySchema,
+  created: isoDateTimeString,
+  arrivalDate: isoDateTimeString,
+  status: z.string().min(1),
+  balanceTransactionId: z.string().min(1).optional(),
+  metadata: z.record(z.string()).optional(),
+});
+
+export type Payout = z.infer<typeof PayoutSchema>;
+
+export const isPayout = (value: unknown): value is Payout =>
+  PayoutSchema.safeParse(value).success;
+
+export const CanonicalInputSchema = z
+  .object({
+    payments: z.array(PaymentSchema).optional(),
+    refunds: z.array(RefundSchema).optional(),
+    disputes: z.array(DisputeSchema).optional(),
+    payouts: z.array(PayoutSchema).optional(),
+  })
+  .refine(
+    (value) =>
+      Boolean(
+        (value.payments && value.payments.length > 0) ||
+          (value.refunds && value.refunds.length > 0) ||
+          (value.disputes && value.disputes.length > 0) ||
+          (value.payouts && value.payouts.length > 0)
+      ),
+    {
+      message: "Canonical input must contain at least one record",
+    }
+  );
+
+export type CanonicalInput = z.infer<typeof CanonicalInputSchema>;
+
+export const isCanonicalInput = (value: unknown): value is CanonicalInput =>
+  CanonicalInputSchema.safeParse(value).success;

--- a/tests/unit/types.keys.spec.ts
+++ b/tests/unit/types.keys.spec.ts
@@ -1,0 +1,139 @@
+import { strict as assert } from "node:assert";
+import {
+  CanonicalInputSchema,
+  DisputeSchema,
+  MoneySchema,
+  PaymentSchema,
+  PayoutSchema,
+  RefundSchema,
+  isCanonicalInput,
+  isDispute,
+  isMoney,
+  isPayment,
+  isPayout,
+  isRefund,
+} from "../../src/services/shared/types";
+import {
+  docnum_fee_daily,
+  docnum_fee_tx,
+  docnum_payout,
+  docnum_refund,
+  docnum_salesreceipt,
+} from "../../src/services/shared/doc_numbers";
+
+const now = new Date().toISOString();
+
+const sampleMoney = { amount: 5000, currency: "usd" };
+
+const samplePayment = {
+  chargeId: "ch_12345",
+  customerId: "cus_54321",
+  invoiceId: "in_6789",
+  created: now,
+  amount: sampleMoney,
+  net: { amount: 4500, currency: "usd" },
+  fee: { amount: 500, currency: "usd" },
+  description: "Donation",
+  metadata: { campaign: "spring" },
+};
+
+const sampleRefund = {
+  refundId: "re_12345",
+  chargeId: "ch_12345",
+  created: now,
+  amount: { amount: 500, currency: "usd" },
+  status: "succeeded",
+  reason: "requested_by_customer",
+  metadata: { note: "Partial refund" },
+};
+
+const sampleDispute = {
+  disputeId: "dp_12345",
+  chargeId: "ch_12345",
+  created: now,
+  amount: { amount: 5000, currency: "usd" },
+  status: "warning_needs_response",
+  reason: "fraudulent",
+  evidenceDueBy: now,
+  metadata: { comment: "Investigating" },
+};
+
+const samplePayout = {
+  payoutId: "po_12345",
+  amount: { amount: 10000, currency: "usd" },
+  created: now,
+  arrivalDate: now,
+  status: "paid",
+  balanceTransactionId: "txn_12345",
+  metadata: { batch: "A1" },
+};
+
+const sampleCanonical = {
+  payments: [samplePayment],
+  refunds: [sampleRefund],
+  disputes: [sampleDispute],
+  payouts: [samplePayout],
+};
+
+assert.ok(isMoney(sampleMoney));
+assert.ok(!isMoney({ amount: 12.34, currency: "usd" }));
+assert.ok(MoneySchema.safeParse(sampleMoney).success);
+assert.ok(!MoneySchema.safeParse({ amount: "5000", currency: "usd" }).success);
+
+assert.ok(isPayment(samplePayment));
+assert.ok(!isPayment({ ...samplePayment, chargeId: "" }));
+assert.ok(PaymentSchema.safeParse(samplePayment).success);
+assert.ok(!PaymentSchema.safeParse({}).success);
+
+assert.ok(isRefund(sampleRefund));
+assert.ok(!isRefund({ ...sampleRefund, amount: { amount: 10.5, currency: "usd" } }));
+assert.ok(RefundSchema.safeParse(sampleRefund).success);
+assert.ok(!RefundSchema.safeParse({ refundId: "" }).success);
+
+assert.ok(isDispute(sampleDispute));
+assert.ok(!isDispute({ ...sampleDispute, status: "" }));
+assert.ok(DisputeSchema.safeParse(sampleDispute).success);
+assert.ok(!DisputeSchema.safeParse({ disputeId: "dp_1" }).success);
+
+assert.ok(isPayout(samplePayout));
+assert.ok(!isPayout({ ...samplePayout, payoutId: "" }));
+assert.ok(PayoutSchema.safeParse(samplePayout).success);
+assert.ok(!PayoutSchema.safeParse({ payoutId: "" }).success);
+
+assert.ok(isCanonicalInput(sampleCanonical));
+assert.ok(
+  !isCanonicalInput({
+    payments: [],
+    refunds: [],
+    disputes: [],
+    payouts: [],
+  })
+);
+assert.ok(CanonicalInputSchema.safeParse(sampleCanonical).success);
+assert.ok(!CanonicalInputSchema.safeParse({}).success);
+
+const originalPrefix = process.env.DOCNUM_PREFIX;
+process.env.DOCNUM_PREFIX = "donation";
+
+assert.equal(
+  docnum_salesreceipt("ch_12345"),
+  "donation-salesreceipt-ch_12345"
+);
+assert.equal(docnum_refund("re_12345"), "donation-refund-re_12345");
+assert.equal(docnum_fee_tx("txn_12345"), "donation-fee-tx-txn_12345");
+assert.equal(
+  docnum_fee_daily("20240102", "usd"),
+  "donation-fee-daily-20240102-usd"
+);
+assert.equal(docnum_payout("po_12345"), "donation-payout-po_12345");
+
+process.env.DOCNUM_PREFIX = "  ";
+assert.equal(docnum_payout("po_99999"), "stripe-payout-po_99999");
+
+if (originalPrefix === undefined) {
+  delete process.env.DOCNUM_PREFIX;
+} else {
+  process.env.DOCNUM_PREFIX = originalPrefix;
+}
+
+console.log("types.keys.spec.ts passed");


### PR DESCRIPTION
## Summary
- define canonical money, payment, refund, dispute, payout, and canonical input schemas with zod-based type guards
- add shared document number helpers for sales receipts, refunds, fees, and payouts
- cover the new helpers with unit tests validating schemas and document number formatting

## Testing
- npx ts-node --transpile-only tests/unit/types.keys.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e411d4c7ec832ca90c9f8494a52f39