### PR TITLE
Add QuickBooks posting service

### DIFF
--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -1,0 +1,511 @@
+import env from '../config/env';
+
+const QBO_BASE_URL: Record<'sandbox' | 'production', string> = {
+  sandbox: 'https://sandbox-quickbooks.api.intuit.com/v3/company',
+  production: 'https://quickbooks.api.intuit.com/v3/company',
+};
+
+const DOC_NUMBER_MAX_LENGTH = 21;
+
+type QuickBooksDocType = 'sales-receipt' | 'journal-entry' | 'bank-deposit';
+
+type Fetcher = (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1]
+) => ReturnType<typeof fetch>;
+
+interface QuickBooksReference {
+  value?: string;
+  name: string;
+}
+
+interface QuickBooksSalesItemLineDetail {
+  ItemRef: QuickBooksReference;
+  ItemAccountRef?: QuickBooksReference;
+  TaxCodeRef?: QuickBooksReference;
+}
+
+interface QuickBooksSalesReceiptLine {
+  Amount: number;
+  DetailType: 'SalesItemLineDetail';
+  Description?: string;
+  SalesItemLineDetail: QuickBooksSalesItemLineDetail;
+}
+
+export interface QuickBooksSalesReceipt {
+  DocNumber: string;
+  TxnDate: string;
+  PrivateNote?: string;
+  DepositToAccountRef: QuickBooksReference;
+  Line: QuickBooksSalesReceiptLine[];
+}
+
+interface QuickBooksJournalEntryLineDetail {
+  PostingType: 'Debit' | 'Credit';
+  AccountRef: QuickBooksReference;
+}
+
+interface QuickBooksJournalEntryLine {
+  Amount: number;
+  DetailType: 'JournalEntryLineDetail';
+  Description?: string;
+  JournalEntryLineDetail: QuickBooksJournalEntryLineDetail;
+}
+
+export interface QuickBooksJournalEntry {
+  DocNumber: string;
+  TxnDate: string;
+  PrivateNote?: string;
+  Line: QuickBooksJournalEntryLine[];
+}
+
+interface QuickBooksDepositLineDetail {
+  AccountRef: QuickBooksReference;
+}
+
+interface QuickBooksDepositLine {
+  Amount: number;
+  DetailType: 'DepositLineDetail';
+  Description?: string;
+  DepositLineDetail: QuickBooksDepositLineDetail;
+}
+
+export interface QuickBooksBankDeposit {
+  DocNumber: string;
+  TxnDate: string;
+  PrivateNote?: string;
+  DepositToAccountRef: QuickBooksReference;
+  Line: QuickBooksDepositLine[];
+}
+
+interface PostOptions {
+  fetcher?: Fetcher;
+  accessToken?: string;
+}
+
+interface PostResult {
+  id: string;
+  type: QuickBooksDocType;
+  raw: unknown;
+}
+
+interface BuildSalesReceiptInput {
+  docNumber: string;
+  amountCents: number;
+  memo?: string;
+  date: string | Date;
+  revenueAccountName?: string;
+  depositAccountName?: string;
+}
+
+interface BuildFeesJournalEntryInput {
+  docNumber: string;
+  feeAmountCents: number;
+  memo?: string;
+  date: string | Date;
+}
+
+interface BuildSingleJournalEntryInput {
+  docNumber: string;
+  grossAmountCents: number;
+  feeAmountCents: number;
+  memo?: string;
+  date: string | Date;
+}
+
+interface BuildBankDepositInput {
+  docNumber: string;
+  amountCents: number;
+  memo?: string;
+  date: string | Date;
+  sourceAccountName?: string;
+  targetAccountName?: string;
+}
+
+export interface PostChargeToQboInput {
+  gross: number;
+  fee: number;
+  memo?: string;
+  date: string | Date;
+  options?: PostOptions;
+}
+
+export interface PostChargeToQboResult {
+  qboId: string;
+  type: Extract<QuickBooksDocType, 'sales-receipt' | 'journal-entry'>;
+}
+
+const ensurePositiveAmount = (value: number, label: string): number => {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative finite number.`);
+  }
+
+  return Math.round(value);
+};
+
+const centsToDollars = (value: number): number => {
+  return Math.round(value) / 100;
+};
+
+const normalizeDate = (value: string | Date): string => {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error('Invalid transaction date provided.');
+  }
+
+  return date.toISOString().slice(0, 10);
+};
+
+const createAccountRef = (name: string): QuickBooksReference => {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error('QuickBooks account name must be provided.');
+  }
+
+  return { name: trimmed };
+};
+
+const buildDocNumber = (prefix: string, date: string | Date, amountCents: number): string => {
+  const formattedDate = normalizeDate(date).replace(/-/g, '');
+  const amountPart = Math.abs(Math.round(amountCents)).toString().slice(-10);
+  const suffix = `${formattedDate}-${amountPart}`;
+  const maxPrefixLength = Math.max(1, DOC_NUMBER_MAX_LENGTH - suffix.length - 1);
+  const safePrefix = prefix.slice(0, maxPrefixLength);
+  return `${safePrefix}-${suffix}`.slice(0, DOC_NUMBER_MAX_LENGTH);
+};
+
+export const buildSalesReceipt = ({
+  docNumber,
+  amountCents,
+  memo,
+  date,
+  revenueAccountName = env.quickBooks.accounts.revenue,
+  depositAccountName = env.quickBooks.accounts.stripeClearing,
+}: BuildSalesReceiptInput): QuickBooksSalesReceipt => {
+  const amount = ensurePositiveAmount(amountCents, 'Sales receipt amount');
+  if (amount === 0) {
+    throw new Error('Sales receipt amount must be greater than zero.');
+  }
+
+  return {
+    DocNumber: docNumber,
+    TxnDate: normalizeDate(date),
+    PrivateNote: memo,
+    DepositToAccountRef: createAccountRef(depositAccountName),
+    Line: [
+      {
+        Amount: centsToDollars(amount),
+        DetailType: 'SalesItemLineDetail',
+        Description: memo,
+        SalesItemLineDetail: {
+          ItemRef: createAccountRef(revenueAccountName),
+          ItemAccountRef: createAccountRef(revenueAccountName),
+        },
+      },
+    ],
+  };
+};
+
+const createJournalEntryLine = (
+  type: 'debit' | 'credit',
+  accountName: string,
+  amountCents: number,
+  memo?: string,
+): QuickBooksJournalEntryLine | null => {
+  const amount = ensurePositiveAmount(amountCents, 'Journal entry amount');
+  if (amount === 0) {
+    return null;
+  }
+
+  return {
+    Amount: centsToDollars(amount),
+    DetailType: 'JournalEntryLineDetail',
+    Description: memo,
+    JournalEntryLineDetail: {
+      PostingType: type === 'debit' ? 'Debit' : 'Credit',
+      AccountRef: createAccountRef(accountName),
+    },
+  };
+};
+
+export const buildFeesJE = ({
+  docNumber,
+  feeAmountCents,
+  memo,
+  date,
+}: BuildFeesJournalEntryInput): QuickBooksJournalEntry => {
+  const feeAmount = ensurePositiveAmount(feeAmountCents, 'Fee amount');
+
+  const lines = [
+    createJournalEntryLine('debit', env.quickBooks.accounts.fees, feeAmount, memo),
+    createJournalEntryLine('credit', env.quickBooks.accounts.stripeClearing, feeAmount, memo),
+  ].filter((line): line is QuickBooksJournalEntryLine => Boolean(line));
+
+  if (lines.length === 0) {
+    throw new Error('Fee journal entry must include at least one non-zero line.');
+  }
+
+  return {
+    DocNumber: docNumber,
+    TxnDate: normalizeDate(date),
+    PrivateNote: memo,
+    Line: lines,
+  };
+};
+
+export const buildSingleJE = ({
+  docNumber,
+  grossAmountCents,
+  feeAmountCents,
+  memo,
+  date,
+}: BuildSingleJournalEntryInput): QuickBooksJournalEntry => {
+  const grossAmount = ensurePositiveAmount(grossAmountCents, 'Gross amount');
+  const feeAmount = ensurePositiveAmount(feeAmountCents, 'Fee amount');
+
+  if (grossAmount === 0) {
+    throw new Error('Gross amount must be greater than zero.');
+  }
+
+  const lines = [
+    createJournalEntryLine('debit', env.quickBooks.accounts.stripeClearing, grossAmount, memo),
+    createJournalEntryLine('credit', env.quickBooks.accounts.revenue, grossAmount, memo),
+  ];
+
+  if (feeAmount > 0) {
+    lines.push(
+      createJournalEntryLine('debit', env.quickBooks.accounts.fees, feeAmount, memo),
+      createJournalEntryLine('credit', env.quickBooks.accounts.stripeClearing, feeAmount, memo),
+    );
+  }
+
+  const filteredLines = lines.filter((line): line is QuickBooksJournalEntryLine => Boolean(line));
+
+  if (filteredLines.length === 0) {
+    throw new Error('Journal entry must contain at least one non-zero line.');
+  }
+
+  return {
+    DocNumber: docNumber,
+    TxnDate: normalizeDate(date),
+    PrivateNote: memo,
+    Line: filteredLines,
+  };
+};
+
+export const buildBankDeposit = ({
+  docNumber,
+  amountCents,
+  memo,
+  date,
+  sourceAccountName = env.quickBooks.accounts.stripeClearing,
+  targetAccountName = env.quickBooks.accounts.operatingBank,
+}: BuildBankDepositInput): QuickBooksBankDeposit => {
+  const amount = ensurePositiveAmount(amountCents, 'Deposit amount');
+  if (amount === 0) {
+    throw new Error('Deposit amount must be greater than zero.');
+  }
+
+  return {
+    DocNumber: docNumber,
+    TxnDate: normalizeDate(date),
+    PrivateNote: memo,
+    DepositToAccountRef: createAccountRef(targetAccountName),
+    Line: [
+      {
+        Amount: centsToDollars(amount),
+        DetailType: 'DepositLineDetail',
+        Description: memo,
+        DepositLineDetail: {
+          AccountRef: createAccountRef(sourceAccountName),
+        },
+      },
+    ],
+  };
+};
+
+const getFetcher = (options?: PostOptions): Fetcher => {
+  if (options?.fetcher) {
+    return options.fetcher;
+  }
+  if (typeof fetch !== 'undefined') {
+    return fetch;
+  }
+  throw new Error('Fetch API is not available in the current environment.');
+};
+
+const getAccessToken = (options?: PostOptions): string => {
+  const token = options?.accessToken ?? process.env.QBO_ACCESS_TOKEN;
+  if (!token) {
+    throw new Error('QuickBooks access token is not configured.');
+  }
+  return token;
+};
+
+const getRealmId = (): string => {
+  const realmId = env.quickBooks.realmId;
+  if (!realmId) {
+    throw new Error('QuickBooks realm ID is not configured.');
+  }
+  return realmId;
+};
+
+const buildQboUrl = (entity: string): string => {
+  const base = QBO_BASE_URL[env.quickBooks.environment];
+  const realmId = getRealmId();
+  return `${base}/${encodeURIComponent(realmId)}/${entity}`;
+};
+
+const postToQbo = async <T extends QuickBooksDocType>(
+  entity: T,
+  payload: T extends 'sales-receipt'
+    ? QuickBooksSalesReceipt
+    : T extends 'journal-entry'
+    ? QuickBooksJournalEntry
+    : QuickBooksBankDeposit,
+  options?: PostOptions,
+): Promise<PostResult> => {
+  const url = buildQboUrl(
+    entity === 'sales-receipt'
+      ? 'salesreceipt'
+      : entity === 'journal-entry'
+      ? 'journalentry'
+      : 'deposit',
+  );
+  const fetcher = getFetcher(options);
+  const accessToken = getAccessToken(options);
+
+  const response = await fetcher(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+    throw new Error(
+      `Failed to post ${entity} to QuickBooks (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const id = extractIdFromResponse(data, entity);
+
+  return { id, type: entity, raw: data };
+};
+
+const extractIdFromResponse = (response: unknown, entity: QuickBooksDocType): string => {
+  if (response && typeof response === 'object') {
+    const key =
+      entity === 'sales-receipt'
+        ? 'SalesReceipt'
+        : entity === 'journal-entry'
+        ? 'JournalEntry'
+        : 'Deposit';
+
+    const container = (response as Record<string, unknown>)[key];
+    if (container && typeof container === 'object') {
+      const idValue = (container as Record<string, unknown>).Id;
+      if (typeof idValue === 'string' && idValue.trim().length > 0) {
+        return idValue;
+      }
+      if (typeof idValue === 'number' && Number.isFinite(idValue)) {
+        return idValue.toString();
+      }
+    }
+
+    const directId = (response as Record<string, unknown>).Id;
+    if (typeof directId === 'string' && directId.trim().length > 0) {
+      return directId;
+    }
+    if (typeof directId === 'number' && Number.isFinite(directId)) {
+      return directId.toString();
+    }
+  }
+
+  throw new Error('QuickBooks response did not include an identifier.');
+};
+
+export const postSalesReceipt = (
+  salesReceipt: QuickBooksSalesReceipt,
+  options?: PostOptions,
+): Promise<PostResult> => postToQbo('sales-receipt', salesReceipt, options);
+
+export const postJournalEntry = (
+  journalEntry: QuickBooksJournalEntry,
+  options?: PostOptions,
+): Promise<PostResult> => postToQbo('journal-entry', journalEntry, options);
+
+export const postBankDeposit = (
+  bankDeposit: QuickBooksBankDeposit,
+  options?: PostOptions,
+): Promise<PostResult> => postToQbo('bank-deposit', bankDeposit, options);
+
+export const postChargeToQbo = async ({
+  gross,
+  fee,
+  memo,
+  date,
+  options,
+}: PostChargeToQboInput): Promise<PostChargeToQboResult> => {
+  const grossAmount = ensurePositiveAmount(gross, 'Gross amount');
+  const feeAmount = ensurePositiveAmount(fee, 'Fee amount');
+  const normalizedMemo = memo?.trim() || undefined;
+
+  const strategy = env.accounting.postingStrategy;
+
+  if (strategy === 'sales-receipt') {
+    const salesReceiptDocNumber = buildDocNumber('CHG', date, grossAmount);
+    const salesReceipt = buildSalesReceipt({
+      docNumber: salesReceiptDocNumber,
+      amountCents: grossAmount,
+      memo: normalizedMemo,
+      date,
+    });
+
+    const salesReceiptResult = await postSalesReceipt(salesReceipt, options);
+
+    if (feeAmount > 0) {
+      const feeDocNumber = buildDocNumber('FEE', date, feeAmount);
+      const feeJournalEntry = buildFeesJE({
+        docNumber: feeDocNumber,
+        feeAmountCents: feeAmount,
+        memo: normalizedMemo,
+        date,
+      });
+
+      await postJournalEntry(feeJournalEntry, options);
+    }
+
+    return { qboId: salesReceiptResult.id, type: 'sales-receipt' };
+  }
+
+  const journalDocNumber = buildDocNumber('CHGJE', date, grossAmount + feeAmount);
+  const journalEntry = buildSingleJE({
+    docNumber: journalDocNumber,
+    grossAmountCents: grossAmount,
+    feeAmountCents: feeAmount,
+    memo: normalizedMemo,
+    date,
+  });
+
+  const journalResult = await postJournalEntry(journalEntry, options);
+  return { qboId: journalResult.id, type: 'journal-entry' };
+};
+
+export default {
+  buildSalesReceipt,
+  buildFeesJE,
+  buildSingleJE,
+  buildBankDeposit,
+  postSalesReceipt,
+  postJournalEntry,
+  postBankDeposit,
+  postChargeToQbo,
+};


### PR DESCRIPTION
## Summary
- add a typed QuickBooks service for building sales receipts, journal entries, and deposits
- implement helpers to post those documents to QuickBooks and route charge postings based on the configured strategy

## Testing
- npm run build *(fails: missing local zod dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e7d61cc074832caf7ccd074180daf1