### PR TITLE
Add QuickBooks posting client and contract tests

### DIFF
--- a/src/services/process/post_qbo.ts
+++ b/src/services/process/post_qbo.ts
@@ -1,7 +1,402 @@
+import { QuickBooksRoute } from "./decide";
 import { NormalizedTransaction } from "./normalize";
-import { ServiceContext } from "../shared/types";
+import { ServiceContext, Money } from "../shared/types";
+import {
+  docnum_dispute,
+  docnum_fee_daily,
+  docnum_fee_tx,
+  docnum_payout,
+  docnum_refund,
+  docnum_salesreceipt,
+} from "../shared/doc_numbers";
+import { createQboClient } from "../qbo/qbo_client";
+
+type QuickBooksSummary = {
+  action: "skipped" | "noop" | "created";
+  doc_type?: string | null;
+  doc_id?: string | null;
+};
+
+const defaultSummary: QuickBooksSummary = {
+  action: "skipped",
+  doc_type: null,
+  doc_id: null,
+};
+
+const centsToDecimal = (money: Money | undefined): number | undefined => {
+  if (!money) {
+    return undefined;
+  }
+
+  return money.amount / 100;
+};
+
+const isoDate = (iso: string | undefined): string | undefined =>
+  iso?.split("T")[0];
+
+const currencyCode = (...values: (string | undefined)[]): string | undefined => {
+  for (const value of values) {
+    if (value) {
+      return value.toUpperCase();
+    }
+  }
+  return undefined;
+};
+
+const stripUndefined = <T extends Record<string, unknown>>(input: T): T => {
+  const entries = Object.entries(input).filter(([, value]) => value !== undefined);
+  return Object.fromEntries(entries) as T;
+};
+
+const maybeCreateFeeEntry = async (
+  context: ServiceContext,
+  client: ReturnType<typeof createQboClient>,
+  transaction: NormalizedTransaction["payments"] | undefined,
+) => {
+  if (!transaction || transaction.length === 0) {
+    return;
+  }
+
+  for (const payment of transaction) {
+    const feeMoney = payment.balanceSummary?.fee_total ?? payment.fee;
+    if (!feeMoney || feeMoney.amount === 0) {
+      continue;
+    }
+
+    const aggregation = context.env.QBO_FEES_AGGREGATION ?? "per_tx";
+    let docNumber: string | null = null;
+
+    if (aggregation === "daily") {
+      const sourceDate =
+        payment.balanceSummary?.available_on ?? payment.created ?? null;
+      if (!sourceDate) {
+        continue;
+      }
+      const datePart = isoDate(sourceDate)?.replace(/-/g, "");
+      const dailyCurrency = feeMoney.currency ?? payment.amount?.currency;
+      if (!datePart || !dailyCurrency) {
+        continue;
+      }
+      docNumber = docnum_fee_daily(datePart, dailyCurrency);
+    } else {
+      const balanceId = payment.balanceTransactionId ?? payment.chargeId;
+      if (!balanceId) {
+        continue;
+      }
+      docNumber = docnum_fee_tx(balanceId);
+    }
+
+    if (!docNumber) {
+      continue;
+    }
+
+    const existing = await client.findByDocNumber("JournalEntry", docNumber);
+    if (existing) {
+      continue;
+    }
+
+    const amount = Math.abs(feeMoney.amount) / 100;
+    if (amount <= 0) {
+      continue;
+    }
+
+    const resolvedCurrency = currencyCode(
+      feeMoney.currency,
+      payment.amount?.currency,
+    );
+    const description = `Stripe fee for ${payment.chargeId}`;
+
+    await client.createJournalEntry(
+      stripUndefined({
+        DocNumber: docNumber,
+        TxnDate: isoDate(payment.created),
+        PrivateNote: description,
+        CurrencyRef: resolvedCurrency ? { value: resolvedCurrency } : undefined,
+        Line: [
+          stripUndefined({
+            DetailType: "JournalEntryLineDetail",
+            Amount: amount,
+            Description: description,
+            JournalEntryLineDetail: {
+              PostingType: "Credit",
+              AccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_CLEARING },
+            },
+          }),
+          stripUndefined({
+            DetailType: "JournalEntryLineDetail",
+            Amount: amount,
+            Description: description,
+            JournalEntryLineDetail: {
+              PostingType: "Debit",
+              AccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_FEES },
+            },
+          }),
+        ],
+      }),
+    );
+  }
+};
+
+const postPayment = async (
+  context: ServiceContext,
+  transaction: NormalizedTransaction,
+): Promise<QuickBooksSummary> => {
+  const payment = transaction.payments?.[0];
+  if (!payment) {
+    return defaultSummary;
+  }
+
+  const client = createQboClient(context);
+  const docNumber = docnum_salesreceipt(payment.chargeId);
+  const existing = await client.findByDocNumber("SalesReceipt", docNumber);
+  if (existing) {
+    await maybeCreateFeeEntry(context, client, transaction.payments);
+    return { action: "noop", doc_type: "SalesReceipt", doc_id: existing.Id };
+  }
+
+  const amount = centsToDecimal(payment.amount);
+  if (amount === undefined) {
+    return defaultSummary;
+  }
+
+  const currency = currencyCode(payment.amount.currency);
+  const description = payment.description ?? undefined;
+
+  const payload = stripUndefined({
+    DocNumber: docNumber,
+    TxnDate: isoDate(payment.created),
+    PrivateNote: description,
+    CustomerMemo: description ? { value: description } : undefined,
+    DepositToAccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_CLEARING },
+    CurrencyRef: currency ? { value: currency } : undefined,
+    TotalAmt: amount,
+    Line: [
+      stripUndefined({
+        DetailType: "SalesItemLineDetail",
+        Amount: amount,
+        Description: description,
+        SalesItemLineDetail: {
+          ItemRef: { value: context.env.QBO_ITEM_DONATION },
+        },
+      }),
+    ],
+  });
+
+  const created = await client.createSalesReceipt(payload);
+  await maybeCreateFeeEntry(context, client, transaction.payments);
+
+  return { action: "created", doc_type: "SalesReceipt", doc_id: created.Id };
+};
+
+const postRefund = async (
+  context: ServiceContext,
+  transaction: NormalizedTransaction,
+): Promise<QuickBooksSummary> => {
+  const refund = transaction.refunds?.[0];
+  if (!refund) {
+    return defaultSummary;
+  }
+
+  const client = createQboClient(context);
+  const docNumber = docnum_refund(refund.refundId);
+  const existing = await client.findByDocNumber("RefundReceipt", docNumber);
+  if (existing) {
+    return { action: "noop", doc_type: "RefundReceipt", doc_id: existing.Id };
+  }
+
+  const amount = centsToDecimal(refund.amount);
+  if (amount === undefined) {
+    return defaultSummary;
+  }
+
+  const currency = currencyCode(refund.amount.currency);
+  const description = refund.reason ?? undefined;
+
+  const payload = stripUndefined({
+    DocNumber: docNumber,
+    TxnDate: isoDate(refund.created),
+    PrivateNote: description,
+    DepositToAccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_CLEARING },
+    CurrencyRef: currency ? { value: currency } : undefined,
+    TotalAmt: amount,
+    Line: [
+      stripUndefined({
+        DetailType: "SalesItemLineDetail",
+        Amount: amount,
+        Description: description,
+        SalesItemLineDetail: {
+          ItemRef: { value: context.env.QBO_ITEM_DONATION },
+        },
+      }),
+    ],
+  });
+
+  const created = await client.createRefundReceipt(payload);
+  return { action: "created", doc_type: "RefundReceipt", doc_id: created.Id };
+};
+
+const postDispute = async (
+  context: ServiceContext,
+  transaction: NormalizedTransaction,
+): Promise<QuickBooksSummary> => {
+  const dispute = transaction.disputes?.[0];
+  if (!dispute) {
+    return defaultSummary;
+  }
+
+  const client = createQboClient(context);
+  const docNumber = docnum_dispute(dispute.disputeId, dispute.status);
+  const existing = await client.findByDocNumber("JournalEntry", docNumber);
+  if (existing) {
+    return { action: "noop", doc_type: "JournalEntry", doc_id: existing.Id };
+  }
+
+  const amountValue = centsToDecimal(dispute.amount);
+  if (!amountValue) {
+    return defaultSummary;
+  }
+
+  const currency = currencyCode(dispute.amount.currency);
+  const description = `Stripe dispute ${dispute.disputeId} (${dispute.status})`;
+
+  const hold =
+    dispute.status !== "won" && dispute.status !== "lost" && dispute.status !== "closed";
+
+  const lines = hold
+    ? [
+        stripUndefined({
+          DetailType: "JournalEntryLineDetail",
+          Amount: amountValue,
+          Description: description,
+          JournalEntryLineDetail: {
+            PostingType: "Debit",
+            AccountRef: { value: context.env.QBO_ACCOUNT_CHECKING },
+          },
+        }),
+        stripUndefined({
+          DetailType: "JournalEntryLineDetail",
+          Amount: amountValue,
+          Description: description,
+          JournalEntryLineDetail: {
+            PostingType: "Credit",
+            AccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_CLEARING },
+          },
+        }),
+      ]
+    : dispute.status === "lost"
+    ? [
+        stripUndefined({
+          DetailType: "JournalEntryLineDetail",
+          Amount: amountValue,
+          Description: description,
+          JournalEntryLineDetail: {
+            PostingType: "Debit",
+            AccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_FEES },
+          },
+        }),
+        stripUndefined({
+          DetailType: "JournalEntryLineDetail",
+          Amount: amountValue,
+          Description: description,
+          JournalEntryLineDetail: {
+            PostingType: "Credit",
+            AccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_CLEARING },
+          },
+        }),
+      ]
+    : [
+        stripUndefined({
+          DetailType: "JournalEntryLineDetail",
+          Amount: amountValue,
+          Description: description,
+          JournalEntryLineDetail: {
+            PostingType: "Debit",
+            AccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_CLEARING },
+          },
+        }),
+        stripUndefined({
+          DetailType: "JournalEntryLineDetail",
+          Amount: amountValue,
+          Description: description,
+          JournalEntryLineDetail: {
+            PostingType: "Credit",
+            AccountRef: { value: context.env.QBO_ACCOUNT_CHECKING },
+          },
+        }),
+      ];
+
+  const created = await client.createJournalEntry(
+    stripUndefined({
+      DocNumber: docNumber,
+      TxnDate: isoDate(dispute.created),
+      PrivateNote: description,
+      CurrencyRef: currency ? { value: currency } : undefined,
+      Line: lines,
+    }),
+  );
+
+  return { action: "created", doc_type: "JournalEntry", doc_id: created.Id };
+};
+
+const postPayout = async (
+  context: ServiceContext,
+  transaction: NormalizedTransaction,
+): Promise<QuickBooksSummary> => {
+  const payout = transaction.payouts?.[0];
+  if (!payout) {
+    return defaultSummary;
+  }
+
+  const client = createQboClient(context);
+  const docNumber = docnum_payout(payout.payoutId);
+  const existing = await client.findByDocNumber("Transfer", docNumber);
+  if (existing) {
+    return { action: "noop", doc_type: "Transfer", doc_id: existing.Id };
+  }
+
+  const amount = centsToDecimal(payout.amount);
+  if (amount === undefined) {
+    return defaultSummary;
+  }
+
+  const currency = currencyCode(payout.amount.currency);
+  const payload = stripUndefined({
+    DocNumber: docNumber,
+    TxnDate: isoDate(payout.arrivalDate),
+    Amount: amount,
+    CurrencyRef: currency ? { value: currency } : undefined,
+    FromAccountRef: { value: context.env.QBO_ACCOUNT_STRIPE_CLEARING },
+    ToAccountRef: { value: context.env.QBO_ACCOUNT_CHECKING },
+  });
+
+  const created = await client.createTransfer(payload);
+  return { action: "created", doc_type: "Transfer", doc_id: created.Id };
+};
 
 export const postToQuickBooks = async (
-  _transaction: NormalizedTransaction,
-  _context: ServiceContext,
-): Promise<{ action: "skipped" }> => ({ action: "skipped" });
+  transaction: NormalizedTransaction,
+  route: QuickBooksRoute | undefined,
+  context: ServiceContext,
+): Promise<QuickBooksSummary> => {
+  if (!route) {
+    return defaultSummary;
+  }
+
+  if (route === "sales_receipt") {
+    return postPayment(context, transaction);
+  }
+
+  if (route === "refund_receipt") {
+    return postRefund(context, transaction);
+  }
+
+  if (route === "dispute_entry") {
+    return postDispute(context, transaction);
+  }
+
+  if (route === "transfer") {
+    return postPayout(context, transaction);
+  }
+
+  return defaultSummary;
+};

