### PR TITLE
feat: add transaction upsert schemas and mapper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@sendgrid/mail": "^8.1.0",
         "jsforce": "^3.10.7",
         "node-quickbooks": "^2.0.46",
-        "stripe": "^14.7.0"
+        "stripe": "^14.7.0",
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/node": "^20.12.7",
@@ -3974,6 +3975,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "@sendgrid/mail": "^8.1.0",
     "jsforce": "^3.10.7",
     "node-quickbooks": "^2.0.46",
-    "stripe": "^14.7.0"
+    "stripe": "^14.7.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^20.12.7",

--- a/src/domain/transactions.ts
+++ b/src/domain/transactions.ts
@@ -1,27 +1,603 @@
-export interface TransactionMetadata {
-  payoutId?: string | null;
-  customerId?: string | null;
-  description?: string | null;
-  category?: string | null;
-  livemode?: boolean;
-  createdAt?: string;
-  updatedAt?: string;
-  [key: string]: unknown;
+import type Stripe from 'stripe';
+import { z } from 'zod';
+
+export const transactionTypeSchema = z.enum(['charge', 'refund', 'dispute', 'payout']);
+export type TransactionType = z.infer<typeof transactionTypeSchema>;
+
+export const transactionStatusSchema = z.enum([
+  'pending',
+  'processing',
+  'paid',
+  'refunded',
+  'disputed',
+  'failed',
+]);
+export type TransactionStatus = z.infer<typeof transactionStatusSchema>;
+
+const stringOrNullSchema = z.union([z.string(), z.null()]);
+const numberOrNullSchema = z.union([z.number(), z.null()]);
+const booleanOrNullSchema = z.union([z.boolean(), z.null()]);
+
+export const transactionUpsertSchema = z
+  .object({
+    transaction_type__c: transactionTypeSchema,
+    status__c: transactionStatusSchema,
+    stripe_payment_intent_id__c: stringOrNullSchema.optional(),
+    stripe_charge_id__c: stringOrNullSchema.optional(),
+    stripe_balance_transaction_id__c: stringOrNullSchema.optional(),
+    stripe_refund_id__c: stringOrNullSchema.optional(),
+    stripe_dispute_id__c: stringOrNullSchema.optional(),
+    stripe_checkout_session_id__c: stringOrNullSchema.optional(),
+    stripe_customer_id__c: stringOrNullSchema.optional(),
+    stripe_subscription_id__c: stringOrNullSchema.optional(),
+    stripe_payout_id__c: stringOrNullSchema.optional(),
+    amount_gross__c: numberOrNullSchema.optional(),
+    amount_fee__c: numberOrNullSchema.optional(),
+    amount_net__c: numberOrNullSchema.optional(),
+    currency_iso_code: stringOrNullSchema.optional(),
+    contact__c: stringOrNullSchema.optional(),
+    account__c: stringOrNullSchema.optional(),
+    campaign__c: stringOrNullSchema.optional(),
+    fund__c: stringOrNullSchema.optional(),
+    designation__c: stringOrNullSchema.optional(),
+    restriction__c: stringOrNullSchema.optional(),
+    frequency__c: stringOrNullSchema.optional(),
+    cover_fees__c: booleanOrNullSchema.optional(),
+    cover_fees_amount__c: numberOrNullSchema.optional(),
+    payment_method__c: stringOrNullSchema.optional(),
+    payment_brand__c: stringOrNullSchema.optional(),
+    payment_last4__c: stringOrNullSchema.optional(),
+    received_at__c: stringOrNullSchema.optional(),
+    posted_to_qbo__c: booleanOrNullSchema.optional(),
+    qbo_doc_type__c: stringOrNullSchema.optional(),
+    qbo_doc_id__c: stringOrNullSchema.optional(),
+    qbo_posted_at__c: stringOrNullSchema.optional(),
+    posting_error__c: stringOrNullSchema.optional(),
+  })
+  .strict();
+
+export const transactionUpsertHttpBodySchema = z.object({
+  transaction: transactionUpsertSchema,
+});
+
+export type TransactionUpsertDTO = z.infer<typeof transactionUpsertSchema>;
+export type TransactionsUpsertBody = z.infer<typeof transactionUpsertHttpBodySchema>;
+
+const metadataSchema = z.record(z.string(), z.unknown());
+
+export const stripePaymentIntentFragmentSchema = z
+  .object({
+    id: z.string(),
+    status: z.string().optional(),
+    currency: z.string().optional(),
+    customer: z
+      .union([z.string(), z.object({ id: z.string() }).passthrough()])
+      .nullish(),
+    created: z.number().optional(),
+    metadata: metadataSchema.optional(),
+    payment_method_types: z.array(z.string()).optional(),
+    payment_method: z.string().nullish(),
+    charges: z
+      .object({
+        data: z.array(
+          z
+            .object({
+              id: z.string(),
+            })
+            .passthrough(),
+        ),
+      })
+      .optional(),
+    latest_charge: z.string().optional(),
+    subscription: z.union([z.string(), z.object({ id: z.string() }).passthrough()]).nullish(),
+  })
+  .passthrough();
+
+export const stripeChargeFragmentSchema = z
+  .object({
+    id: z.string(),
+    status: z.string().optional(),
+    amount: z.number().optional(),
+    currency: z.string().optional(),
+    balance_transaction: z
+      .union([z.string(), z.object({ id: z.string() }).passthrough()])
+      .optional(),
+    metadata: metadataSchema.optional(),
+    payment_method_details: z
+      .object({
+        type: z.string().optional(),
+        card: z
+          .object({
+            brand: z.string().nullish(),
+            last4: z.string().nullish(),
+          })
+          .partial()
+          .optional(),
+      })
+      .partial()
+      .optional(),
+    customer: z
+      .union([z.string(), z.object({ id: z.string() }).passthrough()])
+      .nullish(),
+    disputed: z.boolean().optional(),
+    dispute: z.union([z.string(), z.object({ id: z.string() }).passthrough()]).nullish(),
+    refunds: z
+      .object({
+        data: z.array(
+          z
+            .object({
+              id: z.string(),
+            })
+            .passthrough(),
+        ),
+      })
+      .optional(),
+    amount_refunded: z.number().optional(),
+    created: z.number().optional(),
+  })
+  .passthrough();
+
+export const stripeBalanceTransactionFragmentSchema = z
+  .object({
+    id: z.string(),
+    amount: z.number(),
+    currency: z.string(),
+    fee: z.number().optional(),
+    net: z.number().optional(),
+    type: z.string(),
+    source: z
+      .union([z.string(), z.object({ id: z.string() }).passthrough()])
+      .nullish(),
+    status: z.string().optional(),
+  })
+  .passthrough();
+
+export interface MapStripeToTransactionInput {
+  paymentIntent?: Stripe.PaymentIntent | null;
+  charge?: Stripe.Charge | null;
+  balanceTransaction?: Stripe.BalanceTransaction | null;
 }
 
-export interface TransactionRecord {
-  id: string;
-  amount: number;
-  currency: string;
-  status: string;
-  metadata: TransactionMetadata;
-}
+const normalizeStripeId = (value: unknown): string | null => {
+  if (!value) {
+    return null;
+  }
 
-export interface PayoutSummary {
-  payoutId: string;
-  gross: number;
-  net: number;
-  feeTotal: number;
-  currency: string;
-  transactionCount: number;
-}
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object' && 'id' in (value as Record<string, unknown>)) {
+    const idValue = (value as Record<string, unknown>).id;
+    return typeof idValue === 'string' ? idValue : null;
+  }
+
+  return null;
+};
+
+const centsToMajorUnits = (value: number | undefined): number | null => {
+  if (typeof value !== 'number') {
+    return null;
+  }
+
+  return value / 100;
+};
+
+const parseMetadataString = (
+  metadata: Record<string, unknown> | undefined,
+  ...keys: string[]
+): string | null => {
+  for (const key of keys) {
+    const raw = metadata?.[key];
+    if (raw === undefined || raw === null) {
+      continue;
+    }
+
+    if (typeof raw === 'string') {
+      const trimmed = raw.trim();
+      if (trimmed.length === 0) {
+        continue;
+      }
+      return trimmed;
+    }
+
+    if (typeof raw === 'number' || typeof raw === 'boolean') {
+      return String(raw);
+    }
+  }
+
+  return null;
+};
+
+const parseMetadataBoolean = (
+  metadata: Record<string, unknown> | undefined,
+  ...keys: string[]
+): boolean | null => {
+  for (const key of keys) {
+    const raw = metadata?.[key];
+    if (raw === undefined || raw === null) {
+      continue;
+    }
+
+    if (typeof raw === 'boolean') {
+      return raw;
+    }
+
+    if (typeof raw === 'string') {
+      const normalized = raw.trim().toLowerCase();
+      if (normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on') {
+        return true;
+      }
+
+      if (normalized === 'false' || normalized === '0' || normalized === 'no' || normalized === 'off') {
+        return false;
+      }
+    }
+  }
+
+  return null;
+};
+
+const parseMetadataNumber = (
+  metadata: Record<string, unknown> | undefined,
+  ...keys: string[]
+): number | null => {
+  for (const key of keys) {
+    const raw = metadata?.[key];
+    if (raw === undefined || raw === null) {
+      continue;
+    }
+
+    if (typeof raw === 'number') {
+      return raw;
+    }
+
+    if (typeof raw === 'string') {
+      const cleaned = raw.trim();
+      if (cleaned.length === 0) {
+        continue;
+      }
+
+      const parsed = Number(cleaned);
+      if (!Number.isNaN(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  return null;
+};
+
+const toMetadataRecord = (
+  metadata: Stripe.Metadata | Stripe.MetadataParam | null | undefined,
+): Record<string, unknown> => {
+  if (!metadata) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(metadata).map(([key, value]) => [key, value ?? null]),
+  );
+};
+
+const deriveTransactionType = (
+  charge: Stripe.Charge | null | undefined,
+  balanceTransaction: Stripe.BalanceTransaction | null | undefined,
+): TransactionType => {
+  const balanceType = balanceTransaction?.type;
+
+  if (balanceType === 'payout') {
+    return 'payout';
+  }
+
+  if (balanceType === 'refund') {
+    return 'refund';
+  }
+
+  if (balanceTransaction?.reporting_category === 'dispute') {
+    return 'dispute';
+  }
+
+  if (charge?.disputed) {
+    return 'dispute';
+  }
+
+  return 'charge';
+};
+
+const deriveStatus = (
+  paymentIntent: Stripe.PaymentIntent | null | undefined,
+  charge: Stripe.Charge | null | undefined,
+): TransactionStatus => {
+  if (charge?.disputed) {
+    return 'disputed';
+  }
+
+  const amountRefunded = charge?.amount_refunded ?? 0;
+  if (charge?.refunded || amountRefunded > 0) {
+    return 'refunded';
+  }
+
+  const chargeStatus = charge?.status;
+  switch (chargeStatus) {
+    case 'succeeded':
+      return 'paid';
+    case 'pending':
+      return 'pending';
+    case 'failed':
+      return 'failed';
+  }
+
+  const piStatus = paymentIntent?.status;
+  switch (piStatus) {
+    case 'succeeded':
+      return 'paid';
+    case 'processing':
+      return 'processing';
+    case 'canceled':
+      return 'failed';
+    case 'requires_payment_method':
+    case 'requires_action':
+    case 'requires_capture':
+      return 'pending';
+  }
+
+  return 'pending';
+};
+
+const deriveCurrency = (
+  paymentIntent: Stripe.PaymentIntent | null | undefined,
+  charge: Stripe.Charge | null | undefined,
+  balanceTransaction: Stripe.BalanceTransaction | null | undefined,
+): string | null => {
+  const currency =
+    balanceTransaction?.currency || charge?.currency || paymentIntent?.currency || undefined;
+
+  return currency ? currency.toUpperCase() : null;
+};
+
+const deriveReceivedAt = (
+  paymentIntent: Stripe.PaymentIntent | null | undefined,
+  charge: Stripe.Charge | null | undefined,
+): string | null => {
+  const timestamp = charge?.created ?? paymentIntent?.created;
+
+  if (typeof timestamp !== 'number') {
+    return null;
+  }
+
+  return new Date(timestamp * 1000).toISOString();
+};
+
+const extractRefundId = (charge: Stripe.Charge | null | undefined): string | null => {
+  const refunds = charge?.refunds?.data;
+  if (!refunds || refunds.length === 0) {
+    return null;
+  }
+
+  const latestRefund = refunds[refunds.length - 1];
+  return latestRefund?.id ?? null;
+};
+
+const extractDisputeId = (metadata: Record<string, unknown>): string | null =>
+  parseMetadataString(
+    metadata,
+    'stripe_dispute_id__c',
+    'stripe_dispute_id',
+    'dispute_id',
+  );
+
+const extractBalanceTransactionId = (
+  charge: Stripe.Charge | null | undefined,
+  balanceTransaction: Stripe.BalanceTransaction | null | undefined,
+): string | null => {
+  if (balanceTransaction?.id) {
+    return balanceTransaction.id;
+  }
+
+  const chargeBalanceTxn = charge?.balance_transaction;
+  if (typeof chargeBalanceTxn === 'string') {
+    return chargeBalanceTxn;
+  }
+
+  if (chargeBalanceTxn && typeof chargeBalanceTxn === 'object') {
+    const idValue = (chargeBalanceTxn as { id?: string }).id;
+    return typeof idValue === 'string' ? idValue : null;
+  }
+
+  return null;
+};
+
+const extractPayoutId = (
+  balanceTransaction: Stripe.BalanceTransaction | null | undefined,
+): string | null => {
+  const source = balanceTransaction?.source;
+  const sourceId = normalizeStripeId(source);
+
+  if (sourceId && sourceId.startsWith('po_')) {
+    return sourceId;
+  }
+
+  if (balanceTransaction?.type === 'payout') {
+    return sourceId ?? balanceTransaction?.id ?? null;
+  }
+
+  return null;
+};
+
+const extractSubscriptionId = (
+  paymentIntent: Stripe.PaymentIntent | null | undefined,
+  charge: Stripe.Charge | null | undefined,
+  metadata: Record<string, unknown>,
+): string | null => {
+  const fromMetadata = parseMetadataString(
+    metadata,
+    'stripe_subscription_id__c',
+    'stripe_subscription_id',
+    'subscription_id',
+  );
+  if (fromMetadata) {
+    return fromMetadata;
+  }
+
+  const chargeInvoice = charge?.invoice;
+  if (chargeInvoice && typeof chargeInvoice === 'object' && 'subscription' in chargeInvoice) {
+    const subscription = (chargeInvoice as Stripe.Invoice).subscription;
+    const normalized = normalizeStripeId(subscription ?? null);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  const intentInvoice = paymentIntent?.invoice;
+  if (intentInvoice && typeof intentInvoice === 'object' && 'subscription' in intentInvoice) {
+    const subscription = (intentInvoice as Stripe.Invoice).subscription;
+    const normalized = normalizeStripeId(subscription ?? null);
+    if (normalized) {
+      return normalized;
+    }
+  }
+
+  return null;
+};
+
+const derivePaymentMethod = (
+  paymentIntent: Stripe.PaymentIntent | null | undefined,
+  charge: Stripe.Charge | null | undefined,
+): string | null => {
+  const chargeMethod = charge?.payment_method_details?.type;
+  if (chargeMethod) {
+    return chargeMethod;
+  }
+
+  const piMethod = paymentIntent?.payment_method;
+  if (typeof piMethod === 'string') {
+    return piMethod;
+  }
+
+  const methodTypes = paymentIntent?.payment_method_types;
+  if (methodTypes && methodTypes.length > 0) {
+    return methodTypes[0];
+  }
+
+  return null;
+};
+
+const derivePaymentBrand = (charge: Stripe.Charge | null | undefined): string | null => {
+  const brand = charge?.payment_method_details?.card?.brand;
+  return brand ?? null;
+};
+
+const derivePaymentLast4 = (charge: Stripe.Charge | null | undefined): string | null => {
+  const last4 = charge?.payment_method_details?.card?.last4;
+  return last4 ?? null;
+};
+
+export const mapStripeToTransaction = (
+  input: MapStripeToTransactionInput,
+): TransactionUpsertDTO => {
+  const paymentIntent = input.paymentIntent ?? null;
+  if (paymentIntent) {
+    stripePaymentIntentFragmentSchema.parse(paymentIntent);
+  }
+
+  const charge = input.charge ?? null;
+  if (charge) {
+    stripeChargeFragmentSchema.parse(charge);
+  }
+
+  const balanceTransaction = input.balanceTransaction ?? null;
+  if (balanceTransaction) {
+    stripeBalanceTransactionFragmentSchema.parse(balanceTransaction);
+  }
+
+  const combinedMetadata: Record<string, unknown> = {
+    ...toMetadataRecord(paymentIntent?.metadata ?? null),
+    ...toMetadataRecord(charge?.metadata ?? null),
+  };
+
+  const transactionCandidate: TransactionUpsertDTO = {
+    transaction_type__c: deriveTransactionType(charge, balanceTransaction),
+    status__c: deriveStatus(paymentIntent, charge),
+    stripe_payment_intent_id__c: paymentIntent?.id ?? null,
+    stripe_charge_id__c: charge?.id ?? null,
+    stripe_balance_transaction_id__c: extractBalanceTransactionId(charge, balanceTransaction),
+    stripe_refund_id__c: extractRefundId(charge),
+    stripe_dispute_id__c: extractDisputeId(combinedMetadata),
+    stripe_checkout_session_id__c: parseMetadataString(
+      combinedMetadata,
+      'stripe_checkout_session_id__c',
+      'stripe_checkout_session_id',
+      'checkout_session_id',
+    ),
+    stripe_customer_id__c:
+      normalizeStripeId(charge?.customer) || normalizeStripeId(paymentIntent?.customer),
+    stripe_subscription_id__c: extractSubscriptionId(paymentIntent, charge, combinedMetadata),
+    stripe_payout_id__c: extractPayoutId(balanceTransaction),
+    amount_gross__c:
+      centsToMajorUnits(balanceTransaction?.amount ?? charge?.amount) ??
+      parseMetadataNumber(combinedMetadata, 'amount_gross__c', 'amount_gross'),
+    amount_fee__c:
+      centsToMajorUnits(balanceTransaction?.fee) ??
+      parseMetadataNumber(combinedMetadata, 'amount_fee__c', 'amount_fee'),
+    amount_net__c:
+      centsToMajorUnits(balanceTransaction?.net) ??
+      parseMetadataNumber(combinedMetadata, 'amount_net__c', 'amount_net'),
+    currency_iso_code:
+      deriveCurrency(paymentIntent, charge, balanceTransaction) ||
+      parseMetadataString(combinedMetadata, 'currency_iso_code', 'currency'),
+    contact__c: parseMetadataString(combinedMetadata, 'contact__c', 'contact'),
+    account__c: parseMetadataString(combinedMetadata, 'account__c', 'account'),
+    campaign__c: parseMetadataString(combinedMetadata, 'campaign__c', 'campaign'),
+    fund__c: parseMetadataString(combinedMetadata, 'fund__c', 'fund'),
+    designation__c: parseMetadataString(
+      combinedMetadata,
+      'designation__c',
+      'designation',
+    ),
+    restriction__c: parseMetadataString(
+      combinedMetadata,
+      'restriction__c',
+      'restriction',
+    ),
+    frequency__c: parseMetadataString(combinedMetadata, 'frequency__c', 'frequency'),
+    cover_fees__c: parseMetadataBoolean(
+      combinedMetadata,
+      'cover_fees__c',
+      'cover_fees',
+    ),
+    cover_fees_amount__c: parseMetadataNumber(
+      combinedMetadata,
+      'cover_fees_amount__c',
+      'cover_fees_amount',
+    ),
+    payment_method__c: derivePaymentMethod(paymentIntent, charge),
+    payment_brand__c: derivePaymentBrand(charge),
+    payment_last4__c: derivePaymentLast4(charge),
+    received_at__c: deriveReceivedAt(paymentIntent, charge),
+    posted_to_qbo__c: parseMetadataBoolean(
+      combinedMetadata,
+      'posted_to_qbo__c',
+      'posted_to_qbo',
+    ),
+    qbo_doc_type__c: parseMetadataString(
+      combinedMetadata,
+      'qbo_doc_type__c',
+      'qbo_doc_type',
+    ),
+    qbo_doc_id__c: parseMetadataString(combinedMetadata, 'qbo_doc_id__c', 'qbo_doc_id'),
+    qbo_posted_at__c: parseMetadataString(
+      combinedMetadata,
+      'qbo_posted_at__c',
+      'qbo_posted_at',
+    ),
+    posting_error__c: parseMetadataString(
+      combinedMetadata,
+      'posting_error__c',
+      'posting_error',
+    ),
+  };
+
+  return transactionUpsertSchema.parse(transactionCandidate);
+};
+


### PR DESCRIPTION
## Summary
- add zod as a runtime dependency for schema validation
- define transaction upsert DTOs and Zod schemas for Salesforce mapping and Stripe payload validation
- implement a helper to map Stripe payment objects into validated transaction upsert payloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e7b4a655d8832cac506182b34412d6