### PR TITLE
Add health endpoint and structured logging instrumentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This Azure Function app processes payments through Stripe, handling customer man
 - **Improved transaction naming: "Transaction - {Category}" format**
 - **Idempotency checking to prevent duplicate processing**
 - **Metrics and observability for matching performance**
+- **Environment health endpoint for infrastructure readiness checks**
 
 ## Prerequisites
 
@@ -77,6 +78,47 @@ npm test
 ```
 
 This will run the integration tests to verify the payment processing flow.
+
+## Health Monitoring & Observability
+
+### Runtime Health Endpoint
+
+- `GET /api/health` returns the readiness of critical dependencies:
+  - PostgreSQL database connectivity
+  - Azure Storage queues
+  - Stripe API availability
+  - Salesforce (when enabled)
+  - QuickBooks Online (when enabled)
+- Responses include a `status` value of `healthy`, `degraded`, or `unhealthy`,
+  per-component diagnostics, and current metric counters. Degraded checks still
+  return HTTP 503 so that monitors can alert on partial outages.
+- All log lines emitted from request handlers now include a correlation ID that
+  is sourced from the `x-correlation-id` header when available (falling back to
+  the Azure Functions invocation ID) for easier end-to-end tracing.
+
+### Metric Counters
+
+The function tracks lightweight counters in-memory for operational awareness:
+
+| Counter | Description |
+|---------|-------------|
+| `events_ingested` | Total Stripe webhook events accepted for processing. |
+| `post_success` | Number of ledger operations that completed successfully. |
+| `post_failure` | Number of ledger operations that ended in failure. |
+| `ledger_stuck` | Number of attempts that discovered an existing pending ledger entry (potentially stuck work). |
+
+### Suggested Alert Thresholds
+
+- **Low ingestion volume**: Alert if `events_ingested` does not increase for 15
+  consecutive minutes during expected traffic windows (possible upstream outage).
+- **Posting success ratio**: Alert when `post_failure / (post_success + post_failure)`
+  exceeds 5% over a 10 minute rolling window.
+- **Ledger stuck accumulation**: Alert if `ledger_stuck` increases by more than
+  3 within 10 minutes, indicating retries are not clearing.
+- **Health endpoint degradation**: Page immediately when `/api/health` returns
+  HTTP 503 or reports `unhealthy`, and create a warning when the status is
+  `degraded` for longer than 10 minutes (often due to intentionally disabled
+  integrations).
 
 ## Azure Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,147 @@
       "version": "1.0.0",
       "dependencies": {
         "@azure/functions": "^4.5.0",
+        "@azure/storage-queue": "12.16.0",
         "@sendgrid/mail": "^8.1.0",
         "jsforce": "^3.10.7",
         "node-quickbooks": "^2.0.46",
+        "pg": "^8.11.3",
         "stripe": "^14.7.0",
         "zod": "^3.22.4"
       },
       "devDependencies": {
         "@types/node": "^20.10.5",
+        "@types/pg": "^8.10.9",
         "ts-node": "^10.9.1",
         "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.1.0.tgz",
+      "integrity": "sha512-TrRLIoSQVzfAJX9H1JeFjzAoDGcoK1IYX1UImfceTZpsyYfWr09Ss1aHW1y5TrrR3iq6RZLBwJ3E24uwPhwahw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-3.0.5.tgz",
+      "integrity": "sha512-T8r2q/c3DxNu6mEJfPuJtptUVqwchxzjj32gKcnMi06rdiVONS9rar7kT9T2Am+XvER7uOzpsP79WsqNbdgdWg==",
+      "deprecated": "This package is no longer supported. Please refer to https://github.com/Azure/azure-sdk-for-js/blob/490ce4dfc5b98ba290dee3b33a6d0876c5f138e2/sdk/core/README.md",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.3.0",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/core-util": "^1.1.1",
+        "@azure/logger": "^1.0.0",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.3",
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.6.7",
+        "process": "^0.11.10",
+        "tslib": "^2.2.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.3.0",
+        "xml2js": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-http/node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.0.0-preview.13",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.13.tgz",
+      "integrity": "sha512-KxDlhXyMlh2Jhj2ykX6vNEU0Vou4nHr025KoSEiz7cS3BNiHNaZcdECk/DmLkEB0as5T7b/TpRcehJ5yV6NeXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.1",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util/node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@azure/functions": {
@@ -33,6 +164,36 @@
       },
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/storage-queue": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/storage-queue/-/storage-queue-12.16.0.tgz",
+      "integrity": "sha512-HzwzMsNAh2PwLtx9WfXndj9elUr6duDFak5CjM6BxdWhLqf37VywPCWmEzjxuFfrq30c1T34+MjMXnN6YgqRUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^3.0.0",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.13",
+        "@azure/logger": "^1.0.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -127,6 +288,15 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@sendgrid/client": {
       "version": "8.1.6",
       "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
@@ -212,6 +382,73 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.4"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/tunnel": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.3.tgz",
+      "integrity": "sha512-sOUTGn6h1SfQ+gbgqC364jLFBw2lnFqkgF3q0WovEHRLMrVD1sd5aufqi/aJObLekJO+Aq5z646U4Oxy6shXMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.1.tgz",
+      "integrity": "sha512-SnbaqayTVFEA6/tYumdF0UmybY0KHyKwGPBXnyckFlrrKdhWFrL3a2HIPXHjht5ZOElKGcXfD2D63P36btb+ww==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/acorn": {
@@ -1102,6 +1339,28 @@
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1551,6 +1810,143 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -1859,6 +2255,15 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/sshpk": {
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
@@ -2056,6 +2461,15 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -2267,6 +2681,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -9,14 +9,17 @@
   },
   "dependencies": {
     "@azure/functions": "^4.5.0",
+    "@azure/storage-queue": "12.16.0",
     "@sendgrid/mail": "^8.1.0",
     "jsforce": "^3.10.7",
     "node-quickbooks": "^2.0.46",
+    "pg": "^8.11.3",
     "stripe": "^14.7.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20.10.5",
+    "@types/pg": "^8.10.9",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3"
   }

--- a/src/app/health/function.json
+++ b/src/app/health/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "anonymous",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["get"],
+      "route": "health"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/src/app/health/index.ts
+++ b/src/app/health/index.ts
@@ -1,0 +1,82 @@
+import { getCachedEnv } from "../../config/env";
+import { runHealthChecks } from "../../services/health/checks";
+import { createLogger } from "../../services/shared/logger";
+import { ServiceContext } from "../../services/shared/types";
+
+interface AzureHttpRequest {
+  headers?: Record<string, string | undefined>;
+}
+
+interface AzureHttpResponse {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+interface AzureContext {
+  invocationId: string;
+  res?: AzureHttpResponse;
+}
+
+const logger = createLogger("app:health");
+
+const getCorrelationId = (
+  req: AzureHttpRequest,
+  context: AzureContext,
+): string =>
+  req.headers?.["x-correlation-id"] ??
+  req.headers?.["X-Correlation-Id"] ??
+  context.invocationId;
+
+export const healthHandler = async (
+  context: AzureContext,
+  req: AzureHttpRequest,
+): Promise<void> => {
+  const env = getCachedEnv();
+  const correlationId = getCorrelationId(req, context);
+  const requestLogger = logger.child({
+    correlationId,
+    invocationId: context.invocationId,
+  });
+
+  const serviceContext: ServiceContext = { env };
+
+  try {
+    requestLogger.debug("health check invoked");
+
+    const summary = await runHealthChecks(serviceContext);
+    const statusCode = summary.status === "healthy" ? 200 : 503;
+
+    requestLogger.info("health check completed", {
+      status: summary.status,
+      components: summary.components,
+    });
+
+    context.res = {
+      status: statusCode,
+      body: summary,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "X-Health-Status": summary.status,
+      },
+    };
+  } catch (error) {
+    requestLogger.error("health check failed", { error });
+    context.res = {
+      status: 500,
+      body: {
+        status: "unhealthy",
+        timestamp: new Date().toISOString(),
+        error: error instanceof Error ? error.message : String(error),
+      },
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "X-Health-Status": "unhealthy",
+      },
+    };
+  }
+};
+
+export default healthHandler;

--- a/src/app/processTransaction/index.ts
+++ b/src/app/processTransaction/index.ts
@@ -4,6 +4,7 @@ import { getCachedEnv } from "../../config/env";
 import { normalizeStripeEvent } from "../../services/process/normalize";
 import { processTransaction } from "../../services/process/process_transaction";
 import { createLogger } from "../../services/shared/logger";
+import { incrementCounter } from "../../services/shared/metrics";
 import { ServiceContext } from "../../services/shared/types";
 
 type AzureHttpHeaders = Record<string, string | undefined> | undefined;
@@ -33,6 +34,14 @@ type AzureFunctionHandler = (
 
 const logger = createLogger("app:processTransaction");
 
+const getCorrelationId = (
+  req: AzureHttpRequest,
+  context: AzureContext,
+): string =>
+  req.headers?.["x-correlation-id"] ??
+  req.headers?.["X-Correlation-Id"] ??
+  context.invocationId;
+
 const getStripeSignature = (req: AzureHttpRequest) =>
   req.headers?.["stripe-signature"] ?? req.headers?.["Stripe-Signature"];
 
@@ -57,15 +66,18 @@ export const processTransactionHandler: AzureFunctionHandler = async (
   req: AzureHttpRequest,
 ): Promise<void> => {
   const env = getCachedEnv();
-  const serviceContext: ServiceContext = { env };
-
-  logger.debug("processTransaction invoked", {
+  const correlationId = getCorrelationId(req, context);
+  const requestLogger = logger.child({
+    correlationId,
     invocationId: context.invocationId,
   });
+  const serviceContext: ServiceContext = { env };
+
+  requestLogger.debug("processTransaction invoked");
 
   const signature = getStripeSignature(req);
   if (!signature) {
-    logger.warn("Missing Stripe signature header");
+    requestLogger.warn("Missing Stripe signature header");
     context.res = {
       status: 400,
       body: { error: "Missing Stripe-Signature header" },
@@ -86,7 +98,7 @@ export const processTransactionHandler: AzureFunctionHandler = async (
     );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    logger.warn("Stripe signature verification failed", { message });
+    requestLogger.warn("Stripe signature verification failed", { message });
     context.res = {
       status: 400,
       body: { error: "Invalid Stripe signature" },
@@ -94,13 +106,15 @@ export const processTransactionHandler: AzureFunctionHandler = async (
     return;
   }
 
+  incrementCounter("events_ingested");
+
   try {
     const canonical = await normalizeStripeEvent(event, serviceContext, {
       stripe,
     });
 
     if (!canonical) {
-      logger.info("Stripe event ignored after normalization", {
+      requestLogger.info("Stripe event ignored after normalization", {
         eventId: event.id,
         type: event.type,
       });
@@ -124,7 +138,7 @@ export const processTransactionHandler: AzureFunctionHandler = async (
       body: summary,
     };
   } catch (error) {
-    logger.error("Failed to process Stripe transaction", {
+    requestLogger.error("Failed to process Stripe transaction", {
       eventId: event.id,
       error,
     });

--- a/src/services/health/checks.ts
+++ b/src/services/health/checks.ts
@@ -1,0 +1,81 @@
+import { ServiceContext } from "../shared/types";
+import { getCounterSnapshot } from "../shared/metrics";
+import { defaultHealthChecks, deriveOverallStatus } from "./default_checks";
+import {
+  ComponentHealth,
+  HealthCheckMap,
+  HealthSummary,
+  HealthStatus,
+} from "./types";
+
+const serializeError = (error?: Error | string | null): string | undefined => {
+  if (!error) {
+    return undefined;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+};
+
+const executeCheck = async (
+  component: keyof HealthCheckMap,
+  check: HealthCheckMap[keyof HealthCheckMap],
+  context: ServiceContext,
+): Promise<ComponentHealth> => {
+  const startedAt = Date.now();
+
+  try {
+    const result = await check(context);
+    const latency = Date.now() - startedAt;
+
+    return {
+      component,
+      status: result.status,
+      detail: result.detail,
+      error: serializeError(result.error),
+      latency_ms: latency,
+    };
+  } catch (error) {
+    const latency = Date.now() - startedAt;
+    const message = error instanceof Error ? error.message : String(error);
+
+    return {
+      component,
+      status: "unhealthy",
+      detail: message,
+      error: serializeError(error instanceof Error ? error : message),
+      latency_ms: latency,
+    };
+  }
+};
+
+const determineOverallStatus = (components: ComponentHealth[]): HealthStatus =>
+  deriveOverallStatus(components.map((component) => component.status));
+
+export const runHealthChecks = async (
+  context: ServiceContext,
+  overrides: Partial<HealthCheckMap> = {},
+): Promise<HealthSummary & { metrics: ReturnType<typeof getCounterSnapshot> }> => {
+  const checks: HealthCheckMap = {
+    ...defaultHealthChecks,
+    ...overrides,
+  };
+
+  const components = await Promise.all(
+    Object.entries(checks).map(([component, check]) =>
+      executeCheck(component as keyof HealthCheckMap, check, context),
+    ),
+  );
+
+  const status = determineOverallStatus(components);
+
+  return {
+    status,
+    timestamp: new Date().toISOString(),
+    components,
+    metrics: getCounterSnapshot(),
+  };
+};

--- a/src/services/health/default_checks.ts
+++ b/src/services/health/default_checks.ts
@@ -1,0 +1,128 @@
+import Stripe from "stripe";
+import { QueueServiceClient } from "@azure/storage-queue";
+import { Client } from "pg";
+
+import { SalesforceClient } from "../salesforce/salesforce_client";
+import { createQboClient } from "../qbo/qbo_client";
+import { ServiceContext } from "../shared/types";
+import {
+  HealthCheckResult,
+  HealthCheckMap,
+  HealthStatus,
+} from "./types";
+
+const formatError = (error: unknown): Error | string =>
+  error instanceof Error ? error : String(error);
+
+const databaseCheck = async (
+  context: ServiceContext,
+): Promise<HealthCheckResult> => {
+  const client = new Client({
+    connectionString: context.env.DATABASE_URL,
+    connectionTimeoutMillis: 2_000,
+  });
+
+  try {
+    await client.connect();
+    await client.query("SELECT 1");
+    return { status: "healthy", detail: "Connected to database" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "unhealthy", detail: message, error: formatError(error) };
+  } finally {
+    await client.end().catch(() => undefined);
+  }
+};
+
+const queueCheck = async (
+  context: ServiceContext,
+): Promise<HealthCheckResult> => {
+  try {
+    const client = QueueServiceClient.fromConnectionString(
+      context.env.AZURE_STORAGE_CONNECTION_STRING,
+    );
+    await client.getProperties();
+    return { status: "healthy", detail: "Queue service reachable" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "unhealthy", detail: message, error: formatError(error) };
+  }
+};
+
+const stripeCheck = async (
+  context: ServiceContext,
+): Promise<HealthCheckResult> => {
+  try {
+    const stripe = new Stripe(context.env.STRIPE_SECRET);
+    await stripe.balance.retrieve({}, { timeout: 2_000 });
+    return { status: "healthy", detail: "Stripe API reachable" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "unhealthy", detail: message, error: formatError(error) };
+  }
+};
+
+const salesforceCheck = async (
+  context: ServiceContext,
+): Promise<HealthCheckResult> => {
+  if (context.env.ENABLE_SF === false) {
+    return {
+      status: "degraded",
+      detail: "Salesforce integration disabled",
+    };
+  }
+
+  try {
+    const client = new SalesforceClient({
+      clientId: context.env.SF_CLIENT_ID,
+      clientSecret: context.env.SF_CLIENT_SECRET,
+      username: context.env.SF_USERNAME,
+      password: context.env.SF_PASSWORD,
+    });
+    await client.query("SELECT Id FROM Account LIMIT 1");
+    return { status: "healthy", detail: "Salesforce API reachable" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "unhealthy", detail: message, error: formatError(error) };
+  }
+};
+
+const quickbooksCheck = async (
+  context: ServiceContext,
+): Promise<HealthCheckResult> => {
+  if (context.env.ENABLE_QBO === false) {
+    return {
+      status: "degraded",
+      detail: "QuickBooks integration disabled",
+    };
+  }
+
+  try {
+    const client = createQboClient(context);
+    await client.getCompanyInfo();
+    return { status: "healthy", detail: "QuickBooks API reachable" };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { status: "unhealthy", detail: message, error: formatError(error) };
+  }
+};
+
+export const defaultHealthChecks: HealthCheckMap = {
+  database: databaseCheck,
+  queues: queueCheck,
+  stripe: stripeCheck,
+  salesforce: salesforceCheck,
+  quickbooks: quickbooksCheck,
+};
+
+export const deriveOverallStatus = (
+  statuses: HealthStatus[],
+): HealthStatus => {
+  if (statuses.includes("unhealthy")) {
+    return "unhealthy";
+  }
+  if (statuses.includes("degraded")) {
+    return "degraded";
+  }
+  return "healthy";
+};

--- a/src/services/health/types.ts
+++ b/src/services/health/types.ts
@@ -1,0 +1,34 @@
+import { ServiceContext } from "../shared/types";
+
+export type HealthComponent =
+  | "database"
+  | "queues"
+  | "stripe"
+  | "salesforce"
+  | "quickbooks";
+
+export type HealthStatus = "healthy" | "degraded" | "unhealthy";
+
+export interface HealthCheckResult {
+  status: HealthStatus;
+  detail?: string;
+  error?: Error | string | null;
+}
+
+export type HealthCheck = (
+  context: ServiceContext,
+) => Promise<HealthCheckResult>;
+
+export interface ComponentHealth extends HealthCheckResult {
+  component: HealthComponent;
+  latency_ms: number;
+  error?: string;
+}
+
+export interface HealthSummary {
+  status: HealthStatus;
+  timestamp: string;
+  components: ComponentHealth[];
+}
+
+export type HealthCheckMap = Record<HealthComponent, HealthCheck>;

--- a/src/services/persistence/repository.ts
+++ b/src/services/persistence/repository.ts
@@ -1,3 +1,5 @@
+import { incrementCounter } from "../shared/metrics";
+
 export type LedgerStatus = "pending" | "posted" | "error";
 
 export interface WebhookEventRecord {
@@ -47,6 +49,9 @@ export const saveLedgerAttempt = async (
   const key = ledgerKey(entityType, entityId);
   const existing = postingLedger.get(key);
   if (existing) {
+    if (existing.status === "pending") {
+      incrementCounter("ledger_stuck");
+    }
     return existing;
   }
   const now = new Date();
@@ -79,8 +84,10 @@ export const finalizeLedger = async (
   existing.updated_at = new Date();
   if (status === "error") {
     existing.error = errorMessage ?? "Unknown error";
+    incrementCounter("post_failure");
   } else {
     delete existing.error;
+    incrementCounter("post_success");
   }
   return existing;
 };

--- a/src/services/qbo/qbo_client.ts
+++ b/src/services/qbo/qbo_client.ts
@@ -283,6 +283,24 @@ export class QuickBooksClient {
   createTransfer(payload: Record<string, unknown>) {
     return this.createEntity("Transfer", payload);
   }
+
+  async getCompanyInfo(): Promise<Record<string, unknown>> {
+    const path = `/v3/company/${this.context.env.QBO_REALM_ID}/companyinfo/${this.context.env.QBO_REALM_ID}`;
+    const result = await this.request<Record<string, unknown> | null>(
+      "GET",
+      path,
+    );
+
+    if (result && typeof result === "object") {
+      const companyInfo = result["CompanyInfo"];
+      if (companyInfo && typeof companyInfo === "object") {
+        return companyInfo as Record<string, unknown>;
+      }
+      return result;
+    }
+
+    throw new Error("Unexpected QuickBooks response when retrieving company info");
+  }
 }
 
 export const createQboClient = (

--- a/src/services/shared/logger.ts
+++ b/src/services/shared/logger.ts
@@ -1,29 +1,104 @@
 export type LogLevel = "debug" | "info" | "warn" | "error";
 
+export type LogAttributes = Record<string, unknown>;
+
 export interface Logger {
-  debug: (...args: unknown[]) => void;
-  info: (...args: unknown[]) => void;
-  warn: (...args: unknown[]) => void;
-  error: (...args: unknown[]) => void;
+  debug: (message: string, metadata?: LogAttributes) => void;
+  info: (message: string, metadata?: LogAttributes) => void;
+  warn: (message: string, metadata?: LogAttributes) => void;
+  error: (message: string, metadata?: LogAttributes) => void;
+  child: (attributes: LogAttributes) => Logger;
 }
 
-const logAtLevel = (level: LogLevel, scope: string, args: unknown[]) => {
-  const prefix = `[${scope}]`;
-  const consoleMethod =
-    level === "debug"
-      ? console.debug
-      : level === "info"
-      ? console.info
-      : level === "warn"
-      ? console.warn
-      : console.error;
+const serializeValue = (value: unknown): unknown => {
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+  }
 
-  consoleMethod(prefix, ...args);
+  if (Array.isArray(value)) {
+    return value.map(serializeValue);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        serializeValue(entry),
+      ]),
+    );
+  }
+
+  return value;
 };
 
-export const createLogger = (scope: string): Logger => ({
-  debug: (...args: unknown[]) => logAtLevel("debug", scope, args),
-  info: (...args: unknown[]) => logAtLevel("info", scope, args),
-  warn: (...args: unknown[]) => logAtLevel("warn", scope, args),
-  error: (...args: unknown[]) => logAtLevel("error", scope, args),
-});
+const createConsoleMethod = (level: LogLevel) =>
+  level === "debug"
+    ? console.debug
+    : level === "info"
+    ? console.info
+    : level === "warn"
+    ? console.warn
+    : console.error;
+
+const logAtLevel = (
+  level: LogLevel,
+  scope: string,
+  baseAttributes: LogAttributes,
+  message: string,
+  metadata?: LogAttributes,
+) => {
+  const consoleMethod = createConsoleMethod(level);
+
+  const payload: Record<string, unknown> = {
+    timestamp: new Date().toISOString(),
+    level,
+    scope,
+    message,
+  };
+
+  const normalizedAttributes = serializeValue(baseAttributes);
+  if (
+    normalizedAttributes &&
+    typeof normalizedAttributes === "object" &&
+    !Array.isArray(normalizedAttributes)
+  ) {
+    Object.assign(payload, normalizedAttributes);
+  }
+
+  if (metadata && Object.keys(metadata).length > 0) {
+    const normalizedMetadata = serializeValue(metadata);
+    if (
+      normalizedMetadata &&
+      typeof normalizedMetadata === "object" &&
+      !Array.isArray(normalizedMetadata)
+    ) {
+      Object.assign(payload, normalizedMetadata);
+    }
+  }
+
+  consoleMethod(JSON.stringify(payload));
+};
+
+export const createLogger = (
+  scope: string,
+  attributes: LogAttributes = {},
+): Logger => {
+  const withAttributes = (additional: LogAttributes = {}) =>
+    createLogger(scope, { ...attributes, ...additional });
+
+  return {
+    debug: (message: string, metadata?: LogAttributes) =>
+      logAtLevel("debug", scope, attributes, message, metadata),
+    info: (message: string, metadata?: LogAttributes) =>
+      logAtLevel("info", scope, attributes, message, metadata),
+    warn: (message: string, metadata?: LogAttributes) =>
+      logAtLevel("warn", scope, attributes, message, metadata),
+    error: (message: string, metadata?: LogAttributes) =>
+      logAtLevel("error", scope, attributes, message, metadata),
+    child: (additional: LogAttributes) => withAttributes(additional),
+  };
+};

--- a/src/services/shared/metrics.ts
+++ b/src/services/shared/metrics.ts
@@ -1,0 +1,32 @@
+export type CounterName =
+  | "events_ingested"
+  | "post_success"
+  | "post_failure"
+  | "ledger_stuck";
+
+type CounterStore = Record<CounterName, number>;
+
+const counters: CounterStore = {
+  events_ingested: 0,
+  post_success: 0,
+  post_failure: 0,
+  ledger_stuck: 0,
+};
+
+export const incrementCounter = (name: CounterName, value = 1): void => {
+  counters[name] += value;
+};
+
+export const getCounterSnapshot = (): CounterStore => ({
+  events_ingested: counters.events_ingested,
+  post_success: counters.post_success,
+  post_failure: counters.post_failure,
+  ledger_stuck: counters.ledger_stuck,
+});
+
+export const resetCountersForTest = (): void => {
+  counters.events_ingested = 0;
+  counters.post_success = 0;
+  counters.post_failure = 0;
+  counters.ledger_stuck = 0;
+};


### PR DESCRIPTION
## Summary
- add an Azure Function health endpoint that checks the database, queue storage, Stripe, Salesforce, and QuickBooks integrations while exposing counter snapshots
- implement structured JSON logging with per-request correlation identifiers and new ingestion/posting counters that flag stuck ledger work
- document the new observability surface area and alerting thresholds for the metrics and health endpoint in the README

## Testing
- npm test
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e432f678a0832c9afee8218bf29e69