### PR TITLE
Implement in-memory persistence for webhook idempotency ledger

### DIFF
--- a/src/services/persistence/repository.ts
+++ b/src/services/persistence/repository.ts
@@ -1,0 +1,95 @@
+export type LedgerStatus = "pending" | "posted" | "error";
+
+export interface WebhookEventRecord {
+  stripe_event_id: string;
+  created_at: Date;
+}
+
+export interface LedgerRecord {
+  entity_type: string;
+  entity_id: string;
+  system: string;
+  status: LedgerStatus;
+  doc_type?: string;
+  doc_id?: string;
+  error?: string;
+  created_at: Date;
+  updated_at: Date;
+}
+
+const webhookEvents = new Map<string, WebhookEventRecord>();
+const postingLedger = new Map<string, LedgerRecord>();
+
+const DEFAULT_SYSTEM = "payment-processor";
+
+const ledgerKey = (entityType: string, entityId: string): string =>
+  `${entityType}:${entityId}`;
+
+export const save_event_if_new = async (
+  eventId: string,
+): Promise<{ created: boolean; record?: WebhookEventRecord }> => {
+  const existing = webhookEvents.get(eventId);
+  if (existing) {
+    return { created: false, record: existing };
+  }
+  const record: WebhookEventRecord = {
+    stripe_event_id: eventId,
+    created_at: new Date(),
+  };
+  webhookEvents.set(eventId, record);
+  return { created: true, record };
+};
+
+export const saveLedgerAttempt = async (
+  entityType: string,
+  entityId: string,
+): Promise<LedgerRecord> => {
+  const key = ledgerKey(entityType, entityId);
+  const existing = postingLedger.get(key);
+  if (existing) {
+    return existing;
+  }
+  const now = new Date();
+  const record: LedgerRecord = {
+    entity_type: entityType,
+    entity_id: entityId,
+    system: DEFAULT_SYSTEM,
+    status: "pending",
+    created_at: now,
+    updated_at: now,
+  };
+  postingLedger.set(key, record);
+  return record;
+};
+
+export const finalizeLedger = async (
+  entityType: string,
+  entityId: string,
+  status: "posted" | "error",
+  errorMessage?: string,
+): Promise<LedgerRecord> => {
+  const key = ledgerKey(entityType, entityId);
+  const existing = postingLedger.get(key);
+  if (!existing) {
+    throw new Error(
+      `Cannot finalize ledger for unknown entity ${entityType}:${entityId}`,
+    );
+  }
+  existing.status = status;
+  existing.updated_at = new Date();
+  if (status === "error") {
+    existing.error = errorMessage ?? "Unknown error";
+  } else {
+    delete existing.error;
+  }
+  return existing;
+};
+
+export const __testing = {
+  reset: () => {
+    webhookEvents.clear();
+    postingLedger.clear();
+  },
+  getLedger: () => postingLedger,
+  getEvents: () => webhookEvents,
+};

--- a/src/services/process/idempotency.ts
+++ b/src/services/process/idempotency.ts
@@ -1,8 +1,52 @@
-import { ServiceContext } from "../shared/types";
+import { CanonicalInput, ServiceContext } from "../shared/types";
+import {
+  finalizeLedger,
+  saveLedgerAttempt,
+  save_event_if_new,
+} from "../persistence/repository";
+
+export interface EntityKey {
+  entityType: string;
+  entityId: string;
+}
+
+export const entityKey = (input: CanonicalInput): EntityKey => {
+  if (input.payments && input.payments.length > 0) {
+    return { entityType: "payment", entityId: input.payments[0].chargeId };
+  }
+  if (input.refunds && input.refunds.length > 0) {
+    return { entityType: "refund", entityId: input.refunds[0].refundId };
+  }
+  if (input.disputes && input.disputes.length > 0) {
+    return { entityType: "dispute", entityId: input.disputes[0].disputeId };
+  }
+  if (input.payouts && input.payouts.length > 0) {
+    return { entityType: "payout", entityId: input.payouts[0].payoutId };
+  }
+  throw new Error("Unable to determine entity key from canonical input");
+};
+
+export const withIdempotency = async <T>(
+  input: CanonicalInput,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  const { entityType, entityId } = entityKey(input);
+  await saveLedgerAttempt(entityType, entityId);
+  try {
+    const result = await fn();
+    await finalizeLedger(entityType, entityId, "posted");
+    return result;
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : JSON.stringify(error);
+    await finalizeLedger(entityType, entityId, "error", message);
+    throw error;
+  }
+};
 
 export const ensureIdempotency = async (
-  _key: string,
+  key: string,
   _context: ServiceContext,
 ): Promise<void> => {
-  // Idempotency enforcement placeholder implementation.
+  await save_event_if_new(key);
 };

--- a/tests/unit/ledger.spec.ts
+++ b/tests/unit/ledger.spec.ts
@@ -1,0 +1,53 @@
+import { strict as assert } from "node:assert";
+import {
+  __testing,
+  finalizeLedger,
+  saveLedgerAttempt,
+  save_event_if_new,
+} from "../../src/services/persistence/repository";
+
+const run = async () => {
+  __testing.reset();
+
+  const firstSave = await save_event_if_new("evt_123");
+  assert.equal(firstSave.created, true, "first event should be created");
+  const secondSave = await save_event_if_new("evt_123");
+  assert.equal(secondSave.created, false, "duplicate event should not insert");
+  assert.equal(__testing.getEvents().size, 1, "only one event stored");
+
+  __testing.reset();
+
+  const attempt = await saveLedgerAttempt("payment", "ch_123");
+  const initialUpdatedAt = attempt.updated_at;
+  assert.equal(attempt.status, "pending");
+  assert.equal(attempt.entity_type, "payment");
+  assert.equal(__testing.getLedger().size, 1);
+
+  const duplicateAttempt = await saveLedgerAttempt("payment", "ch_123");
+  assert.equal(__testing.getLedger().size, 1, "duplicate attempts should noop");
+  assert.strictEqual(
+    duplicateAttempt,
+    attempt,
+    "same record instance returned for duplicates",
+  );
+
+  const posted = await finalizeLedger("payment", "ch_123", "posted");
+  assert.equal(posted.status, "posted");
+  assert.equal(posted.error, undefined);
+  assert.ok(posted.updated_at >= initialUpdatedAt);
+
+  const postedUpdatedAt = posted.updated_at;
+  const errored = await finalizeLedger("payment", "ch_123", "error", "boom");
+  assert.equal(errored.status, "error");
+  assert.equal(errored.error, "boom");
+  assert.ok(errored.updated_at >= postedUpdatedAt);
+};
+
+run()
+  .then(() => {
+    console.log("ledger.spec.ts passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary
- add an in-memory persistence layer for webhook events and posting ledger attempts
- expose idempotency utilities that derive entity keys and wrap processing in ledger finalization
- add unit tests covering event uniqueness and ledger status transitions

## Testing
- npx ts-node tests/unit/ledger.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e415da2388832cbb5b4801a6b159fd