### PR TITLE
Add checkout session endpoint for donations

### DIFF
--- a/createCheckoutSession/function.json
+++ b/createCheckoutSession/function.json
@@ -1,0 +1,19 @@
+{
+  "scriptFile": "../dist/src/app/createCheckoutSession/index.js",
+  "entryPoint": "createCheckoutSessionHandler",
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "checkout/session"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "res"
+    }
+  ]
+}

--- a/src/app/createCheckoutSession/index.ts
+++ b/src/app/createCheckoutSession/index.ts
@@ -1,0 +1,165 @@
+import Stripe from "stripe";
+
+import { EnvValidationError, getCachedEnv } from "../../config/env";
+import {
+  CheckoutRequestSchema,
+  buildCheckoutSessionParams,
+} from "../../services/checkout/session";
+import { createLogger } from "../../services/shared/logger";
+import { ServiceContext } from "../../services/shared/types";
+
+type AzureHttpRequest = {
+  method?: string;
+  headers?: Record<string, string | undefined>;
+  body?: unknown;
+};
+
+type AzureHttpResponse = {
+  status?: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+};
+
+type AzureContext = {
+  invocationId: string;
+  res?: AzureHttpResponse;
+};
+
+type AzureFunctionHandler = (
+  context: AzureContext,
+  req: AzureHttpRequest,
+) => Promise<void>;
+
+const logger = createLogger("app:createCheckoutSession");
+
+const getCorrelationId = (
+  req: AzureHttpRequest,
+  context: AzureContext,
+): string =>
+  req.headers?.["x-correlation-id"] ??
+  req.headers?.["X-Correlation-Id"] ??
+  context.invocationId;
+
+const formatEnvIssues = (issues: EnvValidationError["issues"]): string[] =>
+  issues.map((issue) => {
+    const path = issue.path.join(".") || "env";
+    return `${path}: ${issue.message}`;
+  });
+
+const buildErrorResponse = (
+  status: number,
+  body: Record<string, unknown>,
+): AzureHttpResponse => ({
+  status,
+  body,
+  headers: {
+    "Content-Type": "application/json",
+  },
+});
+
+export const createCheckoutSessionHandler: AzureFunctionHandler = async (
+  context,
+  req,
+) => {
+  const correlationId = getCorrelationId(req, context);
+  const requestLogger = logger.child({
+    correlationId,
+    invocationId: context.invocationId,
+  });
+
+  let env: ReturnType<typeof getCachedEnv>;
+
+  try {
+    env = getCachedEnv();
+  } catch (error) {
+    if (error instanceof EnvValidationError) {
+      const details = formatEnvIssues(error.issues);
+      requestLogger.error("Invalid environment configuration", {
+        details,
+      });
+      context.res = buildErrorResponse(500, {
+        error: "Invalid environment configuration",
+        details,
+      });
+      return;
+    }
+
+    requestLogger.error("Failed to read environment configuration", { error });
+    context.res = buildErrorResponse(500, {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return;
+  }
+
+  const serviceContext: ServiceContext = { env };
+  requestLogger.debug("createCheckoutSession invoked");
+
+  const successUrl = env.SUCCESS_URL;
+  const cancelUrl = env.CANCEL_URL;
+
+  if (!successUrl || !cancelUrl) {
+    requestLogger.error("Missing checkout redirect URLs in environment", {
+      successConfigured: Boolean(successUrl),
+      cancelConfigured: Boolean(cancelUrl),
+    });
+    context.res = buildErrorResponse(500, {
+      error: "Checkout redirect URLs are not configured",
+    });
+    return;
+  }
+
+  const parsed = CheckoutRequestSchema.safeParse(req.body);
+
+  if (!parsed.success) {
+    const details = parsed.error.issues.map((issue) => ({
+      path: issue.path.join("."),
+      message: issue.message,
+    }));
+
+    requestLogger.warn("Invalid checkout session payload", { details });
+    context.res = buildErrorResponse(400, {
+      error: "Invalid request body",
+      details,
+    });
+    return;
+  }
+
+  const input = parsed.data;
+  const stripe = new Stripe(serviceContext.env.STRIPE_SECRET);
+
+  try {
+    const params = buildCheckoutSessionParams(input, {
+      successUrl,
+      cancelUrl,
+    });
+
+    const session = await stripe.checkout.sessions.create(params);
+
+    requestLogger.info("Checkout session created", {
+      sessionId: session.id,
+      mode: session.mode,
+    });
+
+    context.res = {
+      status: 200,
+      body: {
+        id: session.id,
+        url: session.url,
+        amount_total: session.amount_total,
+        currency: session.currency,
+        expires_at: session.expires_at,
+        mode: session.mode,
+      },
+      headers: {
+        "Content-Type": "application/json",
+      },
+    };
+  } catch (error) {
+    requestLogger.error("Failed to create checkout session", { error });
+    context.res = buildErrorResponse(500, {
+      error: "Failed to create checkout session",
+    });
+  }
+};
+
+export default createCheckoutSessionHandler;

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -126,6 +126,8 @@ export const envSchema = z
     AZURE_STORAGE_CONNECTION_STRING: z
       .string()
       .min(1, "AZURE_STORAGE_CONNECTION_STRING is required"),
+    SUCCESS_URL: z.string().url().optional(),
+    CANCEL_URL: z.string().url().optional(),
   })
   .passthrough();
 

