### PR TITLE
Implement routing decisions and transaction processing stub

### DIFF
--- a/src/services/process/decide.ts
+++ b/src/services/process/decide.ts
@@ -4,15 +4,102 @@ export interface DecisionInput {
   payload: unknown;
 }
 
+export type SalesforceRoute = "payment" | "refund" | "dispute" | "payout";
+
+export type QuickBooksRoute =
+  | "sales_receipt"
+  | "refund_receipt"
+  | "dispute_entry"
+  | "transfer";
+
 export interface DecisionResult {
   shouldSyncSalesforce: boolean;
+  salesforceRoute?: SalesforceRoute;
   shouldSyncQuickBooks: boolean;
+  quickbooksRoute?: QuickBooksRoute;
 }
 
+const extractEventType = (payload: unknown): string | null => {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  if ("type" in payload) {
+    const type = (payload as { type?: unknown }).type;
+    if (typeof type === "string") {
+      return type;
+    }
+  }
+
+  if ("event" in payload) {
+    const event = (payload as { event?: unknown }).event;
+    if (event && typeof event === "object" && "type" in event) {
+      const type = (event as { type?: unknown }).type;
+      if (typeof type === "string") {
+        return type;
+      }
+    }
+  }
+
+  return null;
+};
+
+const resolveRoutes = (
+  eventType: string | null,
+): Pick<DecisionResult, "shouldSyncSalesforce" | "salesforceRoute" | "shouldSyncQuickBooks" | "quickbooksRoute"> => {
+  if (!eventType) {
+    return {
+      shouldSyncSalesforce: false,
+      shouldSyncQuickBooks: false,
+    };
+  }
+
+  if (eventType === "payment.succeeded") {
+    return {
+      shouldSyncSalesforce: true,
+      salesforceRoute: "payment",
+      shouldSyncQuickBooks: true,
+      quickbooksRoute: "sales_receipt",
+    };
+  }
+
+  if (eventType === "refund.succeeded") {
+    return {
+      shouldSyncSalesforce: true,
+      salesforceRoute: "refund",
+      shouldSyncQuickBooks: true,
+      quickbooksRoute: "refund_receipt",
+    };
+  }
+
+  if (eventType.startsWith("dispute.")) {
+    return {
+      shouldSyncSalesforce: true,
+      salesforceRoute: "dispute",
+      shouldSyncQuickBooks: true,
+      quickbooksRoute: "dispute_entry",
+    };
+  }
+
+  if (eventType === "payout.paid") {
+    return {
+      shouldSyncSalesforce: true,
+      salesforceRoute: "payout",
+      shouldSyncQuickBooks: true,
+      quickbooksRoute: "transfer",
+    };
+  }
+
+  return {
+    shouldSyncSalesforce: false,
+    shouldSyncQuickBooks: false,
+  };
+};
+
 export const decideNextSteps = async (
-  _input: DecisionInput,
+  input: DecisionInput,
   _context: ServiceContext,
-): Promise<DecisionResult> => ({
-  shouldSyncSalesforce: true,
-  shouldSyncQuickBooks: true,
-});
+): Promise<DecisionResult> => {
+  const eventType = extractEventType(input.payload);
+  return resolveRoutes(eventType);
+};

--- a/src/services/process/post_qbo.ts
+++ b/src/services/process/post_qbo.ts
@@ -4,6 +4,4 @@ import { ServiceContext } from "../shared/types";
 export const postToQuickBooks = async (
   _transaction: NormalizedTransaction,
   _context: ServiceContext,
-): Promise<void> => {
-  // QuickBooks sync placeholder implementation.
-};
+): Promise<{ action: "skipped" }> => ({ action: "skipped" });

--- a/src/services/process/post_sf.ts
+++ b/src/services/process/post_sf.ts
@@ -4,6 +4,4 @@ import { ServiceContext } from "../shared/types";
 export const postToSalesforce = async (
   _transaction: NormalizedTransaction,
   _context: ServiceContext,
-): Promise<void> => {
-  // Salesforce sync placeholder implementation.
-};
+): Promise<{ action: "skipped" }> => ({ action: "skipped" });

--- a/src/services/process/process_transaction.ts
+++ b/src/services/process/process_transaction.ts
@@ -1,12 +1,54 @@
-import { ServiceContext } from "../shared/types";
+import { NormalizedTransaction } from "./normalize";
+import { decideNextSteps, DecisionResult } from "./decide";
+import { withIdempotency } from "./idempotency";
+import { postToSalesforce } from "./post_sf";
+import { postToQuickBooks } from "./post_qbo";
+import { CanonicalInput, ServiceContext } from "../shared/types";
 
 export interface ProcessTransactionInput {
   payload: unknown;
+  payments?: CanonicalInput["payments"];
+  refunds?: CanonicalInput["refunds"];
+  disputes?: CanonicalInput["disputes"];
+  payouts?: CanonicalInput["payouts"];
+}
+
+export interface SyncSummary {
+  action: "skipped";
+}
+
+export interface ProcessTransactionResult {
+  decision: DecisionResult;
+  sf: SyncSummary;
+  qbo: SyncSummary;
 }
 
 export const processTransaction = async (
-  _input: ProcessTransactionInput,
-  _context: ServiceContext,
-): Promise<void> => {
-  // Implementation will be added in subsequent iterations.
+  input: ProcessTransactionInput,
+  context: ServiceContext,
+): Promise<ProcessTransactionResult> => {
+  const decision = await decideNextSteps({ payload: input.payload }, context);
+
+  const normalized: NormalizedTransaction = {
+    payments: input.payments,
+    refunds: input.refunds,
+    disputes: input.disputes,
+    payouts: input.payouts,
+  };
+
+  return withIdempotency(normalized, async () => {
+    const sf = decision.shouldSyncSalesforce
+      ? await postToSalesforce(normalized, context)
+      : { action: "skipped" as const };
+
+    const qbo = decision.shouldSyncQuickBooks
+      ? await postToQuickBooks(normalized, context)
+      : { action: "skipped" as const };
+
+    return {
+      decision,
+      sf,
+      qbo,
+    };
+  });
 };

