### PR TITLE
Add Salesforce REST client and sync workflow

### DIFF
--- a/src/services/process/post_sf.ts
+++ b/src/services/process/post_sf.ts
@@ -1,7 +1,321 @@
+import { SalesforceClient } from "../salesforce/salesforce_client";
 import { NormalizedTransaction } from "./normalize";
 import { ServiceContext } from "../shared/types";
 
+type SalesforceSummary = {
+  action: "created" | "updated" | "noop";
+  id: string | null;
+};
+
+type ContactLike = {
+  customerId?: string;
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+};
+
+type SalesforceRecordResult = {
+  id: string;
+  action: "created" | "updated";
+};
+
+const normalizeEmail = (value: string | undefined) =>
+  value ? value.trim().toLowerCase() : undefined;
+
+const defaultSummary: SalesforceSummary = { action: "noop", id: null };
+
+const findContactSource = (transaction: NormalizedTransaction): ContactLike | null => {
+  const payment = transaction.payments?.[0];
+  if (payment) {
+    const metadata = payment.metadata ?? {};
+    const email =
+      normalizeEmail(metadata.customer_email ?? metadata.email ?? undefined) ??
+      undefined;
+    const fullName = metadata.customer_name ?? metadata.name ?? payment.description;
+
+    let firstName: string | undefined;
+    let lastName: string | undefined;
+    if (fullName && fullName.includes(" ")) {
+      const parts = fullName.split(" ");
+      firstName = parts[0];
+      lastName = parts.slice(1).join(" ");
+    } else if (fullName) {
+      lastName = fullName;
+    }
+
+    return {
+      customerId: payment.customerId,
+      email,
+      firstName,
+      lastName,
+    };
+  }
+
+  const refund = transaction.refunds?.[0];
+  if (refund) {
+    const metadata = refund.metadata ?? {};
+    const email = normalizeEmail(metadata.customer_email ?? metadata.email ?? undefined);
+    return {
+      email,
+      lastName: refund.reason ?? refund.refundId,
+    };
+  }
+
+  const dispute = transaction.disputes?.[0];
+  if (dispute) {
+    const metadata = dispute.metadata ?? {};
+    const email = normalizeEmail(metadata.customer_email ?? metadata.email ?? undefined);
+    return {
+      email,
+      lastName: dispute.reason ?? dispute.disputeId,
+    };
+  }
+
+  return null;
+};
+
+const contactPayloadFromSource = (source: ContactLike | null) => {
+  if (!source) {
+    return null;
+  }
+
+  if (!source.customerId && !source.email) {
+    return null;
+  }
+
+  const payload: Record<string, unknown> = {};
+
+  if (source.email) {
+    payload.Email = source.email;
+  }
+
+  if (source.firstName) {
+    payload.FirstName = source.firstName;
+  }
+
+  if (source.lastName) {
+    payload.LastName = source.lastName;
+  }
+
+  if (!payload.LastName) {
+    payload.LastName = "Stripe Customer";
+  }
+
+  if (source.customerId) {
+    payload.stripe_customer_id__c = source.customerId;
+  }
+
+  return payload;
+};
+
+const upsertContact = async (
+  client: SalesforceClient,
+  transaction: NormalizedTransaction,
+): Promise<SalesforceRecordResult | null> => {
+  const source = contactPayloadFromSource(findContactSource(transaction));
+  if (!source) {
+    return null;
+  }
+
+  const customerId = (source as { stripe_customer_id__c?: string }).stripe_customer_id__c;
+  if (customerId) {
+    return client.upsert("Contact", "stripe_customer_id__c", customerId, source);
+  }
+
+  if (source.Email) {
+    return client.upsert("Contact", "Email", source.Email as string, source);
+  }
+
+  return null;
+};
+
+const centsToDollars = (amount: number | undefined) => {
+  if (typeof amount !== "number") {
+    return undefined;
+  }
+
+  return amount / 100;
+};
+
+const isoDate = (iso: string | undefined) => {
+  if (!iso) {
+    return undefined;
+  }
+  return iso.split("T")[0];
+};
+
+const syncPaymentNpsp = async (
+  client: SalesforceClient,
+  payment: NonNullable<NormalizedTransaction["payments"]>[number],
+  contactId: string | null,
+) => {
+  const opportunity = await client.upsert(
+    "Opportunity",
+    "Stripe_Charge_Id__c",
+    payment.chargeId,
+    {
+      Name: payment.description ?? `Stripe Payment ${payment.chargeId}`,
+      StageName: "Closed Won",
+      CloseDate: isoDate(payment.created),
+      Amount: centsToDollars(payment.amount.amount),
+      Stripe_Charge_Id__c: payment.chargeId,
+      Stripe_Invoice_Id__c: payment.invoiceId,
+      Stripe_Customer_Id__c: payment.customerId,
+      CurrencyIsoCode: payment.amount.currency?.toUpperCase(),
+      Primary_Contact__c: contactId ?? undefined,
+    },
+  );
+
+  const paymentRecord = await client.upsert(
+    "npsp__Payment__c",
+    "Stripe_Charge_Id__c",
+    payment.chargeId,
+    {
+      Name: payment.description ?? `Stripe Payment ${payment.chargeId}`,
+      Stripe_Charge_Id__c: payment.chargeId,
+      npsp__Payment_Date__c: isoDate(payment.created),
+      npsp__Amount__c: centsToDollars(payment.amount.amount),
+      npsp__Paid__c: payment.status === "succeeded",
+      npsp__Opportunity__c: opportunity.id,
+      Contact__c: contactId ?? undefined,
+      CurrencyIsoCode: payment.amount.currency?.toUpperCase(),
+    },
+  );
+
+  return paymentRecord;
+};
+
+const syncPayment = async (
+  client: SalesforceClient,
+  payment: NonNullable<NormalizedTransaction["payments"]>[number],
+  contactId: string | null,
+  useNpsp: boolean,
+) => {
+  if (useNpsp) {
+    return syncPaymentNpsp(client, payment, contactId);
+  }
+
+  return client.upsert("Payment__c", "Stripe_Charge_Id__c", payment.chargeId, {
+    Name: payment.description ?? `Payment ${payment.chargeId}`,
+    Stripe_Charge_Id__c: payment.chargeId,
+    Stripe_Invoice_Id__c: payment.invoiceId,
+    Stripe_Customer_Id__c: payment.customerId,
+    Amount__c: payment.amount.amount,
+    Currency__c: payment.amount.currency,
+    Status__c: payment.status,
+    Contact__c: contactId ?? undefined,
+  });
+};
+
+const syncRefund = (
+  client: SalesforceClient,
+  refund: NonNullable<NormalizedTransaction["refunds"]>[number],
+) =>
+  client.upsert("Refund__c", "Stripe_Refund_Id__c", refund.refundId, {
+    Name: refund.refundId,
+    Stripe_Refund_Id__c: refund.refundId,
+    Stripe_Charge_Id__c: refund.chargeId,
+    Amount__c: refund.amount.amount,
+    Currency__c: refund.amount.currency,
+    Status__c: refund.status,
+    Reason__c: refund.reason,
+  });
+
+const syncDispute = (
+  client: SalesforceClient,
+  dispute: NonNullable<NormalizedTransaction["disputes"]>[number],
+) =>
+  client.upsert("Dispute__c", "Stripe_Dispute_Id__c", dispute.disputeId, {
+    Name: dispute.disputeId,
+    Stripe_Dispute_Id__c: dispute.disputeId,
+    Stripe_Charge_Id__c: dispute.chargeId,
+    Amount__c: dispute.amount.amount,
+    Currency__c: dispute.amount.currency,
+    Status__c: dispute.status,
+    Reason__c: dispute.reason,
+  });
+
+const syncPayout = (
+  client: SalesforceClient,
+  payout: NonNullable<NormalizedTransaction["payouts"]>[number],
+) =>
+  client.upsert("Payout__c", "Stripe_Payout_Id__c", payout.payoutId, {
+    Name: payout.payoutId,
+    Stripe_Payout_Id__c: payout.payoutId,
+    Amount__c: payout.amount.amount,
+    Currency__c: payout.amount.currency,
+    Status__c: payout.status,
+    Arrival_Date__c: isoDate(payout.arrivalDate),
+    Created_Date__c: isoDate(payout.created),
+  });
+
+const buildClient = (context: ServiceContext) => {
+  const envRecord = context.env as Record<string, unknown>;
+  const loginUrl =
+    typeof envRecord.SF_LOGIN_URL === "string" ? envRecord.SF_LOGIN_URL : undefined;
+  const apiVersion =
+    typeof envRecord.SF_API_VERSION === "string"
+      ? envRecord.SF_API_VERSION
+      : undefined;
+
+  return new SalesforceClient(
+    {
+      clientId: context.env.SF_CLIENT_ID,
+      clientSecret: context.env.SF_CLIENT_SECRET,
+      username: context.env.SF_USERNAME,
+      password: context.env.SF_PASSWORD,
+    },
+    { loginUrl, apiVersion },
+  );
+};
+
 export const postToSalesforce = async (
-  _transaction: NormalizedTransaction,
-  _context: ServiceContext,
-): Promise<{ action: "skipped" }> => ({ action: "skipped" });
+  transaction: NormalizedTransaction,
+  context: ServiceContext,
+): Promise<SalesforceSummary> => {
+  if (
+    !transaction.payments?.length &&
+    !transaction.refunds?.length &&
+    !transaction.disputes?.length &&
+    !transaction.payouts?.length
+  ) {
+    return defaultSummary;
+  }
+
+  const client = buildClient(context);
+  const results: SalesforceSummary[] = [];
+
+  const contact = await upsertContact(client, transaction);
+  if (contact) {
+    results.push({ action: contact.action, id: contact.id });
+  }
+
+  const contactId = contact?.id ?? null;
+  const useNpsp = Boolean(context.env.SF_USE_NPSP);
+
+  for (const payment of transaction.payments ?? []) {
+    const result = await syncPayment(client, payment, contactId, useNpsp);
+    results.push({ action: result.action, id: result.id });
+  }
+
+  for (const refund of transaction.refunds ?? []) {
+    const result = await syncRefund(client, refund);
+    results.push({ action: result.action, id: result.id });
+  }
+
+  for (const dispute of transaction.disputes ?? []) {
+    const result = await syncDispute(client, dispute);
+    results.push({ action: result.action, id: result.id });
+  }
+
+  for (const payout of transaction.payouts ?? []) {
+    const result = await syncPayout(client, payout);
+    results.push({ action: result.action, id: result.id });
+  }
+
+  if (results.length === 0) {
+    return defaultSummary;
+  }
+
+  return results[results.length - 1] ?? defaultSummary;
+};