--- a/src/services/checkout/session.ts
+++ b/src/services/checkout/session.ts
@@ -1,0 +1,144 @@
+import Stripe from "stripe";
+import { z } from "zod";
+
+type BuildSessionParamsOptions = {
+  successUrl: string;
+  cancelUrl: string;
+};
+
+const AddressSchema = z.object({
+  line1: z.string().min(1),
+  line2: z.string().optional(),
+  city: z.string().min(1),
+  state: z.string().min(1),
+  postal_code: z.string().min(1),
+  country: z
+    .string()
+    .min(2)
+    .max(2)
+    .transform((value) => value.toUpperCase()),
+});
+
+export const CheckoutRequestSchema = z
+  .object({
+    transactionType: z.string().min(1),
+    email: z.string().email(),
+    firstname: z.string().min(1),
+    lastname: z.string().min(1),
+    phone: z.string().min(1).optional(),
+    amount: z.number().int().positive(),
+    frequency: z.string().min(1).default("onetime"),
+    category: z.string().min(1).optional(),
+    coverFee: z.boolean().optional().default(false),
+    address: AddressSchema.optional(),
+    currency: z
+      .string()
+      .min(1)
+      .default("usd")
+      .transform((value) => value.toLowerCase()),
+  })
+  .passthrough();
+
+export type CheckoutRequest = z.infer<typeof CheckoutRequestSchema>;
+
+const buildMetadata = (input: CheckoutRequest): Record<string, string> => {
+  const metadata: Record<string, string> = {
+    transactionType: input.transactionType,
+    firstname: input.firstname,
+    lastname: input.lastname,
+    frequency: input.frequency,
+    coverFee: String(Boolean(input.coverFee)),
+    amount: String(input.amount),
+    currency: input.currency,
+  };
+
+  if (input.category) {
+    metadata.category = input.category;
+  }
+
+  if (input.phone) {
+    metadata.phone = input.phone;
+  }
+
+  if (input.address) {
+    metadata.address_line1 = input.address.line1;
+    if (input.address.line2) {
+      metadata.address_line2 = input.address.line2;
+    }
+    metadata.address_city = input.address.city;
+    metadata.address_state = input.address.state;
+    metadata.address_postal_code = input.address.postal_code;
+    metadata.address_country = input.address.country;
+  }
+
+  return metadata;
+};
+
+const buildProductName = (input: CheckoutRequest): string => {
+  const base = input.transactionType;
+  if (input.category) {
+    return `${base} - ${input.category}`;
+  }
+  return base;
+};
+
+export const buildCheckoutSessionParams = (
+  input: CheckoutRequest,
+  options: BuildSessionParamsOptions,
+): Stripe.Checkout.SessionCreateParams => {
+  const metadata = buildMetadata(input);
+
+  const sessionParams: Stripe.Checkout.SessionCreateParams = {
+    mode: "payment",
+    success_url: options.successUrl,
+    cancel_url: options.cancelUrl,
+    customer_email: input.email,
+    customer_creation: "if_required",
+    billing_address_collection: input.address ? "required" : "auto",
+    phone_number_collection: { enabled: !input.phone },
+    line_items: [
+      {
+        quantity: 1,
+        price_data: {
+          currency: input.currency,
+          unit_amount: input.amount,
+          product_data: {
+            name: buildProductName(input),
+            metadata,
+          },
+        },
+      },
+    ],
+    metadata,
+    payment_intent_data: {
+      metadata,
+      receipt_email: input.email,
+    },
+  };
+
+  if (input.phone) {
+    sessionParams.payment_intent_data = {
+      ...sessionParams.payment_intent_data,
+      metadata: {
+        ...sessionParams.payment_intent_data?.metadata,
+        phone: input.phone,
+      },
+    };
+  }
+
+  return sessionParams;
+};
+
+export type StripeCheckoutSessionsClient = Pick<
+  Stripe.Checkout.SessionsResource,
+  "create"
+>;
+
+export const createCheckoutSession = async (
+  input: CheckoutRequest,
+  options: BuildSessionParamsOptions,
+  stripe: StripeCheckoutSessionsClient,
+) => {
+  const params = buildCheckoutSessionParams(input, options);
+  return stripe.create(params);
+};

