### PR TITLE
Rewrite payoutSyncTrigger for automated payout reconciliation

### DIFF
--- a/__tests__/payoutSyncTrigger.test.js
+++ b/__tests__/payoutSyncTrigger.test.js
@@ -4,13 +4,18 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { createContext } = require('./testUtils');
 
+vi.mock('../src/services/salesforceSvc', () => ({
+    createSalesforceSvc: vi.fn()
+}), { virtual: true });
+
 describe('payoutSyncTrigger', () => {
     let handler;
     let internals;
 
     beforeEach(() => {
-        vi.resetModules();
-        handler = require('../payoutSyncTrigger');
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2024-05-20T12:00:00Z'));
+        handler = require('../src/handlers/payoutSyncTrigger.js');
         internals = handler.__internals;
     });
 
@@ -20,22 +25,141 @@ describe('payoutSyncTrigger', () => {
         }
         handler = undefined;
         internals = undefined;
+        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
-    it('completes without throwing when no payouts are available', async () => {
-        const syncLedger = {
-            getSync: vi.fn().mockResolvedValue(null)
+    it('posts bank deposits for new payouts and links Salesforce transactions', async () => {
+        const payout = {
+            id: 'po_123',
+            amount: 2500,
+            arrival_date: Math.floor(Date.now() / 1000)
         };
 
-        internals.setDependencies({ syncLedger });
+        const payoutsList = vi.fn().mockResolvedValue({
+            data: [payout],
+            has_more: false
+        });
 
-        const { context } = createContext({ bindingData: { payoutId: 'po_missing' } });
-        const req = { method: 'GET', query: {} };
+        const balanceTransactionsList = vi.fn().mockResolvedValue({
+            data: [{ id: 'bt_1' }, { id: 'bt_2' }],
+            has_more: false
+        });
+
+        const buildBankDeposit = vi.fn(({ docNumber, amountCents, memo, date }) => ({
+            docNumber,
+            amountCents,
+            memo,
+            date
+        }));
+
+        const bankDepositResult = { id: 'dep_1' };
+        const postBankDeposit = vi.fn().mockResolvedValue(bankDepositResult);
+        const linkPayoutOnTransactions = vi.fn().mockResolvedValue([]);
+        const processedStore = {
+            isProcessed: vi.fn().mockResolvedValue(false),
+            markProcessed: vi.fn().mockResolvedValue(undefined)
+        };
+
+        internals.setDependencies({
+            stripe: {
+                payouts: { list: payoutsList },
+                balanceTransactions: { list: balanceTransactionsList }
+            },
+            accounting: { buildBankDeposit, postBankDeposit },
+            salesforce: { linkPayoutOnTransactions },
+            processedStore,
+            lookbackDays: 8,
+            now: () => Date.now()
+        });
+
+        const { context } = createContext();
+        const req = { method: 'POST' };
 
         await handler(context, req);
 
-        expect(context.res.status).toBe(404);
-        expect(syncLedger.getSync).toHaveBeenCalledWith('default', 'po_missing');
+        expect(payoutsList).toHaveBeenCalledTimes(1);
+        expect(processedStore.isProcessed).toHaveBeenCalledWith('po_po_123');
+        expect(buildBankDeposit).toHaveBeenCalledWith(expect.objectContaining({
+            docNumber: 'payout_po_123',
+            amountCents: 2500,
+            memo: 'payout_po_123',
+            date: expect.any(Date)
+        }));
+        expect(postBankDeposit).toHaveBeenCalledWith({
+            docNumber: 'payout_po_123',
+            amountCents: 2500,
+            memo: 'payout_po_123',
+            date: expect.any(Date)
+        });
+        expect(linkPayoutOnTransactions).toHaveBeenCalledWith('po_123', ['bt_1', 'bt_2']);
+        expect(processedStore.markProcessed).toHaveBeenCalledWith('po_po_123');
+
+        expect(context.res.status).toBe(200);
+        expect(context.res.body.summary).toEqual({
+            lookbackDays: 8,
+            total: 1,
+            processed: 1,
+            skipped: 0,
+            errors: 0
+        });
+        expect(context.res.body.processed).toEqual([
+            {
+                status: 'processed',
+                payoutId: 'po_123',
+                bankDepositId: 'dep_1'
+            }
+        ]);
+    });
+
+    it('skips payouts that were already processed', async () => {
+        const payout = {
+            id: 'po_999',
+            amount: 1500,
+            arrival_date: Math.floor(Date.now() / 1000)
+        };
+
+        const payoutsList = vi.fn().mockResolvedValue({
+            data: [payout],
+            has_more: false
+        });
+
+        const balanceTransactionsList = vi.fn();
+
+        const processedStore = {
+            isProcessed: vi.fn().mockResolvedValue(true),
+            markProcessed: vi.fn()
+        };
+
+        const buildBankDeposit = vi.fn();
+        const postBankDeposit = vi.fn();
+        const linkPayoutOnTransactions = vi.fn();
+
+        internals.setDependencies({
+            stripe: {
+                payouts: { list: payoutsList },
+                balanceTransactions: { list: balanceTransactionsList }
+            },
+            accounting: { buildBankDeposit, postBankDeposit },
+            salesforce: { linkPayoutOnTransactions },
+            processedStore,
+            lookbackDays: 7,
+            now: () => Date.now()
+        });
+
+        const { context } = createContext();
+        const req = { method: 'POST' };
+
+        await handler(context, req);
+
+        expect(processedStore.isProcessed).toHaveBeenCalledWith('po_po_999');
+        expect(balanceTransactionsList).not.toHaveBeenCalled();
+        expect(buildBankDeposit).not.toHaveBeenCalled();
+        expect(postBankDeposit).not.toHaveBeenCalled();
+        expect(linkPayoutOnTransactions).not.toHaveBeenCalled();
+
+        expect(context.res.status).toBe(200);
+        expect(context.res.body.summary.processed).toBe(0);
+        expect(context.res.body.summary.skipped).toBe(1);
     });
 });

--- a/src/handlers/payoutSyncTrigger.js
+++ b/src/handlers/payoutSyncTrigger.js
@@ -1,117 +1,384 @@
-const SyncLedger = require('../services/payoutRecon/syncLedger');
+const Stripe = require('stripe');
+const jsforce = require('jsforce');
+
+let createSalesforceSvc;
+try {
+    ({ createSalesforceSvc } = require('../services/salesforceSvc'));
+} catch (error) {
+    createSalesforceSvc = null;
+}
 const { createPersistentStorageClients } = require('../services/idempotency/storage/persistentStoreFactory');
 
-let storageClientFactory = createPersistentStorageClients;
-let syncLedger;
+const STRIPE_API_VERSION = '2023-10-16';
+const DEFAULT_LOOKBACK_DAYS = 10;
+const MIN_LOOKBACK_DAYS = 7;
+const MAX_LOOKBACK_DAYS = 10;
+const SECONDS_PER_DAY = 24 * 60 * 60;
 
-const initializeSyncLedger = () => {
-    const storageNamespace = process.env.PERSISTENT_STORAGE_NAMESPACE || 'default';
-    const { syncLedgerStore } = storageClientFactory(storageNamespace);
-    syncLedger = new SyncLedger({ storageClient: syncLedgerStore });
+const clampLookbackDays = (value) => {
+    if (!Number.isFinite(value)) {
+        return DEFAULT_LOOKBACK_DAYS;
+    }
+
+    const rounded = Math.round(value);
+    if (rounded < MIN_LOOKBACK_DAYS) {
+        return MIN_LOOKBACK_DAYS;
+    }
+    if (rounded > MAX_LOOKBACK_DAYS) {
+        return MAX_LOOKBACK_DAYS;
+    }
+
+    return rounded;
 };
 
-initializeSyncLedger();
+const toUnixSeconds = (millis) => Math.floor(millis / 1000);
 
-const setDependencies = ({
-    createPersistentStorageClients: storageFactoryOverride,
-    syncLedger: syncLedgerOverride
-} = {}) => {
-    if (typeof storageFactoryOverride === 'function') {
-        storageClientFactory = storageFactoryOverride;
-        if (!syncLedgerOverride) {
-            initializeSyncLedger();
+const toDateFromStripeTimestamp = (timestamp) => {
+    if (typeof timestamp === 'number' && Number.isFinite(timestamp)) {
+        return new Date(timestamp * 1000);
+    }
+
+    return new Date();
+};
+
+const uniqueIds = (items) => {
+    const seen = new Set();
+    const ids = [];
+    for (const item of items) {
+        const id = item && typeof item.id === 'string' ? item.id : null;
+        if (id && !seen.has(id)) {
+            seen.add(id);
+            ids.push(id);
+        }
+    }
+    return ids;
+};
+
+const collectStripePages = async (listFn, initialParams) => {
+    const results = [];
+    let params = { ...initialParams };
+    let hasMore = true;
+
+    while (hasMore) {
+        const response = await listFn(params);
+        const data = Array.isArray(response?.data) ? response.data : [];
+        results.push(...data);
+
+        hasMore = Boolean(response?.has_more && data.length > 0);
+        if (hasMore) {
+            params = {
+                ...params,
+                starting_after: data[data.length - 1].id
+            };
         }
     }
 
-    if (syncLedgerOverride) {
-        syncLedger = syncLedgerOverride;
+    return results;
+};
+
+const defaultStripeSecret = () => {
+    return process.env.STRIPE_SECRET
+        || process.env.STRIPE_LIVE_SECRET_KEY
+        || process.env.STRIPE_TEST_SECRET_KEY
+        || null;
+};
+
+const createProcessedStore = (namespace) => {
+    const { idempotencyStore } = createPersistentStorageClients(namespace);
+
+    if (!idempotencyStore || typeof idempotencyStore.set !== 'function') {
+        throw new Error('Idempotency store is not configured correctly.');
     }
+
+    return {
+        async isProcessed(key) {
+            if (typeof idempotencyStore.has === 'function') {
+                return idempotencyStore.has(key);
+            }
+            const value = await idempotencyStore.get(key);
+            return Boolean(value);
+        },
+        async markProcessed(key) {
+            await idempotencyStore.set(key, {
+                processedAt: new Date().toISOString()
+            });
+        }
+    };
+};
+
+const createSalesforceGetter = () => {
+    let cachedPromise = null;
+
+    return async () => {
+        if (!cachedPromise) {
+            cachedPromise = (async () => {
+                const username = process.env.SALESFORCE_USERNAME;
+                const password = process.env.SALESFORCE_PASSWORD;
+                const securityToken = process.env.SALESFORCE_SECURITY_TOKEN || '';
+                const loginUrl = process.env.SALESFORCE_LOGIN_URL || 'https://login.salesforce.com';
+
+                if (!username || !password) {
+                    throw new Error('Salesforce credentials are not configured.');
+                }
+
+                if (!createSalesforceSvc) {
+                    throw new Error('Salesforce service is not available.');
+                }
+
+                const connection = new jsforce.Connection({ loginUrl });
+                await connection.login(username, `${password}${securityToken}`);
+                return createSalesforceSvc({ connection });
+            })();
+        }
+
+        return cachedPromise;
+    };
+};
+
+const createDefaultDependencies = () => {
+    const stripeSecret = defaultStripeSecret();
+    if (!stripeSecret) {
+        throw new Error('Stripe secret key is not configured.');
+    }
+
+    const stripe = new Stripe(stripeSecret, { apiVersion: STRIPE_API_VERSION });
+    const processedStore = createProcessedStore(process.env.PERSISTENT_STORAGE_NAMESPACE || 'default');
+
+    const qbo = require('../services/qboSvc');
+
+    return {
+        stripe,
+        accounting: {
+            buildBankDeposit: qbo.buildBankDeposit,
+            postBankDeposit: qbo.postBankDeposit
+        },
+        salesforce: {
+            getService: createSalesforceGetter()
+        },
+        processedStore,
+        lookbackDays: clampLookbackDays(Number(process.env.PAYOUT_SYNC_LOOKBACK_DAYS)),
+        now: () => Date.now()
+    };
+};
+
+let customDependencies = null;
+
+const setDependencies = (overrides = null) => {
+    customDependencies = overrides;
 };
 
 const resetDependencies = () => {
-    storageClientFactory = createPersistentStorageClients;
-    initializeSyncLedger();
+    customDependencies = null;
 };
 
-/**
- * Payout Sync Status Checker
- * 
- * GET /api/sync/stripe/payouts/{payoutId} - Get payout sync status
- * 
- * Note: Payout sync is now webhook-only. This endpoint only checks status.
- * Manual payout syncing has been removed - use Stripe webhooks (payout.paid event).
- */
+const resolveDependencies = () => {
+    if (customDependencies) {
+        return customDependencies;
+    }
 
-module.exports = async function (context, req) {
-    try {
-        const payoutId = context.bindingData.payoutId;
-        const method = req.method.toUpperCase();
+    return createDefaultDependencies();
+};
 
-        // Only GET is supported for status checking
-        if (method !== 'GET') {
-            context.res = {
-                status: 405,
-                body: { 
-                    error: 'Method not allowed',
-                    message: 'Only GET requests are supported. Payout sync is webhook-only - use Stripe webhooks (payout.paid event).'
-                }
-            };
-            return;
+const getSalesforceService = async (deps) => {
+    if (!deps.salesforce) {
+        return null;
+    }
+
+    if (typeof deps.salesforce.linkPayoutOnTransactions === 'function') {
+        return deps.salesforce;
+    }
+
+    if (typeof deps.salesforce.getService === 'function') {
+        return deps.salesforce.getService();
+    }
+
+    return null;
+};
+
+const fetchRecentPayouts = async (stripe, lookbackDays, nowMillis) => {
+    const end = toUnixSeconds(nowMillis);
+    const start = end - (lookbackDays * SECONDS_PER_DAY);
+
+    const params = {
+        limit: 100,
+        arrival_date: {
+            gte: start,
+            lte: end
         }
+    };
 
-        // GET - Check sync status
-        if (!payoutId) {
-            context.res = {
-                status: 400,
-                body: { error: 'Payout ID is required' }
-            };
-            return;
+    return collectStripePages(stripe.payouts.list.bind(stripe.payouts), params);
+};
+
+const fetchBalanceTransactionsForPayout = async (stripe, payoutId) => {
+    const params = {
+        limit: 100,
+        payout: payoutId
+    };
+
+    return collectStripePages(stripe.balanceTransactions.list.bind(stripe.balanceTransactions), params);
+};
+
+const safeAmount = (value) => {
+    if (typeof value !== 'number' || Number.isNaN(value)) {
+        return 0;
+    }
+
+    return Math.abs(Math.trunc(value));
+};
+
+const createDocNumber = (payoutId) => {
+    const memo = `payout_${payoutId}`;
+    return memo.length > 21 ? memo.slice(0, 21) : memo;
+};
+
+const processPayout = async ({
+    payout,
+    deps,
+    salesforce,
+    context
+}) => {
+    const { accounting, processedStore, stripe } = deps;
+
+    if (!processedStore || typeof processedStore.isProcessed !== 'function' || typeof processedStore.markProcessed !== 'function') {
+        throw new Error('Processed store is not configured correctly.');
+    }
+
+    const payoutKey = `po_${payout.id}`;
+
+    if (await processedStore.isProcessed(payoutKey)) {
+        return { status: 'skipped', payoutId: payout.id };
+    }
+
+    const transactions = await fetchBalanceTransactionsForPayout(stripe, payout.id);
+    const memo = `payout_${payout.id}`;
+    const docNumber = createDocNumber(payout.id);
+    const amountCents = safeAmount(payout.amount);
+    const date = toDateFromStripeTimestamp(payout.arrival_date || payout.created);
+
+    const bankDeposit = accounting.buildBankDeposit({
+        docNumber,
+        amountCents,
+        memo,
+        date
+    });
+
+    const qboResult = await accounting.postBankDeposit(bankDeposit);
+
+    if (salesforce && typeof salesforce.linkPayoutOnTransactions === 'function') {
+        const balanceTransactionIds = uniqueIds(transactions);
+        if (balanceTransactionIds.length > 0) {
+            await salesforce.linkPayoutOnTransactions(payout.id, balanceTransactionIds);
         }
+    }
 
-        const stripeAccountId = req.query.account || 'default';
-        const syncRecord = await syncLedger.getSync(stripeAccountId, payoutId);
+    await processedStore.markProcessed(payoutKey);
 
-        if (!syncRecord) {
-            context.res = {
-                status: 404,
-                body: { 
-                    error: 'Payout sync not found', 
-                    payoutId,
-                    message: 'This payout has not been synced yet. Ensure Stripe webhooks are configured to send payout.paid events.'
-                }
-            };
-            return;
-        }
+    context.log?.('[payoutSyncTrigger] Processed payout', {
+        payoutId: payout.id,
+        bankDepositId: qboResult?.id || null,
+        balanceTransactionCount: Array.isArray(transactions) ? transactions.length : 0
+    });
 
+    return {
+        status: 'processed',
+        payoutId: payout.id,
+        bankDepositId: qboResult?.id || null
+    };
+};
+
+const handler = async (context, req = {}) => {
+    const method = typeof req.method === 'string' ? req.method.toUpperCase() : 'GET';
+
+    if (method !== 'POST') {
         context.res = {
-            status: 200,
+            status: 405,
             body: {
-                payoutId,
-                stripeAccountId: syncRecord.stripeAccountId,
-                status: syncRecord.status,
-                provider: syncRecord.provider,
-                providerDocIds: syncRecord.providerDocIds,
-                crmPayoutId: syncRecord.crmPayoutId || null,
-                createdAt: syncRecord.createdAt,
-                updatedAt: syncRecord.updatedAt,
-                postingHash: syncRecord.postingHash
+                error: 'Method not allowed',
+                message: 'Only POST requests are supported.'
             }
         };
+        return;
+    }
 
+    let deps;
+
+    try {
+        deps = resolveDependencies();
     } catch (error) {
-        context.log('Error in payout sync status check:', error);
-
+        context.log?.error?.('[payoutSyncTrigger] Failed to initialize dependencies', error);
         context.res = {
             status: 500,
             body: {
-                error: 'Internal server error',
+                error: 'Initialization failed',
+                message: error.message
+            }
+        };
+        return;
+    }
+
+    try {
+        const lookbackFromRequest = Number(req?.query?.lookbackDays);
+        const lookbackDays = clampLookbackDays(Number.isFinite(lookbackFromRequest) ? lookbackFromRequest : deps.lookbackDays ?? DEFAULT_LOOKBACK_DAYS);
+        const nowMillis = typeof deps.now === 'function' ? deps.now() : Date.now();
+
+        const payouts = await fetchRecentPayouts(deps.stripe, lookbackDays, nowMillis);
+        const salesforce = await getSalesforceService(deps);
+
+        const outcomes = [];
+        const errors = [];
+
+        for (const payout of payouts) {
+            try {
+                const outcome = await processPayout({ payout, deps, salesforce, context });
+                outcomes.push(outcome);
+            } catch (error) {
+                context.log?.error?.('[payoutSyncTrigger] Failed to process payout', {
+                    payoutId: payout?.id,
+                    error: error instanceof Error ? error.message : String(error)
+                });
+                errors.push({
+                    payoutId: payout?.id || null,
+                    message: error instanceof Error ? error.message : String(error)
+                });
+            }
+        }
+
+        const processed = outcomes.filter((entry) => entry.status === 'processed');
+        const skipped = outcomes.filter((entry) => entry.status === 'skipped');
+
+        context.res = {
+            status: errors.length > 0 ? 207 : 200,
+            body: {
+                summary: {
+                    lookbackDays,
+                    total: payouts.length,
+                    processed: processed.length,
+                    skipped: skipped.length,
+                    errors: errors.length
+                },
+                processed,
+                skipped,
+                errors
+            }
+        };
+    } catch (error) {
+        context.log?.error?.('[payoutSyncTrigger] Unexpected error', error);
+        context.res = {
+            status: 500,
+            body: {
+                error: 'Processing failed',
                 message: error.message
             }
         };
     }
 };
 
-module.exports.__internals = {
+handler.__internals = {
     setDependencies,
-    resetDependencies
+    resetDependencies,
+    clampLookbackDays,
+    createDocNumber
 };
+
+module.exports = handler;


### PR DESCRIPTION
## Summary
- replace the payoutSyncTrigger status endpoint with logic that scans recent Stripe payouts, posts QuickBooks bank deposits, links Salesforce balance transactions, and records idempotent processing
- add unit coverage that mocks Stripe, QuickBooks, and Salesforce services to verify new payout processing flows

## Testing
- npx vitest run __tests__/payoutSyncTrigger.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e7f85804b8832c884f62038a9b3357