### PR TITLE
Expand health check integration validation

### DIFF
--- a/__tests__/healthCheck.test.js
+++ b/__tests__/healthCheck.test.js
@@ -7,11 +7,13 @@ const { createContext } = require('./testUtils');
 describe('healthCheck', () => {
     let handler;
     let internals;
+    let originalEnv;
 
     beforeEach(() => {
         vi.resetModules();
         handler = require('../healthCheck');
         internals = handler.__internals;
+        originalEnv = { ...process.env };
     });
 
     afterEach(() => {
@@ -21,15 +23,86 @@ describe('healthCheck', () => {
         handler = undefined;
         internals = undefined;
         vi.restoreAllMocks();
+        Object.keys(process.env).forEach(key => {
+            if (!(key in originalEnv)) {
+                delete process.env[key];
+            }
+        });
+        Object.entries(originalEnv).forEach(([key, value]) => {
+            process.env[key] = value;
+        });
     });
 
-    it('returns a health report with component statuses', async () => {
+    it('validates integrations and reports component statuses', async () => {
+        process.env.STRIPE_TEST_SECRET_KEY = 'sk_test';
+        process.env.STRIPE_LIVE_SECRET_KEY = 'sk_live';
+        process.env.SENDGRID_API_KEY = 'sg_key';
+        process.env.CRM_PROVIDER = 'salesforce';
+        process.env.SALESFORCE_USERNAME = 'user@example.com';
+        process.env.SALESFORCE_PASSWORD = 'password';
+        process.env.SALESFORCE_SECURITY_TOKEN = 'token';
+        process.env.ACCOUNTING_SYNC_ENABLED = 'true';
+        process.env.ACCOUNTING_PROVIDER = 'quickbooks';
+        process.env.QBO_ACCESS_TOKEN = 'access';
+        process.env.QBO_REFRESH_TOKEN = 'refresh';
+        process.env.QBO_COMPANY_ID = '12345';
+        process.env.QBO_CLIENT_ID = 'client';
+        process.env.QBO_CLIENT_SECRET = 'secret';
+
         const storageClient = {
             set: vi.fn().mockResolvedValue(undefined),
             delete: vi.fn().mockResolvedValue(true)
         };
 
+        const stripePayoutList = vi.fn().mockResolvedValue({ data: [] });
+        const stripeFactory = vi.fn(() => ({
+            payouts: {
+                list: stripePayoutList
+            }
+        }));
+
+        const sendGridRequest = vi.fn().mockResolvedValue({});
+
+        const crmHealthCheck = vi.fn().mockResolvedValue({
+            healthy: true,
+            message: 'Salesforce SOQL query succeeded',
+            details: { provider: 'salesforce' }
+        });
+
+        const crmFactory = {
+            validateConfig: vi.fn().mockReturnValue({ isValid: true }),
+            createCrmService: vi.fn(() => ({ healthCheck: crmHealthCheck }))
+        };
+
+        const providerHealthCheck = vi.fn().mockResolvedValue({
+            healthy: true,
+            message: 'QBO connection healthy',
+            details: { provider: 'quickbooks' }
+        });
+        const providerTokenExchange = vi.fn().mockResolvedValue({ accessToken: 'new', refreshToken: 'next' });
+        const accountingProviderFactory = {
+            createProvider: vi.fn(() => ({
+                healthCheck: providerHealthCheck,
+                refreshTokens: providerTokenExchange
+            }))
+        };
+
+        const accountingSyncConfig = {
+            isEnabled: () => true,
+            getConfig: () => ({ provider: 'quickbooks' }),
+            validate: () => ({ isValid: true, errors: [] }),
+            getProviderConfig: () => ({})
+        };
+
         internals.setDependencies({
+            stripeFactory,
+            sendGridClientFactory: () => ({
+                setApiKey: vi.fn(),
+                request: sendGridRequest
+            }),
+            crmFactory,
+            accountingProviderFactory,
+            accountingSyncConfigFactory: () => accountingSyncConfig,
             persistentStorageFactory: () => ({ syncLedgerStore: storageClient })
         });
 
@@ -41,6 +114,8 @@ describe('healthCheck', () => {
         expect(context.res.status).toBe(200);
         expect(Array.isArray(context.res.body.connections)).toBe(true);
         expect(context.res.body.connections.length).toBeGreaterThan(0);
+        expect(Array.isArray(context.res.body.components)).toBe(true);
+        expect(context.res.body.components.length).toBe(context.res.body.connections.length);
         context.res.body.connections.forEach(connection => {
             expect(connection).toHaveProperty('name');
             expect(connection).toHaveProperty('type');
@@ -49,5 +124,67 @@ describe('healthCheck', () => {
 
         expect(storageClient.set).toHaveBeenCalled();
         expect(storageClient.delete).toHaveBeenCalled();
+
+        expect(stripeFactory).toHaveBeenCalledWith('sk_test', expect.any(Object));
+        expect(stripeFactory).toHaveBeenCalledWith('sk_live', expect.any(Object));
+        expect(stripePayoutList).toHaveBeenCalledTimes(2);
+        expect(stripePayoutList).toHaveBeenCalledWith({ limit: 1 });
+        expect(sendGridRequest).toHaveBeenCalledWith({ method: 'GET', url: '/v3/user/account' });
+        expect(crmFactory.validateConfig).toHaveBeenCalled();
+        expect(crmFactory.createCrmService).toHaveBeenCalled();
+        expect(crmHealthCheck).toHaveBeenCalled();
+        expect(accountingProviderFactory.createProvider).toHaveBeenCalled();
+        expect(providerHealthCheck).toHaveBeenCalled();
+        expect(providerTokenExchange).toHaveBeenCalledWith({ persist: false });
+
+        const environmentComponent = context.res.body.components.find(component => component.component === 'environment');
+        expect(environmentComponent).toBeDefined();
+        expect(environmentComponent.status).toBe('healthy');
+        const quickBooksConnection = context.res.body.connections.find(connection => connection.name === 'accounting_quickbooks');
+        expect(quickBooksConnection?.details?.tokenExchange).toEqual({ success: true });
+    });
+
+    it('flags missing environment configuration', async () => {
+        delete process.env.STRIPE_TEST_SECRET_KEY;
+        delete process.env.STRIPE_LIVE_SECRET_KEY;
+        process.env.CRM_PROVIDER = 'salesforce';
+        delete process.env.SALESFORCE_USERNAME;
+        delete process.env.SALESFORCE_PASSWORD;
+        delete process.env.SALESFORCE_SECURITY_TOKEN;
+        process.env.ACCOUNTING_SYNC_ENABLED = 'true';
+        process.env.ACCOUNTING_PROVIDER = 'quickbooks';
+        delete process.env.QBO_ACCESS_TOKEN;
+        delete process.env.QBO_REFRESH_TOKEN;
+        delete process.env.QBO_COMPANY_ID;
+        delete process.env.QBO_CLIENT_ID;
+        delete process.env.QBO_CLIENT_SECRET;
+
+        const storageClient = {
+            set: vi.fn().mockResolvedValue(undefined),
+            delete: vi.fn().mockResolvedValue(true)
+        };
+
+        internals.setDependencies({
+            persistentStorageFactory: () => ({ syncLedgerStore: storageClient }),
+            accountingSyncConfigFactory: () => ({
+                isEnabled: () => false
+            }),
+            crmFactory: {
+                validateConfig: vi.fn().mockReturnValue({ isValid: false, error: 'Missing credentials' })
+            }
+        });
+
+        const { context } = createContext();
+
+        await handler(context, {});
+
+        const environmentConnection = context.res.body.connections.find(connection => connection.name === 'environment');
+        expect(environmentConnection).toBeDefined();
+        expect(environmentConnection.healthy).toBe(false);
+        expect(environmentConnection.details.missingKeys.length).toBeGreaterThan(0);
+
+        const environmentComponent = context.res.body.components.find(component => component.component === 'environment');
+        expect(environmentComponent).toBeDefined();
+        expect(environmentComponent.status).toBe('unhealthy');
     });
 });

--- a/src/handlers/healthCheck.js
+++ b/src/handlers/healthCheck.js
@@ -50,7 +50,11 @@ const checkStripeConnection = async (mode, secretKey) => {
 
     try {
         const stripe = dependencies.stripeFactory(secretKey, { timeout: STRIPE_HEALTH_TIMEOUT_MS });
-        await stripe.accounts.retrieve();
+        if (!stripe?.payouts?.list) {
+            throw new Error('Stripe client does not support payouts.list');
+        }
+
+        await stripe.payouts.list({ limit: 1 });
 
         return createConnectionStatus({
             name: connectionName,
@@ -166,7 +170,7 @@ const checkCrmConnection = async () => {
         });
     }
 
-        const validation = dependencies.crmFactory.validateConfig(crmConfig.provider, crmConfig.config);
+    const validation = dependencies.crmFactory.validateConfig(crmConfig.provider, crmConfig.config);
     if (!validation.isValid) {
         return createConnectionStatus({
             name: `crm_${crmConfig.provider}`,
@@ -179,6 +183,20 @@ const checkCrmConnection = async () => {
 
     try {
         const crmService = dependencies.crmFactory.createCrmService(crmConfig.provider, crmConfig.config);
+
+        if (typeof crmService.healthCheck === 'function') {
+            const health = await crmService.healthCheck();
+
+            return createConnectionStatus({
+                name: `crm_${crmConfig.provider}`,
+                type: 'crm',
+                healthy: Boolean(health?.healthy),
+                status: health?.healthy ? 'healthy' : 'unhealthy',
+                message: health?.message || `${crmConfig.provider} health check completed`,
+                details: health?.details || { provider: crmConfig.provider }
+            });
+        }
+
         if (typeof crmService.connect === 'function') {
             await crmService.connect();
         }
@@ -233,24 +251,59 @@ const checkAccountingConnection = async () => {
         const providerConfig = config.getProviderConfig();
         const provider = dependencies.accountingProviderFactory.createProvider(providerName, providerConfig);
 
+        let providerHealth = null;
         if (typeof provider.healthCheck === 'function') {
-            const health = await provider.healthCheck();
-            return createConnectionStatus({
-                name: `accounting_${providerName}`,
-                type: 'accounting',
-                healthy: Boolean(health?.healthy),
-                status: health?.healthy ? 'healthy' : 'unhealthy',
-                message: health?.message || `${providerName} health check completed`,
-                details: health?.details || { provider: providerName }
-            });
+            providerHealth = await provider.healthCheck();
+        }
+
+        let tokenExchangeResult = null;
+        let tokenExchangeError = null;
+
+        if (providerName.toLowerCase() === 'quickbooks' && typeof provider.refreshTokens === 'function') {
+            try {
+                tokenExchangeResult = await provider.refreshTokens({ persist: false });
+            } catch (error) {
+                tokenExchangeError = error;
+            }
+        }
+
+        const healthy = Boolean(providerHealth?.healthy !== false) && !tokenExchangeError;
+        const status = healthy ? 'healthy' : 'unhealthy';
+
+        const messageParts = [];
+        if (providerHealth?.message) {
+            messageParts.push(providerHealth.message);
+        } else {
+            messageParts.push(`${providerName} health check completed`);
+        }
+
+        if (tokenExchangeError) {
+            messageParts.push(`Token exchange failed: ${tokenExchangeError.message}`);
+        } else if (tokenExchangeResult) {
+            messageParts.push('Token exchange successful');
+        }
+
+        const details = {
+            provider: providerName,
+            providerHealth,
+            tokenExchange: tokenExchangeError
+                ? { success: false, error: tokenExchangeError.message }
+                : tokenExchangeResult
+                    ? { success: true }
+                    : undefined
+        };
+
+        if (!details.tokenExchange) {
+            delete details.tokenExchange;
         }
 
         return createConnectionStatus({
             name: `accounting_${providerName}`,
             type: 'accounting',
-            healthy: true,
-            status: 'healthy',
-            message: `${providerName} provider does not expose a health check`
+            healthy,
+            status,
+            message: messageParts.join(' | '),
+            details
         });
     } catch (error) {
         return createConnectionStatus({
@@ -295,6 +348,86 @@ const checkPersistentStorageConnection = async () => {
     }
 };
 
+const REQUIRED_ENVIRONMENT_KEYS = [
+    { key: 'STRIPE_TEST_SECRET_KEY', label: 'Stripe test secret key', when: () => true },
+    { key: 'STRIPE_LIVE_SECRET_KEY', label: 'Stripe live secret key', when: () => true },
+    { key: 'SENDGRID_API_KEY', label: 'SendGrid API key', when: () => true },
+    {
+        key: 'SALESFORCE_USERNAME',
+        label: 'Salesforce username',
+        when: () => (process.env.CRM_PROVIDER || '').toLowerCase() === 'salesforce'
+    },
+    {
+        key: 'SALESFORCE_PASSWORD',
+        label: 'Salesforce password',
+        when: () => (process.env.CRM_PROVIDER || '').toLowerCase() === 'salesforce'
+    },
+    {
+        key: 'SALESFORCE_SECURITY_TOKEN',
+        label: 'Salesforce security token',
+        when: () => (process.env.CRM_PROVIDER || '').toLowerCase() === 'salesforce'
+    },
+    {
+        key: 'QBO_CLIENT_ID',
+        label: 'QuickBooks client ID',
+        when: () => process.env.ACCOUNTING_SYNC_ENABLED === 'true' && (process.env.ACCOUNTING_PROVIDER || 'quickbooks').toLowerCase() === 'quickbooks'
+    },
+    {
+        key: 'QBO_CLIENT_SECRET',
+        label: 'QuickBooks client secret',
+        when: () => process.env.ACCOUNTING_SYNC_ENABLED === 'true' && (process.env.ACCOUNTING_PROVIDER || 'quickbooks').toLowerCase() === 'quickbooks'
+    },
+    {
+        key: 'QBO_REFRESH_TOKEN',
+        label: 'QuickBooks refresh token',
+        when: () => process.env.ACCOUNTING_SYNC_ENABLED === 'true' && (process.env.ACCOUNTING_PROVIDER || 'quickbooks').toLowerCase() === 'quickbooks'
+    },
+    {
+        key: 'QBO_ACCESS_TOKEN',
+        label: 'QuickBooks access token',
+        when: () => process.env.ACCOUNTING_SYNC_ENABLED === 'true' && (process.env.ACCOUNTING_PROVIDER || 'quickbooks').toLowerCase() === 'quickbooks'
+    },
+    {
+        key: 'QBO_COMPANY_ID',
+        label: 'QuickBooks company ID',
+        when: () => process.env.ACCOUNTING_SYNC_ENABLED === 'true' && (process.env.ACCOUNTING_PROVIDER || 'quickbooks').toLowerCase() === 'quickbooks'
+    }
+];
+
+const checkEnvironmentConfiguration = async () => {
+    const applicableKeys = REQUIRED_ENVIRONMENT_KEYS.filter(def => {
+        try {
+            return def.when();
+        } catch (error) {
+            return false;
+        }
+    });
+
+    const missingKeys = applicableKeys
+        .filter(def => !process.env[def.key] || process.env[def.key].trim() === '')
+        .map(def => def.key);
+
+    if (missingKeys.length === 0) {
+        return createConnectionStatus({
+            name: 'environment',
+            type: 'configuration',
+            healthy: true,
+            status: 'healthy',
+            message: 'All required environment variables are set',
+            details: { checkedKeys: applicableKeys.map(def => def.key) }
+        });
+    }
+
+    return createConnectionStatus({
+        name: 'environment',
+        type: 'configuration',
+        healthy: false,
+        status: 'unhealthy',
+        message: 'Missing required environment variables',
+        details: { missingKeys }
+    });
+};
+
 module.exports = async function healthCheck(context, req) {
     const now = new Date();
     context.log('Health check requested');
@@ -305,7 +438,8 @@ module.exports = async function healthCheck(context, req) {
         checkSendGridConnection(),
         checkCrmConnection(),
         checkAccountingConnection(),
-        checkPersistentStorageConnection()
+        checkPersistentStorageConnection(),
+        checkEnvironmentConfiguration()
     ];
 
     const connections = await Promise.all(connectionChecks);
@@ -313,6 +447,12 @@ module.exports = async function healthCheck(context, req) {
     const overallStatus = degraded ? 'degraded' : 'ok';
 
     context.log('Health check connection statuses', connections);
+
+    const components = connections.map(connection => ({
+        component: connection.name,
+        status: connection.status,
+        healthy: connection.healthy
+    }));
 
     context.res = {
         status: 200,
@@ -324,7 +464,8 @@ module.exports = async function healthCheck(context, req) {
             timestamp: now.toISOString(),
             uptime: process.uptime(),
             version: process.env.APP_VERSION || null,
-            connections
+            connections,
+            components
         }
     };
 };

--- a/src/services/qbo/baseAccountingProvider.js
+++ b/src/services/qbo/baseAccountingProvider.js
@@ -121,9 +121,11 @@ class BaseAccountingProvider {
 
     /**
      * Refresh OAuth tokens if needed
-     * @returns {Promise<boolean>} True if refresh successful
+     * @param {Object} [options]
+     * @param {boolean} [options.persist=true] - Whether refreshed tokens should be persisted on the provider instance
+     * @returns {Promise<*>} Implementation specific
      */
-    async refreshTokens() {
+    async refreshTokens(options = {}) {
         throw new Error('refreshTokens method must be implemented by subclass');
     }
 }

--- a/src/services/qbo/quickbooksProvider.js
+++ b/src/services/qbo/quickbooksProvider.js
@@ -1023,9 +1023,10 @@ class QuickBooksProvider extends BaseAccountingProvider {
     /**
      * Refresh OAuth tokens
      */
-    async refreshTokens() {
-        this.logger.log('[QBO] Refreshing OAuth tokens');
-        
+    async refreshTokens(options = {}) {
+        const { persist = true } = options;
+        this.logger.log(`[QBO] Refreshing OAuth tokens${persist ? '' : ' (validation only)'}`);
+
         if (!this.oauthTokens.refreshToken) {
             throw new Error('No refresh token available');
         }
@@ -1055,24 +1056,36 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 throw new Error(errorDescription);
             }
 
-            // Update stored tokens
-            this.oauthTokens.accessToken = refreshResponse.access_token;
-            if (refreshResponse.refresh_token) {
-                this.oauthTokens.refreshToken = refreshResponse.refresh_token;
+            const refreshedTokens = {
+                accessToken: refreshResponse.access_token,
+                refreshToken: refreshResponse.refresh_token || this.oauthTokens.refreshToken,
+                tokenType: refreshResponse.token_type,
+                expiresIn: refreshResponse.expires_in
+            };
+
+            if (persist) {
+                // Update stored tokens
+                this.oauthTokens.accessToken = refreshedTokens.accessToken;
+                if (refreshResponse.refresh_token) {
+                    this.oauthTokens.refreshToken = refreshResponse.refresh_token;
+                }
+
+                // Reinitialize client with new token
+                this._initializeClient();
+
+                this.logger.log('[QBO] Successfully refreshed OAuth tokens');
+
+                // Note: In production, you should persist these tokens to storage
+                // so they can be used across sessions
+                if (process.env.NODE_ENV === 'production') {
+                    this.logger.warn('[QBO] WARNING: Refreshed tokens should be persisted to storage (e.g., env vars, key vault)');
+                }
+
+                return true;
             }
 
-            // Reinitialize client with new token
-            this._initializeClient();
-
-            this.logger.log('[QBO] Successfully refreshed OAuth tokens');
-
-            // Note: In production, you should persist these tokens to storage
-            // so they can be used across sessions
-            if (process.env.NODE_ENV === 'production') {
-                this.logger.warn('[QBO] WARNING: Refreshed tokens should be persisted to storage (e.g., env vars, key vault)');
-            }
-
-            return true;
+            this.logger.log('[QBO] Successfully validated OAuth token exchange');
+            return refreshedTokens;
         } catch (error) {
             this.logger.error('[QBO] Failed to refresh tokens:', error);
             const message = error && error.message ? error.message : 'Unknown error';

--- a/src/services/salesforce/salesforceCrm.js
+++ b/src/services/salesforce/salesforceCrm.js
@@ -33,6 +33,33 @@ class SalesforceCrmService extends BaseCrmService {
         }
     }
 
+    async healthCheck() {
+        try {
+            const connection = await this.connect();
+            const result = await connection.query('SELECT Id FROM User LIMIT 1');
+
+            const recordCount = Array.isArray(result?.records) ? result.records.length : 0;
+
+            return {
+                healthy: true,
+                message: 'Salesforce SOQL query succeeded',
+                details: {
+                    provider: 'salesforce',
+                    recordCount
+                }
+            };
+        } catch (error) {
+            return {
+                healthy: false,
+                message: `Salesforce health check failed: ${error.message}`,
+                details: {
+                    provider: 'salesforce',
+                    error: error.message
+                }
+            };
+        }
+    }
+
     /**
      * Search for contacts in Salesforce using email, phone, or name
      * @param {Object} searchCriteria - Search criteria


### PR DESCRIPTION
## Summary
- extend the health check handler to probe Stripe payouts, Salesforce queries, QuickBooks token refresh, and required environment keys while preserving existing fields
- surface the individual connection results as a component array and add Salesforce and QuickBooks helpers to support the deeper checks
- cover the new behaviour with additional unit tests and dependency mocks

## Testing
- npx vitest run __tests__/healthCheck.test.js
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e81aebd2d8832cb06474e20d05e77d