--- a/tests/run.ts
+++ b/tests/run.ts
@@ -30,6 +30,12 @@ const runSequentially = async () => {
   const { runEnvAliasSpec } = await import("./unit/env.aliases.spec");
   runEnvAliasSpec();
 
+  console.log("Running checkout session spec...");
+  const { runCheckoutSessionSpec } = await import(
+    "./unit/checkout.session.spec"
+  );
+  runCheckoutSessionSpec();
+
   console.log("Running process transaction integration spec...");
   const { runProcessTransactionIntegration } = await import(
     "./integration/process_transaction.integration.spec"

--- a/tests/unit/checkout.session.spec.ts
+++ b/tests/unit/checkout.session.spec.ts
@@ -1,0 +1,47 @@
+import { strict as assert } from "node:assert";
+
+import {
+  CheckoutRequestSchema,
+  buildCheckoutSessionParams,
+} from "../../src/services/checkout/session";
+
+export const runCheckoutSessionSpec = () => {
+  const payload = {
+    transactionType: "Donation",
+    email: "customer@example.com",
+    firstname: "John",
+    lastname: "Doe",
+    phone: "+1234567890",
+    amount: 2500,
+    frequency: "onetime",
+    category: "General",
+    coverFee: false,
+    address: {
+      line1: "123 Main St",
+      line2: "Apt 4",
+      city: "New York",
+      state: "NY",
+      postal_code: "10001",
+      country: "us",
+    },
+  };
+
+  const parsed = CheckoutRequestSchema.parse(payload);
+  const params = buildCheckoutSessionParams(parsed, {
+    successUrl: "https://example.org/success",
+    cancelUrl: "https://example.org/cancel",
+  });
+
+  assert.equal(params.mode, "payment");
+  assert.equal(params.success_url, "https://example.org/success");
+  assert.equal(params.cancel_url, "https://example.org/cancel");
+  assert.equal(params.customer_email, "customer@example.com");
+  assert.equal(params.line_items?.[0]?.price_data?.unit_amount, 2500);
+  assert.equal(params.line_items?.[0]?.price_data?.currency, "usd");
+  assert.equal(params.line_items?.[0]?.price_data?.product_data?.name, "Donation - General");
+  assert.equal(params.payment_intent_data?.metadata?.firstname, "John");
+  assert.equal(params.payment_intent_data?.metadata?.address_country, "US");
+
+  const invalid = CheckoutRequestSchema.safeParse({ ...payload, email: "not-an-email" });
+  assert.ok(!invalid.success);
+};


### PR DESCRIPTION
## Summary
- add an Azure Function at POST /api/checkout/session to create Stripe Checkout Sessions from donation payloads
- validate incoming checkout requests and map donor metadata into Stripe session parameters
- extend environment schema and unit tests to cover the checkout session workflow

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e471b0ee98832c8950d4734405441f