--- a/tests/unit/process.route.spec.ts
+++ b/tests/unit/process.route.spec.ts
@@ -1,0 +1,143 @@
+import { strict as assert } from "node:assert";
+import { decideNextSteps } from "../../src/services/process/decide";
+import { processTransaction } from "../../src/services/process/process_transaction";
+import { __testing as repositoryTesting } from "../../src/services/persistence/repository";
+import { ServiceContext } from "../../src/services/shared/types";
+import { Env } from "../../src/config/env";
+
+type TestCase = {
+  name: string;
+  payload: unknown;
+  input: Parameters<typeof processTransaction>[0];
+  expectedSalesforceRoute?: string;
+  expectedQuickBooksRoute?: string;
+};
+
+const createContext = (): ServiceContext => ({
+  env: {} as Env,
+});
+
+const iso = () => new Date().toISOString();
+
+const testCases: TestCase[] = [
+  {
+    name: "routes payment.succeeded to payment/sales_receipt",
+    payload: { type: "payment.succeeded" },
+    input: {
+      payload: { type: "payment.succeeded" },
+      payments: [
+        {
+          chargeId: "ch_pay_1",
+          created: iso(),
+          amount: { amount: 1000, currency: "usd" },
+        },
+      ],
+    },
+    expectedSalesforceRoute: "payment",
+    expectedQuickBooksRoute: "sales_receipt",
+  },
+  {
+    name: "routes refund.succeeded to refund/refund_receipt",
+    payload: { event: { type: "refund.succeeded" } },
+    input: {
+      payload: { event: { type: "refund.succeeded" } },
+      refunds: [
+        {
+          refundId: "re_ref_1",
+          chargeId: "ch_ref_1",
+          created: iso(),
+          amount: { amount: 500, currency: "usd" },
+        },
+      ],
+    },
+    expectedSalesforceRoute: "refund",
+    expectedQuickBooksRoute: "refund_receipt",
+  },
+  {
+    name: "routes dispute events to dispute/dispute_entry",
+    payload: { type: "dispute.closed" },
+    input: {
+      payload: { type: "dispute.closed" },
+      disputes: [
+        {
+          disputeId: "dp_1",
+          chargeId: "ch_dp_1",
+          created: iso(),
+          amount: { amount: 2500, currency: "usd" },
+          status: "lost",
+        },
+      ],
+    },
+    expectedSalesforceRoute: "dispute",
+    expectedQuickBooksRoute: "dispute_entry",
+  },
+  {
+    name: "routes payout.paid to payout/transfer",
+    payload: { type: "payout.paid" },
+    input: {
+      payload: { type: "payout.paid" },
+      payouts: [
+        {
+          payoutId: "po_1",
+          created: iso(),
+          arrivalDate: iso(),
+          status: "paid",
+          amount: { amount: 10000, currency: "usd" },
+        },
+      ],
+    },
+    expectedSalesforceRoute: "payout",
+    expectedQuickBooksRoute: "transfer",
+  },
+];
+
+const run = async () => {
+  const context = createContext();
+
+  for (const testCase of testCases) {
+    repositoryTesting.reset();
+
+    const decision = await decideNextSteps({ payload: testCase.payload }, context);
+    assert.equal(
+      decision.salesforceRoute,
+      testCase.expectedSalesforceRoute,
+      `${testCase.name}: Salesforce route mismatch`,
+    );
+    assert.equal(
+      decision.quickbooksRoute,
+      testCase.expectedQuickBooksRoute,
+      `${testCase.name}: QuickBooks route mismatch`,
+    );
+
+    const result = await processTransaction(testCase.input, context);
+    assert.equal(
+      result.decision.salesforceRoute,
+      testCase.expectedSalesforceRoute,
+      `${testCase.name}: decision persisted in result`,
+    );
+    assert.equal(
+      result.decision.quickbooksRoute,
+      testCase.expectedQuickBooksRoute,
+      `${testCase.name}: decision persisted in result`,
+    );
+    assert.deepEqual(
+      result.sf,
+      { action: "skipped" },
+      `${testCase.name}: Salesforce summary should be skipped stub`,
+    );
+    assert.deepEqual(
+      result.qbo,
+      { action: "skipped" },
+      `${testCase.name}: QuickBooks summary should be skipped stub`,
+    );
+  }
+};
+
+run()
+  .then(() => {
+    console.log("process.route.spec.ts passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary
- map Stripe event types to Salesforce and QuickBooks routes in the decision service
- add a stubbed transaction processor that applies idempotency and returns Salesforce/QuickBooks summaries
- cover routing decisions and processing flow with unit tests

## Testing
- npx ts-node tests/unit/process.route.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e41f9f9fd8832ca50c00171e8e802b