### PR TITLE
Implement Stripe event normalization pipeline

### DIFF
--- a/src/services/process/normalize.ts
+++ b/src/services/process/normalize.ts
@@ -1,14 +1,303 @@
-import { ServiceContext } from "../shared/types";
+import Stripe from "stripe";
+import {
+  CanonicalInput,
+  Payment,
+  Refund,
+  ServiceContext,
+} from "../shared/types";
 
-export interface NormalizedTransaction {
-  id: string;
-  raw: unknown;
-}
+type StripeClient = {
+  balanceTransactions: {
+    list: (
+      params: { source?: string | null; limit?: number },
+    ) => Promise<{ data: Stripe.BalanceTransaction[] }>;
+  };
+};
+
+type PaymentIntentWithCharges = Stripe.PaymentIntent & {
+  charges?: { data?: Stripe.Charge[] };
+};
+
+type BalanceSummary = NonNullable<Payment["balanceSummary"]>;
+type CardSnapshot = NonNullable<Payment["card"]>;
+
+const toMoney = (
+  amount: number | null | undefined,
+  currency: string | null | undefined,
+) => {
+  if (typeof amount !== "number" || !currency) {
+    return undefined;
+  }
+
+  return { amount, currency };
+};
+
+const toIsoDateTime = (timestamp: number | null | undefined) => {
+  if (!timestamp && timestamp !== 0) {
+    return undefined;
+  }
+
+  return new Date(timestamp * 1000).toISOString();
+};
+
+const mapMetadata = (metadata: Stripe.Metadata | null | undefined) => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const entries: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof value === "string") {
+      entries[key] = value;
+    }
+  }
+
+  return Object.keys(entries).length > 0 ? entries : undefined;
+};
+
+const extractCardSnapshot = (
+  charge: Stripe.Charge | null | undefined,
+): CardSnapshot | undefined => {
+  const details = charge?.payment_method_details;
+  if (!details || details.type !== "card") {
+    return undefined;
+  }
+
+  const card = details.card;
+  if (!card?.brand || !card?.last4) {
+    return undefined;
+  }
+
+  return {
+    brand: card.brand,
+    last4: card.last4,
+  };
+};
+
+const createBalanceSummary = (
+  transaction: Stripe.BalanceTransaction | undefined,
+): BalanceSummary | undefined => {
+  if (!transaction) {
+    return undefined;
+  }
+
+  const gross = toMoney(transaction.amount, transaction.currency);
+  const fee = toMoney(transaction.fee ?? 0, transaction.currency);
+  const net = toMoney(transaction.net, transaction.currency);
+
+  if (!gross || !fee || !net) {
+    return undefined;
+  }
+
+  return {
+    gross,
+    fee_total: fee,
+    net,
+    available_on: toIsoDateTime(transaction.available_on ?? undefined),
+  };
+};
+
+const getId = (value: unknown) => {
+  if (!value) {
+    return undefined;
+  }
+
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (typeof value === "object" && "id" in (value as Record<string, unknown>)) {
+    const id = (value as { id?: unknown }).id;
+    return typeof id === "string" ? id : undefined;
+  }
+
+  return undefined;
+};
+
+const findBalanceTransactionBySource = async (
+  stripe: StripeClient | null | undefined,
+  source: string | null | undefined,
+) => {
+  if (!stripe || !stripe.balanceTransactions || !source) {
+    return undefined;
+  }
+
+  try {
+    const response = await stripe.balanceTransactions.list({ source, limit: 1 });
+    if (!response?.data?.length) {
+      return undefined;
+    }
+
+    return response.data[0];
+  } catch {
+    return undefined;
+  }
+};
+
+const normalizePaymentIntent = async (
+  paymentIntent: Stripe.PaymentIntent,
+  stripe: StripeClient,
+): Promise<CanonicalInput | null> => {
+  const paymentIntentWithCharges = paymentIntent as PaymentIntentWithCharges;
+  const charge = paymentIntentWithCharges.charges?.data?.[0];
+  if (!charge) {
+    return null;
+  }
+
+  const balanceTransaction = await findBalanceTransactionBySource(
+    stripe,
+    charge.id,
+  );
+
+  const amount = toMoney(charge.amount, charge.currency ?? paymentIntent.currency);
+  const created = toIsoDateTime(charge.created ?? paymentIntent.created);
+
+  if (!amount || !created) {
+    return null;
+  }
+
+  const metadataFromIntent = mapMetadata(paymentIntent.metadata);
+  const metadataFromCharge = mapMetadata(charge.metadata);
+  const metadata = metadataFromIntent || metadataFromCharge
+    ? { ...metadataFromIntent, ...metadataFromCharge }
+    : undefined;
+
+  const payment: Payment = {
+    chargeId: charge.id,
+    customerId: getId(paymentIntent.customer),
+    invoiceId: getId(charge.invoice ?? paymentIntent.invoice),
+    created,
+    amount,
+    net: balanceTransaction
+      ? toMoney(balanceTransaction.net, balanceTransaction.currency)
+      : undefined,
+    fee: balanceTransaction
+      ? toMoney(balanceTransaction.fee ?? 0, balanceTransaction.currency)
+      : undefined,
+    description: charge.description ?? undefined,
+    metadata: metadata,
+    status: paymentIntent.status,
+    balanceTransactionId: balanceTransaction?.id,
+    balanceSummary: createBalanceSummary(balanceTransaction),
+    card: extractCardSnapshot(charge),
+  };
+
+  return { payments: [payment] };
+};
+
+const normalizeChargeRefunded = async (
+  charge: Stripe.Charge,
+  stripe: StripeClient,
+): Promise<CanonicalInput | null> => {
+  const refundsData = charge.refunds?.data ?? [];
+
+  const refunds: Refund[] = [];
+
+  for (const refund of refundsData) {
+    const amount = toMoney(refund.amount, refund.currency ?? charge.currency);
+    const created = toIsoDateTime(refund.created);
+
+    if (!amount || !created) {
+      continue;
+    }
+
+    const balanceTransaction = await findBalanceTransactionBySource(
+      stripe,
+      refund.id,
+    );
+
+    refunds.push({
+      refundId: refund.id,
+      chargeId: charge.id,
+      created,
+      amount,
+      status: refund.status ?? undefined,
+      reason: refund.reason ?? undefined,
+      metadata: mapMetadata(refund.metadata),
+      balanceTransactionId: balanceTransaction?.id,
+      balanceSummary: createBalanceSummary(balanceTransaction),
+      card: extractCardSnapshot(charge),
+    });
+  }
+
+  if (!refunds.length) {
+    return null;
+  }
+
+  return { refunds };
+};
+
+const normalizeDispute = (dispute: Stripe.Dispute): CanonicalInput => {
+  const amount = toMoney(dispute.amount, dispute.currency);
+  const created = toIsoDateTime(dispute.created);
+
+  if (!amount || !created) {
+    throw new Error("Invalid dispute payload");
+  }
+
+  return {
+    disputes: [
+      {
+        disputeId: dispute.id,
+        chargeId: getId(dispute.charge)!,
+        created,
+        amount,
+        status: dispute.status,
+        reason: dispute.reason ?? undefined,
+        evidenceDueBy: toIsoDateTime(dispute.evidence_details?.due_by),
+        metadata: mapMetadata(dispute.metadata),
+      },
+    ],
+  };
+};
+
+const normalizePayout = (payout: Stripe.Payout): CanonicalInput | null => {
+  const amount = toMoney(payout.amount, payout.currency);
+  const created = toIsoDateTime(payout.created);
+  const arrivalDate = toIsoDateTime(payout.arrival_date);
+
+  if (!amount || !created || !arrivalDate) {
+    return null;
+  }
+
+  return {
+    payouts: [
+      {
+        payoutId: payout.id,
+        amount,
+        created,
+        arrivalDate,
+        status: payout.status,
+        balanceTransactionId: getId(payout.balance_transaction),
+        metadata: mapMetadata(payout.metadata),
+      },
+    ],
+  };
+};
 
 export const normalizeTransaction = async (
-  _payload: unknown,
+  payload: Stripe.Event,
   _context: ServiceContext,
-): Promise<NormalizedTransaction> => ({
-  id: "placeholder",
-  raw: _payload,
-});
+  stripe: StripeClient,
+): Promise<CanonicalInput | null> => {
+  switch (payload.type) {
+    case "payment_intent.succeeded":
+    case "payment_intent.payment_failed":
+    case "payment_intent.canceled":
+      return normalizePaymentIntent(payload.data.object as Stripe.PaymentIntent, stripe);
+    case "charge.refunded":
+      return normalizeChargeRefunded(payload.data.object as Stripe.Charge, stripe);
+    case "charge.dispute.created":
+    case "charge.dispute.closed":
+      return normalizeDispute(payload.data.object as Stripe.Dispute);
+    case "payout.paid":
+    case "payout.failed":
+    case "payout.canceled":
+      return normalizePayout(payload.data.object as Stripe.Payout);
+    default:
+      return null;
+  }
+};
+
+export type NormalizedTransaction = CanonicalInput;

