### PR TITLE
Add Azure Table idempotency store with lock handling

### DIFF
--- a/__tests__/idempotencyStore.test.ts
+++ b/__tests__/idempotencyStore.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import AzureIdempotencyStore from '../src/services/idempotencyStore';
+
+interface StoredEntity {
+  entity: Record<string, any>;
+  etag: string;
+}
+
+class FakeTableClient {
+  public beforeUpsert: ((entity: Record<string, any>) => Promise<void>) | null = null;
+  private readonly entities = new Map<string, StoredEntity>();
+  private etagCounter = 0;
+
+  async createTable(): Promise<void> {
+    return;
+  }
+
+  async getEntity<T extends object>(partitionKey: string, rowKey: string): Promise<T & { etag: string }> {
+    const key = this.key(partitionKey, rowKey);
+    const stored = this.entities.get(key);
+    if (!stored) {
+      const error = new Error('Not found');
+      (error as any).statusCode = 404;
+      throw error;
+    }
+
+    return { ...(stored.entity as T), etag: stored.etag };
+  }
+
+  async createEntity(entity: Record<string, any>): Promise<void> {
+    const key = this.key(entity.partitionKey, entity.rowKey);
+    if (this.entities.has(key)) {
+      const error = new Error('Conflict');
+      (error as any).statusCode = 409;
+      throw error;
+    }
+
+    this.entities.set(key, { entity: { ...entity }, etag: this.nextEtag() });
+  }
+
+  async upsertEntity(entity: Record<string, any>): Promise<void> {
+    if (this.beforeUpsert) {
+      await this.beforeUpsert(entity);
+    }
+
+    const key = this.key(entity.partitionKey, entity.rowKey);
+    const existing = this.entities.get(key);
+    const merged = existing ? { ...existing.entity, ...entity } : { ...entity };
+    this.entities.set(key, { entity: merged, etag: this.nextEtag() });
+  }
+
+  async deleteEntity(partitionKey: string, rowKey: string, options: { etag?: string } = {}): Promise<void> {
+    const key = this.key(partitionKey, rowKey);
+    const existing = this.entities.get(key);
+    if (!existing) {
+      const error = new Error('Not found');
+      (error as any).statusCode = 404;
+      throw error;
+    }
+
+    if (options.etag && options.etag !== existing.etag) {
+      const error = new Error('Precondition failed');
+      (error as any).statusCode = 412;
+      throw error;
+    }
+
+    this.entities.delete(key);
+  }
+
+  hasEntity(partitionKey: string, rowKey: string): boolean {
+    return this.entities.has(this.key(partitionKey, rowKey));
+  }
+
+  private key(partitionKey: string, rowKey: string): string {
+    return `${partitionKey}|${rowKey}`;
+  }
+
+  private nextEtag(): string {
+    this.etagCounter += 1;
+    return `W/\"etag-${this.etagCounter}\"`;
+  }
+}
+
+describe('AzureIdempotencyStore', () => {
+  it('flushes pending writes queued during an in-flight persist', async () => {
+    const client = new FakeTableClient();
+    let firstUpsert = true;
+    let releaseFirstUpsert: (() => void) | null = null;
+    const firstUpsertDeferred = new Promise<void>((resolve) => {
+      releaseFirstUpsert = resolve;
+    });
+
+    client.beforeUpsert = async () => {
+      if (firstUpsert) {
+        firstUpsert = false;
+        await firstUpsertDeferred;
+      }
+    };
+
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const store = new AzureIdempotencyStore({ tableClient: client as any, logger });
+
+    await store.markProcessed('evt_1');
+    const firstFlush = store.flush();
+    await Promise.resolve();
+    await store.markProcessed('evt_2');
+
+    releaseFirstUpsert?.();
+    await firstFlush;
+    await store.flush();
+
+    expect(client.hasEntity('processed', 'evt_1')).toBe(true);
+    expect(client.hasEntity('processed', 'evt_2')).toBe(true);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "payment-processing-function",
       "version": "1.0.0",
       "dependencies": {
+        "@azure/data-tables": "^13.2.2",
         "@azure/functions": "^4.5.0",
         "@sendgrid/client": "^8.1.0",
         "@sendgrid/mail": "^8.1.0",
@@ -26,6 +27,169 @@
         "node": ">=20.0.0 <21"
       }
     },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.1.tgz",
+      "integrity": "sha512-UVZlVLfLyz6g3Hy7GNDpooMQonUygH7ghdiSASOOHy97fKj/mPLqgDX7aidOijn+sCMU+WU8NjlPlNTgnvbcGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.0.tgz",
+      "integrity": "sha512-D/sdlJBMJfx7gqoj66PKVmhDDaU6TKA49ptcolxdas29X7AfvLTmfAGLjAcIMBK7UZ2o4lygHIqVckOlQU3xWw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.0.7",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml/node_modules/fast-xml-parser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.0.tgz",
+      "integrity": "sha512-gkWGshjYcQCF+6qtlrqBqELqNqnt4CxruY6UVAWWnqb3DQ6qaNFEIKqzYep1XzHLM/QtrHVCxyPOtTk4LTQ7Aw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/@azure/core-xml/node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@azure/data-tables": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.3.1.tgz",
+      "integrity": "sha512-jGk1s1SbAfy39zxArNn4HAmycmHF/+XtYYRZ6kakayxJNQeeuacSkLUioezOZIVI01i3Yvr4xzTMuKZpdKXf1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.4",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.20.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.12.0",
+        "@azure/core-xml": "^1.4.5",
+        "@azure/logger": "^1.2.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@azure/functions": {
       "version": "4.8.0",
       "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-4.8.0.tgz",
@@ -38,6 +202,19 @@
       },
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -943,6 +1120,42 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.1.tgz",
+      "integrity": "sha512-SnbaqayTVFEA6/tYumdF0UmybY0KHyKwGPBXnyckFlrrKdhWFrL3a2HIPXHjht5ZOElKGcXfD2D63P36btb+ww==",
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@typespec/ts-http-runtime/node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@vitest/expect": {
@@ -2156,6 +2369,28 @@
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/http-signature": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@azure/functions": "^4.5.0",
     "@sendgrid/client": "^8.1.0",
     "@sendgrid/mail": "^8.1.0",
+    "@azure/data-tables": "^13.2.2",
     "jsforce": "^3.10.7",
     "node-quickbooks": "^2.0.46",
     "stripe": "^14.7.0",

--- a/src/services/idempotencyStore.ts
+++ b/src/services/idempotencyStore.ts
@@ -1,0 +1,323 @@
+import { TableClient, RestError } from '@azure/data-tables';
+import type { TableEntityResult } from '@azure/data-tables';
+
+export interface AzureIdempotencyStoreOptions {
+  /** Optional preconfigured TableClient instance. */
+  tableClient?: TableClient;
+  /** Azure Tables connection string. Falls back to AZURE_TABLES_CONNECTION_STRING or AZURE_STORAGE_CONNECTION_STRING. */
+  connectionString?: string;
+  /** Name of the table to store processed keys and locks. */
+  tableName?: string;
+  /** Partition key for processed records. */
+  processedPartitionKey?: string;
+  /** Partition key for locks. */
+  lockPartitionKey?: string;
+  /** TTL for lock rows, in seconds. */
+  lockTtlSeconds?: number;
+  /** Maximum attempts when trying to acquire a lock. */
+  lockMaxAttempts?: number;
+  /** Base delay (in milliseconds) between lock attempts. */
+  lockRetryDelayMs?: number;
+  /** Optional logger implementation. */
+  logger?: Pick<typeof console, 'debug' | 'info' | 'warn' | 'error'>;
+}
+
+export interface IdempotencyStore {
+  isProcessed(key: string): Promise<boolean>;
+  markProcessed(key: string): Promise<void>;
+  withLock<T>(key: string, fn: () => Promise<T>): Promise<T>;
+  flush(): Promise<void>;
+}
+
+const DEFAULT_TABLE_NAME = 'IdempotencyState';
+const DEFAULT_PROCESSED_PARTITION = 'processed';
+const DEFAULT_LOCK_PARTITION = 'locks';
+const DEFAULT_LOCK_TTL_SECONDS = 60;
+const DEFAULT_LOCK_MAX_ATTEMPTS = 10;
+const DEFAULT_LOCK_RETRY_DELAY_MS = 200;
+
+type LockEntity = {
+  leaseExpiresAt?: string;
+  ttl?: number;
+};
+
+function isRestError(error: unknown): error is RestError {
+  return Boolean(error && typeof error === 'object' && 'statusCode' in (error as Record<string, unknown>));
+}
+
+function isStatus(error: unknown, status: number): boolean {
+  return isRestError(error) && (error.statusCode === status);
+}
+
+function nowPlusSeconds(seconds: number): string {
+  return new Date(Date.now() + seconds * 1000).toISOString();
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class AzureIdempotencyStore implements IdempotencyStore {
+  private readonly client: TableClient;
+  private readonly processedPartitionKey: string;
+  private readonly lockPartitionKey: string;
+  private readonly lockTtlSeconds: number;
+  private readonly lockMaxAttempts: number;
+  private readonly lockRetryDelayMs: number;
+  private readonly logger: Pick<typeof console, 'debug' | 'info' | 'warn' | 'error'>;
+  private readonly ensureTablePromise: Promise<void>;
+
+  private readonly processedKeys = new Set<string>();
+  private readonly pendingPersist = new Set<string>();
+  private persistPromise: Promise<void> | null = null;
+  private reschedulePersist = false;
+
+  constructor(options: AzureIdempotencyStoreOptions = {}) {
+    const logger = options.logger ?? console;
+    this.logger = logger;
+
+    const tableName = options.tableName ?? process.env.IDEMPOTENCY_TABLE_NAME ?? DEFAULT_TABLE_NAME;
+    this.processedPartitionKey = options.processedPartitionKey ?? DEFAULT_PROCESSED_PARTITION;
+    this.lockPartitionKey = options.lockPartitionKey ?? DEFAULT_LOCK_PARTITION;
+    this.lockTtlSeconds = options.lockTtlSeconds ?? DEFAULT_LOCK_TTL_SECONDS;
+    this.lockMaxAttempts = options.lockMaxAttempts ?? DEFAULT_LOCK_MAX_ATTEMPTS;
+    this.lockRetryDelayMs = options.lockRetryDelayMs ?? DEFAULT_LOCK_RETRY_DELAY_MS;
+
+    if (this.lockTtlSeconds <= 0) {
+      throw new Error('lockTtlSeconds must be greater than 0.');
+    }
+
+    const client = options.tableClient ?? this.createClient(tableName, options.connectionString);
+    this.client = client;
+    this.ensureTablePromise = this.ensureTableExists(client);
+  }
+
+  private createClient(tableName: string, overrideConnectionString?: string): TableClient {
+    const connectionString =
+      overrideConnectionString ??
+      process.env.AZURE_TABLES_CONNECTION_STRING ??
+      process.env.AZURE_STORAGE_CONNECTION_STRING;
+
+    if (!connectionString) {
+      throw new Error('An Azure Tables connection string is required. Set AZURE_TABLES_CONNECTION_STRING or AZURE_STORAGE_CONNECTION_STRING.');
+    }
+
+    return TableClient.fromConnectionString(connectionString, tableName);
+  }
+
+  private async ensureTableExists(client: TableClient): Promise<void> {
+    try {
+      await client.createTable();
+    } catch (error) {
+      if (!isStatus(error, 409)) {
+        throw error;
+      }
+    }
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.ensureTablePromise;
+  }
+
+  async isProcessed(key: string): Promise<boolean> {
+    if (!key) {
+      throw new Error('Key must be provided to isProcessed.');
+    }
+
+    if (this.processedKeys.has(key)) {
+      return true;
+    }
+
+    await this.ensureReady();
+
+    try {
+      await this.client.getEntity(this.processedPartitionKey, key);
+      this.processedKeys.add(key);
+      return true;
+    } catch (error) {
+      if (isStatus(error, 404)) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async markProcessed(key: string): Promise<void> {
+    if (!key) {
+      throw new Error('Key must be provided to markProcessed.');
+    }
+
+    await this.ensureReady();
+
+    this.processedKeys.add(key);
+    this.pendingPersist.add(key);
+    this.schedulePersist();
+  }
+
+  async flush(): Promise<void> {
+    await this.ensureReady();
+
+    if (this.pendingPersist.size === 0 && !this.persistPromise) {
+      return;
+    }
+
+    this.schedulePersist();
+    if (this.persistPromise) {
+      await this.persistPromise;
+    }
+  }
+
+  private schedulePersist(): void {
+    if (this.persistPromise) {
+      this.reschedulePersist = true;
+      return;
+    }
+
+    this.persistPromise = this.persistPending()
+      .catch((error) => {
+        this.logger.error?.('[IdempotencyStore] Failed to persist processed keys', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      })
+      .finally(() => {
+        this.persistPromise = null;
+        if (this.reschedulePersist || this.pendingPersist.size > 0) {
+          this.reschedulePersist = false;
+          this.schedulePersist();
+        }
+      });
+  }
+
+  private async persistPending(): Promise<void> {
+    if (this.pendingPersist.size === 0) {
+      return;
+    }
+
+    const keys = Array.from(this.pendingPersist);
+    this.pendingPersist.clear();
+
+    for (let i = 0; i < keys.length; i += 1) {
+      const key = keys[i];
+      try {
+        await this.client.upsertEntity({
+          partitionKey: this.processedPartitionKey,
+          rowKey: key,
+          processedAt: new Date().toISOString(),
+        });
+      } catch (error) {
+        for (let j = i; j < keys.length; j += 1) {
+          this.pendingPersist.add(keys[j]);
+        }
+        throw error;
+      }
+    }
+  }
+
+  async withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    if (!key) {
+      throw new Error('Key must be provided to withLock.');
+    }
+
+    await this.ensureReady();
+    const release = await this.acquireLock(key);
+
+    try {
+      const result = await fn();
+      return result;
+    } finally {
+      try {
+        await release();
+      } catch (error) {
+        if (!isStatus(error, 404)) {
+          this.logger.warn?.('[IdempotencyStore] Failed to release lock', {
+            key,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+  }
+
+  private async acquireLock(key: string): Promise<() => Promise<void>> {
+    const partitionKey = this.lockPartitionKey;
+    const ttl = Math.max(1, Math.ceil(this.lockTtlSeconds));
+
+    for (let attempt = 0; attempt < this.lockMaxAttempts; attempt += 1) {
+      const leaseExpiresAt = nowPlusSeconds(this.lockTtlSeconds);
+
+      try {
+        await this.client.createEntity({
+          partitionKey,
+          rowKey: key,
+          leaseExpiresAt,
+          ttl,
+        });
+
+        let released = false;
+        return async () => {
+          if (released) {
+            return;
+          }
+          released = true;
+          try {
+            await this.client.deleteEntity(partitionKey, key);
+          } catch (error) {
+            if (!isStatus(error, 404)) {
+              throw error;
+            }
+          }
+        };
+      } catch (error) {
+        if (!isStatus(error, 409)) {
+          throw error;
+        }
+
+        const existing = await this.getLockEntity(key);
+        if (existing && !this.lockExpired(existing)) {
+          const delayMs = this.lockRetryDelayMs * (attempt + 1);
+          await delay(delayMs);
+          continue;
+        }
+
+        if (existing) {
+          try {
+            await this.client.deleteEntity(partitionKey, key, { etag: existing.etag });
+          } catch (deleteError) {
+            if (!isStatus(deleteError, 404) && !isStatus(deleteError, 412)) {
+              throw deleteError;
+            }
+          }
+        }
+      }
+    }
+
+    throw new Error(`Failed to acquire lock for key "${key}" after ${this.lockMaxAttempts} attempts.`);
+  }
+
+  private async getLockEntity(key: string): Promise<TableEntityResult<LockEntity> | null> {
+    try {
+      return await this.client.getEntity<LockEntity>(this.lockPartitionKey, key);
+    } catch (error) {
+      if (isStatus(error, 404)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  private lockExpired(entity: TableEntityResult<LockEntity>): boolean {
+    if (!entity.leaseExpiresAt) {
+      return true;
+    }
+
+    const expires = Date.parse(entity.leaseExpiresAt);
+    if (Number.isNaN(expires)) {
+      return true;
+    }
+
+    return expires <= Date.now();
+  }
+}
+
+export default AzureIdempotencyStore;

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     test: {
-        include: ['__tests__/**/*.test.js'],
+        include: ['__tests__/**/*.test.{js,ts}'],
         environment: 'node',
         restoreMocks: true
     }


### PR DESCRIPTION
## Summary
- add an Azure Table-backed idempotency store with helpers to check, record, and lock work items
- ensure pending writes are flushed after in-flight persists complete and cover the race with a new unit test
- update test discovery and dependencies to include the Azure Tables SDK and TypeScript test files

## Testing
- npm run build
- npm run test:unit


------
https://chatgpt.com/codex/tasks/task_e_68e7e0109668832cb6519b13318554cb