--- a/src/services/process/process_transaction.ts
+++ b/src/services/process/process_transaction.ts
@@ -14,7 +14,8 @@ export interface ProcessTransactionInput {
 }
 
 export interface SyncSummary {
-  action: "skipped";
+  action: "skipped" | "noop" | "created" | "updated";
+  id?: string | null;
 }
 
 export interface ProcessTransactionResult {
@@ -37,9 +38,12 @@ export const processTransaction = async (
   };
 
   return withIdempotency(normalized, async () => {
-    const sf = decision.shouldSyncSalesforce
-      ? await postToSalesforce(normalized, context)
-      : { action: "skipped" as const };
+    const isSalesforceEnabled = context.env.ENABLE_SF !== false;
+
+    const sf =
+      decision.shouldSyncSalesforce && isSalesforceEnabled
+        ? await postToSalesforce(normalized, context)
+        : { action: "skipped" as const };
 
     const qbo = decision.shouldSyncQuickBooks
       ? await postToQuickBooks(normalized, context)

--- a/src/services/salesforce/salesforce_client.ts
+++ b/src/services/salesforce/salesforce_client.ts
@@ -1,0 +1,242 @@
+import { IncomingHttpHeaders } from "node:http";
+import http from "node:http";
+import https from "node:https";
+import { URL, URLSearchParams } from "node:url";
+
+export interface SalesforceClientOptions {
+  loginUrl?: string;
+  apiVersion?: string;
+}
+
+export interface SalesforceCredentials {
+  clientId: string;
+  clientSecret: string;
+  username: string;
+  password: string;
+}
+
+export interface SalesforceAuthResponse {
+  access_token: string;
+  instance_url: string;
+  token_type: string;
+}
+
+export interface SalesforceQueryResult<T> {
+  totalSize: number;
+  done: boolean;
+  records: T[];
+}
+
+export interface SalesforceUpsertResult {
+  id: string;
+  action: "created" | "updated";
+}
+
+type RequestOptions = {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: string;
+};
+
+interface RawResponse {
+  statusCode: number;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+export class SalesforceClient {
+  private readonly loginUrl: string;
+  private readonly apiVersion: string;
+  private accessToken: string | null = null;
+  private instanceUrl: string | null = null;
+
+  constructor(
+    private readonly credentials: SalesforceCredentials,
+    options: SalesforceClientOptions = {},
+  ) {
+    this.loginUrl = options.loginUrl ?? "https://login.salesforce.com";
+    this.apiVersion = options.apiVersion ?? "v59.0";
+  }
+
+  private async performRequest({ method, url, headers, body }: RequestOptions) {
+    const target = new URL(url);
+    const isHttps = target.protocol === "https:";
+    const transport = isHttps ? https : http;
+
+    const requestOptions: https.RequestOptions = {
+      method,
+      hostname: target.hostname,
+      port: target.port || (isHttps ? 443 : 80),
+      path: `${target.pathname}${target.search}`,
+      headers,
+    };
+
+    return new Promise<RawResponse>((resolve, reject) => {
+      const req = transport.request(requestOptions, (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      });
+
+      req.on("error", reject);
+
+      if (body) {
+        req.write(body);
+      }
+
+      req.end();
+    });
+  }
+
+  private async authenticate() {
+    const params = new URLSearchParams({
+      grant_type: "password",
+      client_id: this.credentials.clientId,
+      client_secret: this.credentials.clientSecret,
+      username: this.credentials.username,
+      password: this.credentials.password,
+    });
+
+    const response = await this.performRequest({
+      method: "POST",
+      url: `${this.loginUrl}/services/oauth2/token`,
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+      },
+      body: params.toString(),
+    });
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new Error(
+        `Failed to authenticate with Salesforce: ${response.statusCode} ${response.body}`,
+      );
+    }
+
+    const payload = JSON.parse(response.body) as SalesforceAuthResponse;
+    this.accessToken = payload.access_token;
+    this.instanceUrl = payload.instance_url;
+  }
+
+  private async ensureSession() {
+    if (!this.accessToken || !this.instanceUrl) {
+      await this.authenticate();
+    }
+  }
+
+  private async requestWithAuth(
+    options: Omit<RequestOptions, "url"> & { path: string },
+  ): Promise<RawResponse> {
+    await this.ensureSession();
+    const url = `${this.instanceUrl}${options.path}`;
+
+    const headers = {
+      Authorization: `Bearer ${this.accessToken}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...options.headers,
+    };
+
+    const response = await this.performRequest({
+      method: options.method,
+      url,
+      headers,
+      body: options.body,
+    });
+
+    if (response.statusCode === 401) {
+      this.accessToken = null;
+      await this.ensureSession();
+      return this.requestWithAuth(options);
+    }
+
+    return response;
+  }
+
+  private apiPath(resource: string) {
+    return `/services/data/${this.apiVersion}${resource}`;
+  }
+
+  async query<T>(soql: string): Promise<SalesforceQueryResult<T>> {
+    const response = await this.requestWithAuth({
+      method: "GET",
+      path: this.apiPath(`/query?q=${encodeURIComponent(soql)}`),
+    });
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new Error(`Salesforce query failed: ${response.statusCode} ${response.body}`);
+    }
+
+    return JSON.parse(response.body) as SalesforceQueryResult<T>;
+  }
+
+  private async retrieveByExternalId(
+    objectName: string,
+    externalIdField: string,
+    externalIdValue: string,
+  ) {
+    const path =
+      externalIdField === "Id"
+        ? this.apiPath(`/sobjects/${objectName}/${encodeURIComponent(externalIdValue)}`)
+        : this.apiPath(
+            `/sobjects/${objectName}/${externalIdField}/${encodeURIComponent(externalIdValue)}`,
+          );
+
+    const response = await this.requestWithAuth({
+      method: "GET",
+      path,
+    });
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw new Error(
+        `Salesforce retrieve failed: ${response.statusCode} ${response.body}`,
+      );
+    }
+
+    return JSON.parse(response.body) as { Id: string };
+  }
+
+  async upsert(
+    objectName: string,
+    externalIdField: string,
+    externalIdValue: string,
+    payload: Record<string, unknown>,
+  ): Promise<SalesforceUpsertResult> {
+    const path =
+      externalIdField === "Id"
+        ? this.apiPath(`/sobjects/${objectName}/${encodeURIComponent(externalIdValue)}`)
+        : this.apiPath(
+            `/sobjects/${objectName}/${externalIdField}/${encodeURIComponent(externalIdValue)}`,
+          );
+
+    const response = await this.requestWithAuth({
+      method: "PATCH",
+      path,
+      body: JSON.stringify(payload),
+    });
+
+    if (response.statusCode === 201 || response.statusCode === 200) {
+      const body = JSON.parse(response.body) as { id: string };
+      return { id: body.id, action: "created" };
+    }
+
+    if (response.statusCode === 204) {
+      const record = await this.retrieveByExternalId(
+        objectName,
+        externalIdField,
+        externalIdValue,
+      );
+      return { id: record.Id, action: "updated" };
+    }
+
+    throw new Error(
+      `Salesforce upsert failed: ${response.statusCode} ${response.body}`,
+    );
+  }
+}

--- a/tests/contract/salesforce.post.spec.ts
+++ b/tests/contract/salesforce.post.spec.ts
@@ -1,0 +1,243 @@
+import { strict as assert } from "node:assert";
+import http from "node:http";
+import { AddressInfo } from "node:net";
+import { once } from "node:events";
+import { postToSalesforce } from "../../src/services/process/post_sf";
+import { NormalizedTransaction } from "../../src/services/process/normalize";
+import { ServiceContext } from "../../src/services/shared/types";
+import { Env } from "../../src/config/env";
+
+type RecordedRequest = {
+  method: string;
+  url: string;
+  body: unknown;
+};
+
+type RecordStore = {
+  id: string;
+  body: Record<string, unknown>;
+};
+
+const createServer = async () => {
+  let counter = 1;
+  const records = new Map<string, RecordStore>();
+  const requests: RecordedRequest[] = [];
+
+  const server = http.createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.from(chunk));
+    }
+
+    const rawBody = Buffer.concat(chunks).toString("utf8");
+    let body: unknown = undefined;
+
+    if (rawBody) {
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        body = rawBody;
+      }
+    }
+    requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+
+    const url = req.url ?? "";
+
+    if (req.method === "POST" && url === "/services/oauth2/token") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          access_token: "token",
+          instance_url: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+          token_type: "Bearer",
+        }),
+      );
+      return;
+    }
+
+    if (url.startsWith("/services/data/")) {
+      const [path] = url.split("?");
+      const parts = path.split("/").filter(Boolean);
+      const objectName = parts[4];
+
+      if (parts[3] === "query") {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ totalSize: 0, done: true, records: [] }));
+        return;
+      }
+
+      let externalField = "Id";
+      let externalValue = "";
+
+      if (parts.length === 7) {
+        externalField = decodeURIComponent(parts[5]);
+        externalValue = decodeURIComponent(parts[6]);
+      } else {
+        externalValue = decodeURIComponent(parts[5]);
+      }
+
+      const key = `${objectName}:${externalField}:${externalValue}`;
+      const existing = records.get(key);
+
+      if (req.method === "PATCH") {
+        const incoming =
+          body && typeof body === "object"
+            ? (body as Record<string, unknown>)
+            : ({} as Record<string, unknown>);
+
+        if (existing) {
+          records.set(key, { id: existing.id, body: { ...existing.body, ...incoming } });
+          res.writeHead(204, { "Content-Type": "application/json" });
+          res.end();
+          return;
+        }
+
+        const id = `${objectName.slice(0, 3)}${String(counter).padStart(6, "0")}`;
+        counter += 1;
+        records.set(key, { id, body: incoming });
+        res.writeHead(201, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ id }));
+        return;
+      }
+
+      if (req.method === "GET") {
+        if (!existing) {
+          res.writeHead(404, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ error: "not_found" }));
+          return;
+        }
+
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ Id: existing.id, ...existing.body }));
+        return;
+      }
+    }
+
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "unhandled" }));
+  });
+
+  server.listen(0);
+  await once(server, "listening");
+  const address = server.address() as AddressInfo;
+
+  return {
+    requests,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+    baseUrl: `http://127.0.0.1:${address.port}`,
+  };
+};
+
+const createContext = (overrides?: Partial<Env>): ServiceContext => ({
+  env: {
+    STRIPE_SECRET: "sk_test",
+    STRIPE_WEBHOOK_SECRET: "whsec",
+    SF_CLIENT_ID: "client",
+    SF_CLIENT_SECRET: "secret",
+    SF_USERNAME: "user",
+    SF_PASSWORD: "pass",
+    QBO_CLIENT_ID: "qbo",
+    QBO_CLIENT_SECRET: "qbo_secret",
+    QBO_ENV: "sandbox",
+    QBO_REALM_ID: "realm",
+    ENABLE_SF: true,
+    ENABLE_QBO: false,
+    QBO_FEES_AGGREGATION: "per_tx",
+    DOCNUM_PREFIX: "stripe",
+    SF_USE_NPSP: false,
+    QBO_ACCOUNT_STRIPE_CLEARING: "1",
+    QBO_ACCOUNT_CHECKING: "2",
+    QBO_ACCOUNT_STRIPE_FEES: "3",
+    QBO_ITEM_DONATION: "donation",
+    DATABASE_URL: "postgres://test",
+    AZURE_STORAGE_CONNECTION_STRING: "UseDevelopmentStorage=true",
+    ...(overrides ?? {}),
+  } as Env,
+});
+
+const paymentTransaction = (): NormalizedTransaction => ({
+  payments: [
+    {
+      chargeId: "ch_123",
+      customerId: "cus_123",
+      created: new Date("2024-01-01T00:00:00Z").toISOString(),
+      amount: { amount: 5000, currency: "usd" },
+      net: undefined,
+      fee: undefined,
+      description: "Donation",
+      metadata: { customer_email: "donor@example.com", customer_name: "Jane Doe" },
+    },
+  ],
+});
+
+const paymentWithoutCustomer = (): NormalizedTransaction => ({
+  payments: [
+    {
+      chargeId: "ch_124",
+      created: new Date("2024-01-02T00:00:00Z").toISOString(),
+      amount: { amount: 2500, currency: "usd" },
+      description: "Donation",
+      metadata: { email: "fallback@example.com" },
+    },
+  ],
+});
+
+const run = async () => {
+  const server = await createServer();
+
+  const context = createContext({ SF_LOGIN_URL: server.baseUrl });
+  const result = await postToSalesforce(paymentTransaction(), context);
+
+  assert.equal(result.action, "created");
+  assert.ok(result.id, "should return created id");
+
+  const contactRequest = server.requests.find((request) =>
+    request.url.includes("Contact/stripe_customer_id__c/cus_123"),
+  );
+  assert.ok(contactRequest, "contact upsert by customer id should occur");
+
+  const paymentRequest = server.requests.find((request) =>
+    request.url.includes("Payment__c/Stripe_Charge_Id__c/ch_123"),
+  );
+  assert.ok(paymentRequest, "payment upsert should occur");
+
+  const rerun = await postToSalesforce(paymentTransaction(), context);
+  assert.equal(rerun.action, "updated", "second run should update existing record");
+
+  const contactUpdates = server.requests.filter(
+    (request) =>
+      request.method === "PATCH" &&
+      request.url.includes("Contact/stripe_customer_id__c/cus_123"),
+  );
+  assert.equal(contactUpdates.length, 2, "contact upsert should run twice");
+
+  const paymentUpdates = server.requests.filter(
+    (request) =>
+      request.method === "PATCH" &&
+      request.url.includes("Payment__c/Stripe_Charge_Id__c/ch_123"),
+  );
+  assert.equal(paymentUpdates.length, 2, "payment upsert should run twice");
+
+  const fallbackContext = createContext({ SF_LOGIN_URL: server.baseUrl });
+  const fallbackResult = await postToSalesforce(paymentWithoutCustomer(), fallbackContext);
+  assert.equal(fallbackResult.action, "created");
+
+  const fallbackRequest = server.requests.find((request) =>
+    request.url.includes("Contact/Email/fallback%40example.com"),
+  );
+  assert.ok(fallbackRequest, "fallback upsert should use email path");
+
+  await server.close();
+};
+
+run()
+  .then(() => {
+    console.log("salesforce.post.spec.ts passed");
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
## Summary
- add a lightweight Salesforce REST client with password-flow authentication, query, and upsert helpers that resolve record ids
- implement postToSalesforce to upsert contacts, payments, refunds, disputes, and payouts (with NPSP support) and honor ENABLE_SF gating in process_transaction
- add a contract test with a mocked Salesforce server to verify upsert behavior and idempotency

## Testing
- npx ts-node tests/contract/salesforce.post.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e423b9fce4832cbac3a124c7f6e2d5