--- a/src/services/process/process_transaction.ts
+++ b/src/services/process/process_transaction.ts
@@ -18,10 +18,16 @@ export interface SyncSummary {
   id?: string | null;
 }
 
+export interface QuickBooksSummary {
+  action: "skipped" | "noop" | "created";
+  doc_type?: string | null;
+  doc_id?: string | null;
+}
+
 export interface ProcessTransactionResult {
   decision: DecisionResult;
   sf: SyncSummary;
-  qbo: SyncSummary;
+  qbo: QuickBooksSummary;
 }
 
 export const processTransaction = async (
@@ -45,9 +51,12 @@ export const processTransaction = async (
         ? await postToSalesforce(normalized, context)
         : { action: "skipped" as const };
 
-    const qbo = decision.shouldSyncQuickBooks
-      ? await postToQuickBooks(normalized, context)
-      : { action: "skipped" as const };
+    const isQuickBooksEnabled = context.env.ENABLE_QBO !== false;
+
+    const qbo =
+      decision.shouldSyncQuickBooks && isQuickBooksEnabled
+        ? await postToQuickBooks(normalized, decision.quickbooksRoute, context)
+        : { action: "skipped" as const };
 
     return {
       decision,

--- a/src/services/qbo/qbo_client.ts
+++ b/src/services/qbo/qbo_client.ts
@@ -1,0 +1,291 @@
+import { ServiceContext } from "../shared/types";
+
+export type QboDocType =
+  | "SalesReceipt"
+  | "RefundReceipt"
+  | "JournalEntry"
+  | "Transfer";
+
+type FetchFn = typeof fetch;
+
+type OAuthTokens = {
+  accessToken: string | null;
+  refreshToken: string | null;
+  expiresAt: number;
+};
+
+type RequestOptions = {
+  body?: unknown;
+  query?: Record<string, string | number | undefined>;
+  retry?: boolean;
+};
+
+type QueryResponse<T> = {
+  QueryResponse?: Record<string, T[]>;
+};
+
+type CreatedEntity<T extends QboDocType> =
+  | { [K in T]: { Id: string } & Record<string, unknown> }
+  | ({ Id: string } & Record<string, unknown>);
+
+const DEFAULT_MINOR_VERSION = "65";
+const DEFAULT_EXPIRATION_BUFFER = 60_000;
+const DEFAULT_ACCESS_TOKEN_TTL = 60 * 60 * 1000; // 1 hour
+
+const docTypePath: Record<QboDocType, string> = {
+  SalesReceipt: "salesreceipt",
+  RefundReceipt: "refundreceipt",
+  JournalEntry: "journalentry",
+  Transfer: "transfer",
+};
+
+const defaultBaseUrl = (env: ServiceContext["env"]): string =>
+  env.QBO_ENV === "prod"
+    ? "https://quickbooks.api.intuit.com"
+    : "https://sandbox-quickbooks.api.intuit.com";
+
+const defaultTokenUrl = () =>
+  "https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer";
+
+const encodeBasicAuth = (clientId: string, clientSecret: string) =>
+  Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+
+const parseJson = async (response: Response) => {
+  const text = await response.text();
+  if (!text) {
+    return null;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+export class QuickBooksClient {
+  private readonly fetchFn: FetchFn;
+  private readonly baseUrl: string;
+  private readonly tokenUrl: string;
+  private readonly minorVersion: string;
+  private tokens: OAuthTokens;
+
+  constructor(
+    private readonly context: ServiceContext,
+    options?: { fetchFn?: FetchFn; minorVersion?: string },
+  ) {
+    const env = context.env as ServiceContext["env"] & {
+      QBO_API_BASE_URL?: string;
+      QBO_TOKEN_URL?: string;
+      QBO_ACCESS_TOKEN?: string;
+      QBO_REFRESH_TOKEN?: string;
+    };
+
+    this.fetchFn = options?.fetchFn ?? fetch;
+    this.baseUrl = env.QBO_API_BASE_URL ?? defaultBaseUrl(env);
+    this.tokenUrl = env.QBO_TOKEN_URL ?? defaultTokenUrl();
+    this.minorVersion = options?.minorVersion ?? DEFAULT_MINOR_VERSION;
+
+    const accessToken = env.QBO_ACCESS_TOKEN ?? null;
+    const refreshToken = env.QBO_REFRESH_TOKEN ?? null;
+    const expiresAt = accessToken
+      ? Date.now() + DEFAULT_ACCESS_TOKEN_TTL
+      : 0;
+
+    this.tokens = {
+      accessToken,
+      refreshToken,
+      expiresAt,
+    };
+  }
+
+  private async refreshAccessToken(): Promise<string> {
+    if (!this.tokens.refreshToken) {
+      throw new Error("QuickBooks refresh token is not configured");
+    }
+
+    const headers = {
+      Authorization: `Basic ${encodeBasicAuth(
+        this.context.env.QBO_CLIENT_ID,
+        this.context.env.QBO_CLIENT_SECRET,
+      )}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    };
+
+    const body = new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: this.tokens.refreshToken,
+    }).toString();
+
+    const response = await this.fetchFn(this.tokenUrl, {
+      method: "POST",
+      headers,
+      body,
+    });
+
+    if (!response.ok) {
+      const payload = await parseJson(response);
+      throw new Error(
+        `Failed to refresh QuickBooks token: ${response.status} ${JSON.stringify(payload)}`,
+      );
+    }
+
+    const payload = (await parseJson(response)) as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+    } | null;
+
+    if (!payload || typeof payload.access_token !== "string") {
+      throw new Error("Invalid token response from QuickBooks");
+    }
+
+    this.tokens.accessToken = payload.access_token;
+    if (payload.refresh_token) {
+      this.tokens.refreshToken = payload.refresh_token;
+    }
+
+    const expiresInMs =
+      typeof payload.expires_in === "number"
+        ? payload.expires_in * 1000
+        : DEFAULT_ACCESS_TOKEN_TTL;
+
+    this.tokens.expiresAt = Date.now() + expiresInMs;
+
+    return this.tokens.accessToken;
+  }
+
+  private async ensureAccessToken(): Promise<string> {
+    const now = Date.now();
+    if (
+      this.tokens.accessToken &&
+      now < this.tokens.expiresAt - DEFAULT_EXPIRATION_BUFFER
+    ) {
+      return this.tokens.accessToken;
+    }
+
+    if (!this.tokens.refreshToken && this.tokens.accessToken) {
+      return this.tokens.accessToken;
+    }
+
+    return this.refreshAccessToken();
+  }
+
+  private async request<T = unknown>(
+    method: string,
+    path: string,
+    options?: RequestOptions,
+  ): Promise<T> {
+    const token = await this.ensureAccessToken();
+    const url = new URL(`${this.baseUrl}${path}`);
+
+    url.searchParams.set("minorversion", this.minorVersion);
+
+    for (const [key, value] of Object.entries(options?.query ?? {})) {
+      if (value === undefined) {
+        continue;
+      }
+      url.searchParams.set(key, String(value));
+    }
+
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    };
+
+    let body: string | undefined;
+
+    if (options?.body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      body = JSON.stringify(options.body);
+    }
+
+    const response = await this.fetchFn(url.toString(), {
+      method,
+      headers,
+      body,
+    });
+
+    if (response.status === 401 && options?.retry !== false) {
+      this.tokens.expiresAt = 0;
+      await this.refreshAccessToken();
+      return this.request<T>(method, path, { ...options, retry: false });
+    }
+
+    const payload = await parseJson(response);
+
+    if (!response.ok) {
+      throw new Error(
+        `QuickBooks request failed: ${response.status} ${JSON.stringify(payload)}`,
+      );
+    }
+
+    return payload as T;
+  }
+
+  async findByDocNumber<T extends QboDocType>(
+    docType: T,
+    docNumber: string,
+  ): Promise<({ Id: string } & Record<string, unknown>) | null> {
+    const sanitized = docNumber.replace(/'/g, "''");
+    const query = `select * from ${docType} where DocNumber = '${sanitized}'`;
+    const result = await this.request<QueryResponse<{ Id: string }>>(
+      "GET",
+      `/v3/company/${this.context.env.QBO_REALM_ID}/query`,
+      { query: { query } },
+    );
+
+    const entries = result.QueryResponse?.[docType];
+    if (Array.isArray(entries) && entries.length > 0) {
+      return entries[0];
+    }
+
+    return null;
+  }
+
+  private async createEntity<T extends QboDocType>(
+    docType: T,
+    payload: Record<string, unknown>,
+  ): Promise<{ Id: string } & Record<string, unknown>> {
+    const path = `/v3/company/${this.context.env.QBO_REALM_ID}/${docTypePath[docType]}`;
+    const result = await this.request<CreatedEntity<T>>("POST", path, {
+      body: payload,
+    });
+
+    if (result && typeof result === "object") {
+      if (docType in result && result[docType as keyof typeof result]) {
+        const entity = result[docType as keyof typeof result];
+        if (entity && typeof entity === "object" && "Id" in entity) {
+          return entity as { Id: string } & Record<string, unknown>;
+        }
+      }
+
+      if ("Id" in result) {
+        return result as { Id: string } & Record<string, unknown>;
+      }
+    }
+
+    throw new Error(`Unexpected QuickBooks response for ${docType}`);
+  }
+
+  createSalesReceipt(payload: Record<string, unknown>) {
+    return this.createEntity("SalesReceipt", payload);
+  }
+
+  createRefundReceipt(payload: Record<string, unknown>) {
+    return this.createEntity("RefundReceipt", payload);
+  }
+
+  createJournalEntry(payload: Record<string, unknown>) {
+    return this.createEntity("JournalEntry", payload);
+  }
+
+  createTransfer(payload: Record<string, unknown>) {
+    return this.createEntity("Transfer", payload);
+  }
+}
+
+export const createQboClient = (
+  context: ServiceContext,
+  options?: { fetchFn?: FetchFn; minorVersion?: string },
+): QuickBooksClient => new QuickBooksClient(context, options);

--- a/src/services/shared/doc_numbers.ts
+++ b/src/services/shared/doc_numbers.ts
@@ -31,3 +31,8 @@ export const docnum_fee_daily = (
 
 export const docnum_payout = (payoutId: string): string =>
   formatDocnum("payout", payoutId);
+
+export const docnum_dispute = (
+  disputeId: string,
+  status: string,
+): string => formatDocnum("dispute", disputeId, status);

--- a/tests/contract/qbo.post.spec.ts
+++ b/tests/contract/qbo.post.spec.ts
@@ -1,0 +1,334 @@
+import { strict as assert } from "node:assert";
+import http from "node:http";
+import { AddressInfo } from "node:net";
+import { once } from "node:events";
+import { postToQuickBooks } from "../../src/services/process/post_qbo";
+import { NormalizedTransaction } from "../../src/services/process/normalize";
+import { ServiceContext } from "../../src/services/shared/types";
+import { Env } from "../../src/config/env";
+import { docnum_fee_tx, docnum_payout, docnum_salesreceipt, docnum_dispute } from "../../src/services/shared/doc_numbers";
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+type StoredRecord = { Id: string } & Record<string, unknown>;
+
+type RecordStore = {
+  SalesReceipt: Map<string, StoredRecord>;
+  RefundReceipt: Map<string, StoredRecord>;
+  JournalEntry: Map<string, StoredRecord>;
+  Transfer: Map<string, StoredRecord>;
+};
+
+type ServerInstance = {
+  baseUrl: string;
+  requests: RecordedRequest[];
+  records: RecordStore;
+  close: () => Promise<void>;
+};
+
+const resourceToDocType: Record<string, keyof RecordStore> = {
+  salesreceipt: "SalesReceipt",
+  refundreceipt: "RefundReceipt",
+  journalentry: "JournalEntry",
+  transfer: "Transfer",
+};
+
+const createServer = async (): Promise<ServerInstance> => {
+  let counter = 1;
+  const requests: RecordedRequest[] = [];
+  const records: RecordStore = {
+    SalesReceipt: new Map(),
+    RefundReceipt: new Map(),
+    JournalEntry: new Map(),
+    Transfer: new Map(),
+  };
+
+  const server = http.createServer(async (req, res) => {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.from(chunk));
+    }
+
+    const rawBody = Buffer.concat(chunks).toString("utf8");
+    let body: unknown = undefined;
+    if (rawBody) {
+      try {
+        body = JSON.parse(rawBody);
+      } catch {
+        body = rawBody;
+      }
+    }
+
+    requests.push({ method: req.method ?? "GET", url: req.url ?? "", body });
+
+    const url = new URL(req.url ?? "", "http://qbo.local");
+
+    if (req.method === "POST" && url.pathname === "/oauth/token") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          access_token: `token-${counter++}`,
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        }),
+      );
+      return;
+    }
+
+    const match = url.pathname.match(/\/v3\/company\/[^/]+\/(\w+)/);
+    const resource = match?.[1]?.toLowerCase();
+
+    if (req.method === "GET" && resource === "query") {
+      const query = url.searchParams.get("query") ?? "";
+      const docTypeMatch = query.match(/from\s+(\w+)/i);
+      const docNumberMatch = query.match(/DocNumber\s*=\s*'([^']+)'/i);
+      const docType = docTypeMatch?.[1] as keyof RecordStore | undefined;
+      const docNumber = docNumberMatch?.[1] ?? "";
+      const existing = docType ? records[docType].get(docNumber) : null;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          QueryResponse: {
+            [docType ?? "Unknown"]: existing ? [existing] : [],
+          },
+        }),
+      );
+      return;
+    }
+
+    if (req.method === "POST" && resource && resource in resourceToDocType) {
+      const docType = resourceToDocType[resource];
+      const payload = (body ?? {}) as Record<string, unknown>;
+      const docNumber = String(payload.DocNumber ?? "");
+      const id = `${docType.slice(0, 2).toUpperCase()}-${counter++}`;
+      const record = { Id: id, ...payload } as StoredRecord;
+      records[docType].set(docNumber, record);
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ [docType]: record }));
+      return;
+    }
+
+    res.writeHead(404, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "not_found" }));
+  });
+
+  server.listen(0);
+  await once(server, "listening");
+  const address = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  return {
+    baseUrl,
+    requests,
+    records,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+};
+
+const createContext = (
+  baseUrl: string,
+  overrides?: Partial<Env>,
+): ServiceContext => ({
+  env: {
+    STRIPE_SECRET: "sk_test",
+    STRIPE_WEBHOOK_SECRET: "whsec",
+    SF_CLIENT_ID: "sf",
+    SF_CLIENT_SECRET: "sf_secret",
+    SF_USERNAME: "sf_user",
+    SF_PASSWORD: "sf_pass",
+    QBO_CLIENT_ID: "qbo",
+    QBO_CLIENT_SECRET: "qbo_secret",
+    QBO_ENV: "sandbox",
+    QBO_REALM_ID: "realm",
+    ENABLE_SF: false,
+    ENABLE_QBO: true,
+    QBO_FEES_AGGREGATION: "per_tx",
+    DOCNUM_PREFIX: "stripe",
+    SF_USE_NPSP: false,
+    QBO_ACCOUNT_STRIPE_CLEARING: "clearing",
+    QBO_ACCOUNT_CHECKING: "checking",
+    QBO_ACCOUNT_STRIPE_FEES: "fees",
+    QBO_ITEM_DONATION: "donation",
+    DATABASE_URL: "postgres://test",
+    AZURE_STORAGE_CONNECTION_STRING: "UseDevelopmentStorage=true",
+    QBO_API_BASE_URL: baseUrl,
+    QBO_TOKEN_URL: `${baseUrl}/oauth/token`,
+    QBO_REFRESH_TOKEN: "refresh",
+    ...(overrides ?? {}),
+  } as Env & Record<string, unknown>,
+});
+
+const paymentTransaction = (): NormalizedTransaction => ({
+  payments: [
+    {
+      chargeId: "ch_123",
+      created: new Date("2024-01-01T00:00:00Z").toISOString(),
+      amount: { amount: 5000, currency: "usd" },
+      description: "Donation",
+      metadata: {},
+      balanceTransactionId: "txn_123",
+      balanceSummary: {
+        gross: { amount: 5000, currency: "usd" },
+        fee_total: { amount: 200, currency: "usd" },
+        net: { amount: 4800, currency: "usd" },
+        available_on: new Date("2024-01-02T00:00:00Z").toISOString(),
+      },
+    },
+  ],
+});
+
+const refundTransaction = (): NormalizedTransaction => ({
+  refunds: [
+    {
+      refundId: "re_123",
+      chargeId: "ch_123",
+      created: new Date("2024-01-05T00:00:00Z").toISOString(),
+      amount: { amount: 1500, currency: "usd" },
+      status: "succeeded",
+      reason: "requested_by_customer",
+      metadata: {},
+    },
+  ],
+});
+
+const payoutTransaction = (): NormalizedTransaction => ({
+  payouts: [
+    {
+      payoutId: "po_123",
+      amount: { amount: 4800, currency: "usd" },
+      created: new Date("2024-01-03T00:00:00Z").toISOString(),
+      arrivalDate: new Date("2024-01-05T00:00:00Z").toISOString(),
+      status: "paid",
+    },
+  ],
+});
+
+const disputeTransaction = (): NormalizedTransaction => ({
+  disputes: [
+    {
+      disputeId: "dp_123",
+      chargeId: "ch_123",
+      created: new Date("2024-01-04T00:00:00Z").toISOString(),
+      amount: { amount: 1500, currency: "usd" },
+      status: "lost",
+      reason: "fraudulent",
+      metadata: {},
+    },
+  ],
+});
+
+const run = async () => {
+  const server = await createServer();
+  const context = createContext(server.baseUrl);
+
+  const paymentResult = await postToQuickBooks(
+    paymentTransaction(),
+    "sales_receipt",
+    context,
+  );
+  assert.equal(paymentResult.action, "created");
+  assert.equal(paymentResult.doc_type, "SalesReceipt");
+  assert.ok(paymentResult.doc_id, "should return doc id for sales receipt");
+
+  const salesDocNumber = docnum_salesreceipt("ch_123");
+  const salesReceipt = server.records.SalesReceipt.get(salesDocNumber);
+  assert.ok(salesReceipt, "sales receipt should be stored");
+  assert.equal(
+    (salesReceipt?.DepositToAccountRef as { value: string }).value,
+    context.env.QBO_ACCOUNT_STRIPE_CLEARING,
+  );
+
+  const feeDocNumber = docnum_fee_tx("txn_123");
+  const feeEntry = server.records.JournalEntry.get(feeDocNumber);
+  assert.ok(feeEntry, "fee journal entry should be created");
+  const feeLines = (feeEntry?.Line as Array<Record<string, any>>) ?? [];
+  const feeCredit = feeLines.find(
+    (line) => line.JournalEntryLineDetail?.PostingType === "Credit",
+  );
+  const feeDebit = feeLines.find(
+    (line) => line.JournalEntryLineDetail?.PostingType === "Debit",
+  );
+  assert.equal(
+    feeCredit?.JournalEntryLineDetail?.AccountRef?.value,
+    context.env.QBO_ACCOUNT_STRIPE_CLEARING,
+  );
+  assert.equal(
+    feeDebit?.JournalEntryLineDetail?.AccountRef?.value,
+    context.env.QBO_ACCOUNT_STRIPE_FEES,
+  );
+
+  const rerun = await postToQuickBooks(paymentTransaction(), "sales_receipt", context);
+  assert.equal(rerun.action, "noop", "second run should be idempotent");
+  const salesPosts = server.requests.filter(
+    (req) => req.method === "POST" && req.url.includes("salesreceipt"),
+  );
+  assert.equal(salesPosts.length, 1, "sales receipt should be posted once");
+
+  const refundResult = await postToQuickBooks(
+    refundTransaction(),
+    "refund_receipt",
+    context,
+  );
+  assert.equal(refundResult.action, "created");
+  assert.equal(refundResult.doc_type, "RefundReceipt");
+
+  const payoutResult = await postToQuickBooks(
+    payoutTransaction(),
+    "transfer",
+    context,
+  );
+  assert.equal(payoutResult.action, "created");
+  assert.equal(payoutResult.doc_type, "Transfer");
+  const transferDocNumber = docnum_payout("po_123");
+  const transfer = server.records.Transfer.get(transferDocNumber);
+  assert.ok(transfer, "transfer should be stored");
+  assert.equal(
+    (transfer?.FromAccountRef as { value: string }).value,
+    context.env.QBO_ACCOUNT_STRIPE_CLEARING,
+  );
+  assert.equal(
+    (transfer?.ToAccountRef as { value: string }).value,
+    context.env.QBO_ACCOUNT_CHECKING,
+  );
+
+  const disputeResult = await postToQuickBooks(
+    disputeTransaction(),
+    "dispute_entry",
+    context,
+  );
+  assert.equal(disputeResult.action, "created");
+  assert.equal(disputeResult.doc_type, "JournalEntry");
+  const disputeDocNumber = docnum_dispute("dp_123", "lost");
+  const disputeEntry = server.records.JournalEntry.get(disputeDocNumber);
+  assert.ok(disputeEntry, "dispute journal entry should be stored");
+  const disputeLines = (disputeEntry?.Line as Array<Record<string, any>>) ?? [];
+  const disputeDebit = disputeLines.find(
+    (line) => line.JournalEntryLineDetail?.PostingType === "Debit",
+  );
+  const disputeCredit = disputeLines.find(
+    (line) => line.JournalEntryLineDetail?.PostingType === "Credit",
+  );
+  assert.equal(
+    disputeDebit?.JournalEntryLineDetail?.AccountRef?.value,
+    context.env.QBO_ACCOUNT_STRIPE_FEES,
+  );
+  assert.equal(
+    disputeCredit?.JournalEntryLineDetail?.AccountRef?.value,
+    context.env.QBO_ACCOUNT_STRIPE_CLEARING,
+  );
+
+  await server.close();
+  console.log("qbo.post.spec.ts passed");
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- implement a QuickBooks client with OAuth token refresh, doc lookup, and create helpers
- add end-to-end QuickBooks posting logic for sales, refunds, disputes, payouts, and fee journal entries
- cover the QuickBooks posting flow with a contract test using a mocked API

## Testing
- npx ts-node tests/contract/qbo.post.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e426c5d298832cabb2d6b3c5e7065f