--- a/src/services/shared/types.ts
+++ b/src/services/shared/types.ts
@@ -17,6 +17,22 @@ export type Money = z.infer<typeof MoneySchema>;
 export const isMoney = (value: unknown): value is Money =>
   MoneySchema.safeParse(value).success;
 
+export const CardSnapshotSchema = z.object({
+  brand: z.string().min(1),
+  last4: z.string().min(1),
+});
+
+export type CardSnapshot = z.infer<typeof CardSnapshotSchema>;
+
+export const BalanceSummarySchema = z.object({
+  gross: MoneySchema,
+  fee_total: MoneySchema,
+  net: MoneySchema,
+  available_on: isoDateTimeString.optional(),
+});
+
+export type BalanceSummary = z.infer<typeof BalanceSummarySchema>;
+
 export const PaymentSchema = z.object({
   chargeId: z.string().min(1),
   customerId: z.string().min(1).optional(),
@@ -27,6 +43,10 @@ export const PaymentSchema = z.object({
   fee: MoneySchema.optional(),
   description: z.string().optional(),
   metadata: z.record(z.string()).optional(),
+  status: z.string().min(1).optional(),
+  balanceTransactionId: z.string().min(1).optional(),
+  balanceSummary: BalanceSummarySchema.optional(),
+  card: CardSnapshotSchema.optional(),
 });
 
 export type Payment = z.infer<typeof PaymentSchema>;
@@ -42,6 +62,9 @@ export const RefundSchema = z.object({
   status: z.string().min(1).optional(),
   reason: z.string().optional(),
   metadata: z.record(z.string()).optional(),
+  balanceTransactionId: z.string().min(1).optional(),
+  balanceSummary: BalanceSummarySchema.optional(),
+  card: CardSnapshotSchema.optional(),
 });
 
 export type Refund = z.infer<typeof RefundSchema>;
@@ -88,7 +111,12 @@ export const CanonicalInputSchema = z
     payouts: z.array(PayoutSchema).optional(),
   })
   .refine(
-    (value) =>
+    (value: {
+      payments?: unknown[];
+      refunds?: unknown[];
+      disputes?: unknown[];
+      payouts?: unknown[];
+    }) =>
       Boolean(
         (value.payments && value.payments.length > 0) ||
           (value.refunds && value.refunds.length > 0) ||

--- a/tests/integration/normalize.stripe.spec.ts
+++ b/tests/integration/normalize.stripe.spec.ts
@@ -1,0 +1,503 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import Stripe from "stripe";
+
+import { normalizeTransaction } from "../../src/services/process/normalize";
+import { ServiceContext } from "../../src/services/shared/types";
+
+const context = { env: {} as never } satisfies ServiceContext;
+
+const iso = (timestamp: number) => new Date(timestamp * 1000).toISOString();
+
+type BalanceMap = Record<string, Stripe.BalanceTransaction>;
+
+const createStripeStub = (balances: BalanceMap) => ({
+  balanceTransactions: {
+    async list({ source }: { source?: string | null }) {
+      const entry = source ? balances[source] : undefined;
+      return { data: entry ? [entry] : [] };
+    },
+  },
+});
+
+test("normalizes payment_intent.succeeded events", async () => {
+  const balanceTransactions: BalanceMap = {
+    ch_test_succeeded: {
+      id: "txn_charge_succeeded",
+      object: "balance_transaction",
+      amount: 2000,
+      currency: "usd",
+      net: 1950,
+      fee: 50,
+      fee_details: [],
+      source: "ch_test_succeeded",
+      status: "available",
+      type: "charge",
+      created: 1_700_000_001,
+      available_on: 1_700_086_400,
+      exchange_rate: null,
+      description: null,
+      reporting_category: "charge",
+    } as Stripe.BalanceTransaction,
+  };
+
+  const event = {
+    id: "evt_payment_succeeded",
+    object: "event",
+    api_version: "2023-10-16",
+    created: 1_700_000_000,
+    data: {
+      object: {
+        id: "pi_test_succeeded",
+        object: "payment_intent",
+        status: "succeeded",
+        currency: "usd",
+        customer: "cus_123",
+        created: 1_700_000_000,
+        metadata: { campaign: "fall" },
+        charges: {
+          object: "list",
+          data: [
+            {
+              id: "ch_test_succeeded",
+              object: "charge",
+              amount: 2000,
+              currency: "usd",
+              created: 1_700_000_001,
+              invoice: "in_123",
+              description: "Test charge",
+              metadata: { campaign: "fall" },
+              payment_method_details: {
+                type: "card",
+                card: {
+                  brand: "visa",
+                  last4: "4242",
+                },
+              },
+            },
+          ],
+          has_more: false,
+          url: "/v1/charges?payment_intent=pi_test_succeeded",
+        },
+      },
+    },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    type: "payment_intent.succeeded",
+  } as unknown as Stripe.Event;
+
+  const canonical = await normalizeTransaction(
+    event,
+    context,
+    createStripeStub(balanceTransactions),
+  );
+
+  assert.deepStrictEqual(canonical, {
+    payments: [
+      {
+        chargeId: "ch_test_succeeded",
+        customerId: "cus_123",
+        invoiceId: "in_123",
+        created: iso(1_700_000_001),
+        amount: { amount: 2000, currency: "usd" },
+        net: { amount: 1950, currency: "usd" },
+        fee: { amount: 50, currency: "usd" },
+        description: "Test charge",
+        metadata: { campaign: "fall" },
+        status: "succeeded",
+        balanceTransactionId: "txn_charge_succeeded",
+        balanceSummary: {
+          gross: { amount: 2000, currency: "usd" },
+          fee_total: { amount: 50, currency: "usd" },
+          net: { amount: 1950, currency: "usd" },
+          available_on: iso(1_700_086_400),
+        },
+        card: { brand: "visa", last4: "4242" },
+      },
+    ],
+  });
+});
+
+test("normalizes payment_intent.payment_failed events", async () => {
+  const event = {
+    id: "evt_payment_failed",
+    object: "event",
+    api_version: "2023-10-16",
+    created: 1_700_000_000,
+    data: {
+      object: {
+        id: "pi_test_failed",
+        object: "payment_intent",
+        status: "requires_payment_method",
+        currency: "usd",
+        customer: "cus_456",
+        created: 1_700_000_000,
+        metadata: { retry: "true" },
+        charges: {
+          object: "list",
+          data: [
+            {
+              id: "ch_test_failed",
+              object: "charge",
+              amount: 3500,
+              currency: "usd",
+              created: 1_700_000_100,
+              invoice: null,
+              description: null,
+              metadata: {},
+              payment_method_details: {
+                type: "card",
+                card: {
+                  brand: "mastercard",
+                  last4: "9999",
+                },
+              },
+            },
+          ],
+          has_more: false,
+          url: "/v1/charges?payment_intent=pi_test_failed",
+        },
+      },
+    },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    type: "payment_intent.payment_failed",
+  } as unknown as Stripe.Event;
+
+  const canonical = await normalizeTransaction(
+    event,
+    context,
+    createStripeStub({}),
+  );
+
+  assert.deepStrictEqual(canonical, {
+    payments: [
+      {
+        chargeId: "ch_test_failed",
+        customerId: "cus_456",
+        invoiceId: undefined,
+        created: iso(1_700_000_100),
+        amount: { amount: 3500, currency: "usd" },
+        net: undefined,
+        fee: undefined,
+        description: undefined,
+        metadata: { retry: "true" },
+        status: "requires_payment_method",
+        balanceTransactionId: undefined,
+        balanceSummary: undefined,
+        card: { brand: "mastercard", last4: "9999" },
+      },
+    ],
+  });
+});
+
+test("normalizes payment_intent.canceled events", async () => {
+  const balanceTransactions: BalanceMap = {
+    ch_test_canceled: {
+      id: "txn_charge_canceled",
+      object: "balance_transaction",
+      amount: 2500,
+      currency: "usd",
+      net: 2500,
+      fee: 0,
+      fee_details: [],
+      source: "ch_test_canceled",
+      status: "available",
+      type: "charge",
+      created: 1_700_000_150,
+      available_on: 1_700_086_400,
+      exchange_rate: null,
+      description: null,
+      reporting_category: "charge",
+    } as Stripe.BalanceTransaction,
+  };
+
+  const event = {
+    id: "evt_payment_canceled",
+    object: "event",
+    api_version: "2023-10-16",
+    created: 1_700_000_140,
+    data: {
+      object: {
+        id: "pi_test_canceled",
+        object: "payment_intent",
+        status: "canceled",
+        currency: "usd",
+        customer: null,
+        created: 1_700_000_140,
+        metadata: {},
+        charges: {
+          object: "list",
+          data: [
+            {
+              id: "ch_test_canceled",
+              object: "charge",
+              amount: 2500,
+              currency: "usd",
+              created: 1_700_000_150,
+              invoice: null,
+              description: "Canceled before capture",
+              metadata: {},
+              payment_method_details: {
+                type: "card",
+                card: {
+                  brand: "amex",
+                  last4: "0005",
+                },
+              },
+            },
+          ],
+          has_more: false,
+          url: "/v1/charges?payment_intent=pi_test_canceled",
+        },
+      },
+    },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    type: "payment_intent.canceled",
+  } as unknown as Stripe.Event;
+
+  const canonical = await normalizeTransaction(
+    event,
+    context,
+    createStripeStub(balanceTransactions),
+  );
+
+  assert.deepStrictEqual(canonical, {
+    payments: [
+      {
+        chargeId: "ch_test_canceled",
+        customerId: undefined,
+        invoiceId: undefined,
+        created: iso(1_700_000_150),
+        amount: { amount: 2500, currency: "usd" },
+        net: { amount: 2500, currency: "usd" },
+        fee: { amount: 0, currency: "usd" },
+        description: "Canceled before capture",
+        metadata: undefined,
+        status: "canceled",
+        balanceTransactionId: "txn_charge_canceled",
+        balanceSummary: {
+          gross: { amount: 2500, currency: "usd" },
+          fee_total: { amount: 0, currency: "usd" },
+          net: { amount: 2500, currency: "usd" },
+          available_on: iso(1_700_086_400),
+        },
+        card: { brand: "amex", last4: "0005" },
+      },
+    ],
+  });
+});
+
+test("normalizes charge.refunded events", async () => {
+  const balanceTransactions: BalanceMap = {
+    re_test_refund: {
+      id: "txn_refund",
+      object: "balance_transaction",
+      amount: -1000,
+      currency: "usd",
+      net: -1000,
+      fee: 0,
+      fee_details: [],
+      source: "re_test_refund",
+      status: "available",
+      type: "refund",
+      created: 1_700_000_500,
+      available_on: 1_700_086_400,
+      exchange_rate: null,
+      description: null,
+      reporting_category: "refund",
+    } as Stripe.BalanceTransaction,
+  };
+
+  const event = {
+    id: "evt_charge_refunded",
+    object: "event",
+    api_version: "2023-10-16",
+    created: 1_700_000_400,
+    data: {
+      object: {
+        id: "ch_test_refund",
+        object: "charge",
+        amount: 1000,
+        currency: "usd",
+        created: 1_700_000_200,
+        refunds: {
+          object: "list",
+          data: [
+            {
+              id: "re_test_refund",
+              object: "refund",
+              amount: 1000,
+              currency: "usd",
+              created: 1_700_000_500,
+              status: "succeeded",
+              reason: "requested_by_customer",
+              metadata: { order: "123" },
+            },
+          ],
+          has_more: false,
+          url: "/v1/refunds?charge=ch_test_refund",
+        },
+        payment_method_details: {
+          type: "card",
+          card: {
+            brand: "visa",
+            last4: "4242",
+          },
+        },
+      },
+    },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    type: "charge.refunded",
+  } as unknown as Stripe.Event;
+
+  const canonical = await normalizeTransaction(
+    event,
+    context,
+    createStripeStub(balanceTransactions),
+  );
+
+  assert.deepStrictEqual(canonical, {
+    refunds: [
+      {
+        refundId: "re_test_refund",
+        chargeId: "ch_test_refund",
+        created: iso(1_700_000_500),
+        amount: { amount: 1000, currency: "usd" },
+        status: "succeeded",
+        reason: "requested_by_customer",
+        metadata: { order: "123" },
+        balanceTransactionId: "txn_refund",
+        balanceSummary: {
+          gross: { amount: -1000, currency: "usd" },
+          fee_total: { amount: 0, currency: "usd" },
+          net: { amount: -1000, currency: "usd" },
+          available_on: iso(1_700_086_400),
+        },
+        card: { brand: "visa", last4: "4242" },
+      },
+    ],
+  });
+});
+
+test("normalizes charge.dispute.created events", async () => {
+  const event = {
+    id: "evt_dispute_created",
+    object: "event",
+    api_version: "2023-10-16",
+    created: 1_700_000_600,
+    data: {
+      object: {
+        id: "dp_test",
+        object: "dispute",
+        amount: 1500,
+        currency: "usd",
+        created: 1_700_000_600,
+        status: "needs_response",
+        reason: "fraudulent",
+        charge: "ch_disputed",
+        metadata: { case: "42" },
+        evidence_details: { due_by: 1_700_086_400 },
+      },
+    },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    type: "charge.dispute.created",
+  } as unknown as Stripe.Event;
+
+  const canonical = await normalizeTransaction(
+    event,
+    context,
+    createStripeStub({}),
+  );
+
+  assert.deepStrictEqual(canonical, {
+    disputes: [
+      {
+        disputeId: "dp_test",
+        chargeId: "ch_disputed",
+        created: iso(1_700_000_600),
+        amount: { amount: 1500, currency: "usd" },
+        status: "needs_response",
+        reason: "fraudulent",
+        evidenceDueBy: iso(1_700_086_400),
+        metadata: { case: "42" },
+      },
+    ],
+  });
+});
+
+test("normalizes payout events", async () => {
+  const event = {
+    id: "evt_payout_paid",
+    object: "event",
+    api_version: "2023-10-16",
+    created: 1_700_000_700,
+    data: {
+      object: {
+        id: "po_test",
+        object: "payout",
+        amount: 5000,
+        currency: "usd",
+        created: 1_700_000_700,
+        arrival_date: 1_700_086_400,
+        status: "paid",
+        balance_transaction: "txn_payout",
+        metadata: { batch: "payout-1" },
+      },
+    },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    type: "payout.paid",
+  } as unknown as Stripe.Event;
+
+  const canonical = await normalizeTransaction(
+    event,
+    context,
+    createStripeStub({}),
+  );
+
+  assert.deepStrictEqual(canonical, {
+    payouts: [
+      {
+        payoutId: "po_test",
+        amount: { amount: 5000, currency: "usd" },
+        created: iso(1_700_000_700),
+        arrivalDate: iso(1_700_086_400),
+        status: "paid",
+        balanceTransactionId: "txn_payout",
+        metadata: { batch: "payout-1" },
+      },
+    ],
+  });
+});
+
+test("returns null for unsupported events", async () => {
+  const event = {
+    id: "evt_unhandled",
+    object: "event",
+    api_version: "2023-10-16",
+    created: 1_700_000_800,
+    data: { object: { id: "obj" } },
+    livemode: false,
+    pending_webhooks: 0,
+    request: null,
+    type: "product.created",
+  } as unknown as Stripe.Event;
+
+  const canonical = await normalizeTransaction(
+    event,
+    context,
+    createStripeStub({}),
+  );
+
+  assert.equal(canonical, null);
+});


### PR DESCRIPTION
## Summary
- implement Stripe event normalization that enriches payments, refunds, disputes, and payouts with balance transaction and card data
- extend shared schemas to store balance summaries and card snapshots for payments and refunds
- add Stripe fixture-based integration tests covering supported webhook event types

## Testing
- npx ts-node tests/integration/normalize.stripe.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e41a9ecf24832caba01ac59c206629