### PR TITLE
Restore HTTP function discovery for HTTP triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 npm-debug.log*
+dist/
 
 # Azure Functions artifacts
 bin

--- a/health/function.json
+++ b/health/function.json
@@ -1,12 +1,14 @@
 {
+  "scriptFile": "../dist/app/health/index.js",
+  "entryPoint": "healthHandler",
   "bindings": [
     {
-      "authLevel": "function",
+      "authLevel": "anonymous",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["post"],
-      "route": "transaction"
+      "methods": ["get"],
+      "route": "health"
     },
     {
       "type": "http",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "payment-processing-function",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@azure/functions": "^4.5.0",
         "@azure/storage-queue": "12.16.0",

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "description": "Azure Function for payment processing with Stripe integration",
   "main": "dist/app/processTransaction/index.js",
   "scripts": {
+    "build": "tsc",
+    "prestart": "npm run build",
     "start": "func start",
     "test": "ts-node --transpile-only tests/run.ts",
-    "report:v2": "ts-node --transpile-only scripts/v2_processor_report.ts"
+    "report:v2": "ts-node --transpile-only scripts/v2_processor_report.ts",
+    "postinstall": "npm run build"
   },
   "dependencies": {
     "@azure/functions": "^4.5.0",

--- a/processTransaction/function.json
+++ b/processTransaction/function.json
@@ -1,12 +1,14 @@
 {
+  "scriptFile": "../dist/app/processTransaction/index.js",
+  "entryPoint": "processTransactionHandler",
   "bindings": [
     {
-      "authLevel": "anonymous",
+      "authLevel": "function",
       "type": "httpTrigger",
       "direction": "in",
       "name": "req",
-      "methods": ["get"],
-      "route": "health"
+      "methods": ["post"],
+      "route": "transaction"
     },
     {
       "type": "http",


### PR DESCRIPTION
## Summary
- expose the health and transaction HTTP trigger directories at the Function App root with scriptFile targets
- add a TypeScript build step that runs before starting or after installing so dist assets are produced
- ignore generated dist output in git

## Testing
- npm run build
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4474a1f14832c8f90138961cffeba