### PR TITLE
Add correlation-aware logger and replace console logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@azure/functions": "^4.5.0",
         "@sendgrid/client": "^8.1.0",
         "@sendgrid/mail": "^8.1.0",
+        "applicationinsights": "^3.12.0",
         "jsforce": "^3.10.7",
         "node-quickbooks": "^2.0.46",
         "stripe": "^14.7.0",
@@ -204,6 +205,70 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/@azure/functions-old": {
+      "name": "@azure/functions",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-3.5.1.tgz",
+      "integrity": "sha512-6UltvJiuVpvHSwLcK/Zc6NfUwlkDLOFFx97BHCJzlWNsfiWwzwmTsxJXg4kE/LemKTHxPpfoPE+kOJ8hAdiKFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "long": "^4.0.0",
+        "uuid": "^8.3.0"
+      }
+    },
+    "node_modules/@azure/functions-old/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
+      "integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^4.2.0",
+        "@azure/msal-node": "^3.5.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity/node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@azure/logger": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
@@ -215,6 +280,182 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@azure/monitor-opentelemetry/-/monitor-opentelemetry-1.14.0.tgz",
+      "integrity": "sha512-ITyx79SE6vb8fOk3NzZ+bTYEET6P+eTecx2lFLIQTFqkJe0HiFna1vuoXkXghQhMtL8+tRTDwKomAP/2H0/YJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.18.2",
+        "@azure/logger": "^1.1.4",
+        "@azure/monitor-opentelemetry-exporter": "1.0.0-beta.35",
+        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.7",
+        "@microsoft/applicationinsights-web-snippet": "^1.2.1",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.204.0",
+        "@opentelemetry/core": "^2.1.0",
+        "@opentelemetry/instrumentation": "^0.204.0",
+        "@opentelemetry/instrumentation-bunyan": "^0.50.0",
+        "@opentelemetry/instrumentation-http": "^0.204.0",
+        "@opentelemetry/instrumentation-mongodb": "^0.57.0",
+        "@opentelemetry/instrumentation-mysql": "^0.50.0",
+        "@opentelemetry/instrumentation-pg": "^0.57.0",
+        "@opentelemetry/instrumentation-redis": "^0.53.0",
+        "@opentelemetry/instrumentation-redis-4": "^0.49.0",
+        "@opentelemetry/instrumentation-winston": "^0.49.0",
+        "@opentelemetry/resource-detector-azure": "^0.7.0",
+        "@opentelemetry/resources": "^2.1.0",
+        "@opentelemetry/sdk-logs": "^0.204.0",
+        "@opentelemetry/sdk-metrics": "^2.1.0",
+        "@opentelemetry/sdk-node": "^0.204.0",
+        "@opentelemetry/sdk-trace-base": "^2.1.0",
+        "@opentelemetry/sdk-trace-node": "^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.32.0",
+        "@opentelemetry/winston-transport": "^0.15.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter": {
+      "version": "1.0.0-beta.35",
+      "resolved": "https://registry.npmjs.org/@azure/monitor-opentelemetry-exporter/-/monitor-opentelemetry-exporter-1.0.0-beta.35.tgz",
+      "integrity": "sha512-MVNtTkwkFgkFzwhK1lz+OpCkLl4kHJ3zC6DFOt2QgC6WurRiuFbxQD4YAN2Jx/f5Ly3p+SbC4HS7vSDGDLGsgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.205.0",
+        "@opentelemetry/core": "^2.1.0",
+        "@opentelemetry/resources": "^2.1.0",
+        "@opentelemetry/sdk-logs": "^0.205.0",
+        "@opentelemetry/sdk-metrics": "^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.37.0",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/api-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.205.0.tgz",
+      "integrity": "sha512-wBlPk1nFB37Hsm+3Qy73yQSobVn28F4isnWIBvKpd5IUH/eat8bwcL02H9yzmHyyPmukeccSl2mbN5sDQZYnPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/monitor-opentelemetry-exporter/node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.205.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.205.0.tgz",
+      "integrity": "sha512-nyqhNQ6eEzPWQU60Nc7+A5LIq8fz3UeIzdEVBQYefB4+msJZ2vuVtRuk9KxPMw1uHoHDtYEwkr2Ct0iG29jU8w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.205.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "4.25.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.25.0.tgz",
+      "integrity": "sha512-kbL+Ae7/UC62wSzxirZddYeVnHvvkvAnSZkBqL55X+jaSXTAXfngnNsDM5acEWU0Q/SAv3gEQfxO1igWOn87Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "15.13.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "15.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.13.0.tgz",
+      "integrity": "sha512-8oF6nj02qX7eE/6+wFT5NluXRHc05AgdCC3fJnkjiJooq8u7BcLmxaYYSwc2AfEkWRMRi6Eyvvbeqk4U4412Ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.0.tgz",
+      "integrity": "sha512-23BXm82Mp5XnRhrcd4mrHa0xuUNRp96ivu3nRatrfdAqjoeWAGyD0eEAafxAOHAEWWmdlyFK4ELFcdziXyw2sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "15.13.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk": {
+      "version": "1.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/@azure/opentelemetry-instrumentation-azure-sdk/-/opentelemetry-instrumentation-azure-sdk-1.0.0-beta.9.tgz",
+      "integrity": "sha512-gNCFokEoQQEkhu2T8i1i+1iW2o9wODn2slu5tpqJmjV1W7qf9dxVv6GNXW1P1WC8wMga8BCc2t/oMhOK3iwRQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.200.0",
+        "@opentelemetry/sdk-trace-web": "^2.0.0",
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk/node_modules/@opentelemetry/api-logs": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.200.0.tgz",
+      "integrity": "sha512-IKJBQxh91qJ+3ssRly5hYEJ8NDHu9oY/B1PXVSCWf7zytmYO9RNLB0Ox9XQ/fJ8m6gY6Q6NtBWlmXfaXt5Uc4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@azure/opentelemetry-instrumentation-azure-sdk/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.200.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.200.0.tgz",
+      "integrity": "sha512-pmPlzfJd+vvgaZd/reMsC8RWgTXn2WY1OWT5RT42m3aOn5532TozwXNDhg1vzqJ+jnvmkREcdLr27ebJEQt0Jg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.200.0",
+        "@types/shimmer": "^1.2.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1",
+        "shimmer": "^1.2.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -236,6 +477,15 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -651,6 +901,43 @@
         "node": ">=14"
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
+      "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.2.tgz",
@@ -712,6 +999,826 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web-snippet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.2.2.tgz",
+      "integrity": "sha512-pIa6QiUaenVlKzNJ9PYMgHDm4PfIJjm5zW3Vq//xsSkRerNlFfcv7dJKHGtX7kYPlSeMRFwld303bwIoUijehQ==",
+      "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.204.0.tgz",
+      "integrity": "sha512-DqxY8yoAaiBPivoJD4UtgrMS8gEmzZ5lnaxzPojzLVHBGqPxgWm4zcuvcUHZiqQ6kRX2Klel2r9y8cA2HAtqpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/context-async-hooks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.1.0.tgz",
+      "integrity": "sha512-zOyetmZppnwTyPrt4S7jMfXiSX9yyfF0hxlA8B5oo2TtKl+/RGCy7fi4DrBfIf3lCPrkKsRBWZZD7RFojK7FDg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.1.0.tgz",
+      "integrity": "sha512-RMEtHsxJs/GiHHxYT58IY57UXAQTuUnZVco6ymDEqTNlJKTimM4qPUPVe8InNFyBjhHBEAx4k3Q8LtNayBsbUQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-grpc": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-grpc/-/exporter-logs-otlp-grpc-0.204.0.tgz",
+      "integrity": "sha512-0dBqvTU04wvJVze4o5cGxFR2qmMkzJ0rnqL7vt35Xkn+OVrl7CUxmhZtkWxEePuWnyjIWQeCyDIrQUVXeXhQAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/sdk-logs": "0.204.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.204.0.tgz",
+      "integrity": "sha512-cQyIIZxUnXy3M6n9LTW3uhw/cem4WP+k7NtrXp8pf4U3v0RljSCBeD0kA8TRotPJj2YutCjUIDrWOn0u+06PSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.204.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/sdk-logs": "0.204.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-proto": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-proto/-/exporter-logs-otlp-proto-0.204.0.tgz",
+      "integrity": "sha512-TeinnqCmgAW9WjZJtmzyTlJxu76WMWvGQ+qkYBHXm1yvsRzClHoUcpODD7X7sZqEELGL6bjpfEMUJap7Eh3tlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.204.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.204.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-grpc": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-grpc/-/exporter-metrics-otlp-grpc-0.204.0.tgz",
+      "integrity": "sha512-wA4a97B9fGUw9ezrtjcMEh3NPzDXhXzHudEorSrc9JjO7pBdV2kHz8nLB5BG/h955I/5m+yj1bzSf9BiYtJkQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.204.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-metrics": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-http": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-http/-/exporter-metrics-otlp-http-0.204.0.tgz",
+      "integrity": "sha512-E+2GjtHcOdYscUhKBgNI/+9pDRqknm4MwXlW8mDRImDwcwbdalTNbiJGjUUmdFK/1IVNHR5DsI/o9ASLAN6f+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-metrics": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-metrics-otlp-proto": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-metrics-otlp-proto/-/exporter-metrics-otlp-proto-0.204.0.tgz",
+      "integrity": "sha512-3jUOeqwtw1QNo3mtjxYHu5sZQqT08nJbntyt0Irpya0a46+Z2GLwcB13Eg8Lr459vbxC7T+T9hL1YhaRr1b/Cg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.204.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-metrics": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-prometheus": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-prometheus/-/exporter-prometheus-0.204.0.tgz",
+      "integrity": "sha512-X+P2Qk2ZBG1etKX0A2T64D5Vj2itmzNavDmzgO4t22C9P6V3yUEsbdcZZLFl04pi7wxUaYe72dCf6EvC3v0R9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-metrics": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-grpc": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-grpc/-/exporter-trace-otlp-grpc-0.204.0.tgz",
+      "integrity": "sha512-sBnu+sEmHrHH8FGYFLH4ipfQx8p2KjtXTzbMhfUKEcR7vb4WTfTdNSUhyrVgM7HolKFM3IUbEj3Kahnp5lrRvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-grpc-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.204.0.tgz",
+      "integrity": "sha512-yS/yPKJF0p+/9aE3MaZuB12NGTPGeBky1NwE3jUGzSM7cQ8tLxpSTPN3uMtLMoNtHRiGTWgE4nkaGgX2vQIqkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-proto": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-proto/-/exporter-trace-otlp-proto-0.204.0.tgz",
+      "integrity": "sha512-lqoHMT+NgqdjGp+jeRKsdm3fxBayGVUPOMWXFndSE9Q4Ph6LoG5W3o/a4s9df3MAUHLpFsJPUT5ktI0C/mwETg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-zipkin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-zipkin/-/exporter-zipkin-2.1.0.tgz",
+      "integrity": "sha512-0mEI0VDZrrX9t5RE1FhAyGz+jAGt96HSuXu73leswtY3L5YZD11gtcpARY2KAx/s6Z2+rj5Mhj566JsI2C7mfA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.204.0.tgz",
+      "integrity": "sha512-vV5+WSxktzoMP8JoYWKeopChy6G3HKk4UQ2hESCRDUUTZqQ3+nM3u8noVG0LmNfRWwcFBnbZ71GKC7vaYYdJ1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.204.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-bunyan": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-bunyan/-/instrumentation-bunyan-0.50.0.tgz",
+      "integrity": "sha512-phTNmUmLYE9/z0euoElk8Llen6AETTHRu9edixAMNRLV6qSslL4jYrvM+25cpzrgJav62MvljtSUhXe+z8cI5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "^0.204.0",
+        "@opentelemetry/instrumentation": "^0.204.0",
+        "@types/bunyan": "1.8.11"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-http": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.204.0.tgz",
+      "integrity": "sha512-1afJYyGRA4OmHTv0FfNTrTAzoEjPQUYgd+8ih/lX0LlZBnGio/O80vxA0lN3knsJPS7FiDrsDrWq25K7oAzbkw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/instrumentation": "0.204.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0",
+        "forwarded-parse": "2.1.2"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mongodb": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.57.0.tgz",
+      "integrity": "sha512-KD6Rg0KSHWDkik+qjIOWoksi1xqSpix8TSPfquIK1DTmd9OTFb5PHmMkzJe16TAPVEuElUW8gvgP59cacFcrMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.204.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-mysql": {
+      "version": "0.50.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.50.0.tgz",
+      "integrity": "sha512-duKAvMRI3vq6u9JwzIipY9zHfikN20bX05sL7GjDeLKr2qV0LQ4ADtKST7KStdGcQ+MTN5wghWbbVdLgNcB3rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.204.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0",
+        "@types/mysql": "2.15.27"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-pg": {
+      "version": "0.57.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.57.0.tgz",
+      "integrity": "sha512-dWLGE+r5lBgm2A8SaaSYDE3OKJ/kwwy5WLyGyzor8PLhUL9VnJRiY6qhp4njwhnljiLtzeffRtG2Mf/YyWLeTw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/instrumentation": "^0.204.0",
+        "@opentelemetry/semantic-conventions": "^1.34.0",
+        "@opentelemetry/sql-common": "^0.41.0",
+        "@types/pg": "8.15.5",
+        "@types/pg-pool": "2.0.6"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.53.0.tgz",
+      "integrity": "sha512-WUHV8fr+8yo5RmzyU7D5BIE1zwiaNQcTyZPwtxlfr7px6NYYx7IIpSihJK7WA60npWynfxxK1T67RAVF0Gdfjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.204.0",
+        "@opentelemetry/redis-common": "^0.38.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis-4/-/instrumentation-redis-4-0.49.0.tgz",
+      "integrity": "sha512-i+Wsl7M2LXEDA2yXouNJ3fttSzzb5AhlehvSBVRIFuinY51XrrKSH66biO0eox+pYQMwAlPxJ778XcMQffN78A==",
+      "deprecated": "Use \"@opentelemetry/instrumentation-redis\", which (as of v0.50.0) includes support for instrumenting redis v4.",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/instrumentation": "^0.202.0",
+        "@opentelemetry/redis-common": "^0.37.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/api-logs": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.202.0.tgz",
+      "integrity": "sha512-fTBjMqKCfotFWfLzaKyhjLvyEyq5vDKTTFfBmx21btv3gvy8Lq6N5Dh2OzqeuN4DjtpSvNT1uNVfg08eD2Rfxw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/instrumentation": {
+      "version": "0.202.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.202.0.tgz",
+      "integrity": "sha512-Uz3BxZWPgDwgHM2+vCKEQRh0R8WKrd/q6Tus1vThRClhlPO39Dyz7mDrOr6KuqGXAlBQ1e5Tnymzri4RMZNaWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.202.0",
+        "import-in-the-middle": "^1.8.1",
+        "require-in-the-middle": "^7.1.1"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-redis-4/node_modules/@opentelemetry/redis-common": {
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.37.0.tgz",
+      "integrity": "sha512-tJwgE6jt32bLs/9J6jhQRKU2EZnsD8qaO13aoFyXwF6s4LhpT7YFHf3Z03MqdILk6BA2BFUhoyh7k9fj9i032A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation-winston": {
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-winston/-/instrumentation-winston-0.49.0.tgz",
+      "integrity": "sha512-LjL+bQs4Wix1WBEsX84payw8cnmmaPVGuMMgelETumRD/BMWwpzU3VID6OYiBFWX1rjm/2lzd0ZlRYC7uyblKw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "^0.204.0",
+        "@opentelemetry/instrumentation": "^0.204.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.204.0.tgz",
+      "integrity": "sha512-K1LB1Ht4rGgOtZQ1N8xAwUnE1h9EQBfI4XUbSorbC6OxK6s/fLzl+UAhZX1cmBsDqM5mdx5+/k4QaKlDxX6UXQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-transformer": "0.204.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-grpc-exporter-base": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-grpc-exporter-base/-/otlp-grpc-exporter-base-0.204.0.tgz",
+      "integrity": "sha512-U9EsCWHLflUyZX13CpT7056bvpLTOntdHZamZoOwlzwwosvqaKeuxNzmjGB1KFtsiLyAwcb9NNrKSHNytuVDhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/grpc-js": "^1.7.1",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/otlp-exporter-base": "0.204.0",
+        "@opentelemetry/otlp-transformer": "0.204.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.204.0.tgz",
+      "integrity": "sha512-AekB2dgHJ0PMS0b3LH7xA2HDKZ0QqqZW4n5r/AVZy00gKnFoeyVF9t0AUz051fm80G7tKjGSLqOUSazqfTNpVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.204.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.204.0",
+        "@opentelemetry/sdk-metrics": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-b3": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-b3/-/propagator-b3-2.1.0.tgz",
+      "integrity": "sha512-yOdHmFseIChYanddMMz0mJIFQHyjwbNhoxc65fEAA8yanxcBPwoFDoh1+WBUWAO/Z0NRgk+k87d+aFIzAZhcBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/propagator-jaeger": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/propagator-jaeger/-/propagator-jaeger-2.1.0.tgz",
+      "integrity": "sha512-QYo7vLyMjrBCUTpwQBF/e+rvP7oGskrSELGxhSvLj5gpM0az9oJnu/0O4l2Nm7LEhAff80ntRYKkAcSwVgvSVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/redis-common": {
+      "version": "0.38.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
+      "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@opentelemetry/resource-detector-azure": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resource-detector-azure/-/resource-detector-azure-0.7.0.tgz",
+      "integrity": "sha512-aR2ALsK+b/+5lLDhK9KTK8rcuKg7+sqa/Cg+QCeasqoy7qby70FRtAbQcZGljJ5BLBcVPYjl1hcTYIUyL3Laww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0",
+        "@opentelemetry/resources": "^2.0.0",
+        "@opentelemetry/semantic-conventions": "^1.27.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.1.0.tgz",
+      "integrity": "sha512-1CJjf3LCvoefUOgegxi8h6r4B/wLSzInyhGP2UmIBYNlo4Qk5CZ73e1eEyWmfXvFtm1ybkmfb2DqWvspsYLrWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.204.0.tgz",
+      "integrity": "sha512-y32iNNmpMUVFWSqbNrXE8xY/6EMge+HX3PXsMnCDV4cXT4SNT+W/3NgyMDf80KJL0fUK17/a0NmfXcrBhkFWrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.204.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.1.0.tgz",
+      "integrity": "sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-node": {
+      "version": "0.204.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-node/-/sdk-node-0.204.0.tgz",
+      "integrity": "sha512-HRMTjiA6urw9kLpBJrhe6jxDw+69KdXkqr2tBhmsLgpdN7LlVWWPUQbYUtiUg9nWaEOk1Q1blhV2sGQoFNZk+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.204.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/exporter-logs-otlp-grpc": "0.204.0",
+        "@opentelemetry/exporter-logs-otlp-http": "0.204.0",
+        "@opentelemetry/exporter-logs-otlp-proto": "0.204.0",
+        "@opentelemetry/exporter-metrics-otlp-grpc": "0.204.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "0.204.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "0.204.0",
+        "@opentelemetry/exporter-prometheus": "0.204.0",
+        "@opentelemetry/exporter-trace-otlp-grpc": "0.204.0",
+        "@opentelemetry/exporter-trace-otlp-http": "0.204.0",
+        "@opentelemetry/exporter-trace-otlp-proto": "0.204.0",
+        "@opentelemetry/exporter-zipkin": "2.1.0",
+        "@opentelemetry/instrumentation": "0.204.0",
+        "@opentelemetry/propagator-b3": "2.1.0",
+        "@opentelemetry/propagator-jaeger": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/sdk-logs": "0.204.0",
+        "@opentelemetry/sdk-metrics": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0",
+        "@opentelemetry/sdk-trace-node": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.1.0.tgz",
+      "integrity": "sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/resources": "2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-node/-/sdk-trace-node-2.1.0.tgz",
+      "integrity": "sha512-SvVlBFc/jI96u/mmlKm86n9BbTCbQ35nsPoOohqJX6DXH92K0kTe73zGY5r8xoI1QkjR9PizszVJLzMC966y9Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/context-async-hooks": "2.1.0",
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-web": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-web/-/sdk-trace-web-2.1.0.tgz",
+      "integrity": "sha512-2F6ZuZFmJg4CdhRPP8+60DkvEwGLCiU3ffAkgnnqe/ALGEBqGa0HrZaNWFGprXWVivrYHpXhr7AEfasgLZD71g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.1.0",
+        "@opentelemetry/sdk-trace-base": "2.1.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.37.0.tgz",
+      "integrity": "sha512-JD6DerIKdJGmRp4jQyX5FlrQjA4tjOw1cvfsPAZXfOOEErMUHjPcPSICS+6WnM0nB0efSFARh0KAZss+bvExOA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sql-common": {
+      "version": "0.41.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sql-common/-/sql-common-0.41.2.tgz",
+      "integrity": "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "^2.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0"
+      }
+    },
+    "node_modules/@opentelemetry/winston-transport": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/winston-transport/-/winston-transport-0.15.0.tgz",
+      "integrity": "sha512-2i4A/Alevdtc4j/vAqOxbb+P48BOHNl9b0mcleq9h1ie9wQ768KmT3Z3TFzUHA8MWs8CrdDerySXtcvhn8jCSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "^0.204.0",
+        "winston-transport": "4.*"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.52.4",
@@ -1106,12 +2213,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/bunyan": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/@types/bunyan/-/bunyan-1.8.11.tgz",
+      "integrity": "sha512-758fRH7umIMk5qt5ELmRMff4mLDlN+xyYzC+dkPTdKwbSkJFvz6xwyScrytPU0QIBbRRwbiE8/BIg8bpajerNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mysql": {
+      "version": "2.15.27",
+      "resolved": "https://registry.npmjs.org/@types/mysql/-/mysql-2.15.27.tgz",
+      "integrity": "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.19",
@@ -1121,6 +2246,38 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.15.5",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.5.tgz",
+      "integrity": "sha512-LF7lF6zWEKxuT3/OR8wAZGzkg4ENGXFNyiV/JeOt9z5B+0ZVwbql9McqX5c/WStFq1GaGso7H1AzP/qSzmlCKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^2.2.0"
+      }
+    },
+    "node_modules/@types/pg-pool": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/pg-pool/-/pg-pool-2.0.6.tgz",
+      "integrity": "sha512-TaAUE5rq2VQYxab5Ts7WZhKNmuN78Q6PiFonTDdpbx8a1H0M1vhy3rhiMjl+e2iHmogyMw7jZF4FrE6eJUy5HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pg": "*"
+      }
+    },
+    "node_modules/@types/shimmer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
       "version": "0.3.1",
@@ -1236,13 +2393,21 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-walk": {
@@ -1323,6 +2488,40 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/applicationinsights": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-3.12.0.tgz",
+      "integrity": "sha512-SOxvobRGSzKBNkl8GPmr/m1Hf1do9Yg7XuhkljSAViDOPgxj4Yb7gmA+xfIyt0mTqyj7LpzBeeqtdpW/Wv9kgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/functions": "^4.6.0",
+        "@azure/functions-old": "npm:@azure/functions@3.5.1",
+        "@azure/identity": "^4.6.0",
+        "@azure/monitor-opentelemetry": "^1.14.0",
+        "@azure/monitor-opentelemetry-exporter": "^1.0.0-beta.35",
+        "@azure/opentelemetry-instrumentation-azure-sdk": "^1.0.0-beta.7",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.204.0",
+        "@opentelemetry/core": "^2.1.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.204.0",
+        "@opentelemetry/exporter-metrics-otlp-http": "^0.204.0",
+        "@opentelemetry/exporter-metrics-otlp-proto": "^0.204.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.204.0",
+        "@opentelemetry/otlp-exporter-base": "^0.204.0",
+        "@opentelemetry/resources": "^2.1.0",
+        "@opentelemetry/sdk-logs": "^0.204.0",
+        "@opentelemetry/sdk-metrics": "^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^2.1.0",
+        "@opentelemetry/sdk-trace-node": "^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.32.0",
+        "diagnostic-channel": "1.1.1",
+        "diagnostic-channel-publishers": "1.0.8"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/arg": {
@@ -1477,6 +2676,27 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cac": {
       "version": "6.7.14",
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
@@ -1576,6 +2796,12 @@
         "node": "*"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "license": "MIT"
+    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -1607,6 +2833,37 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/clone": {
@@ -1814,6 +3071,34 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -1826,6 +3111,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1833,6 +3130,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/diagnostic-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-1.1.1.tgz",
+      "integrity": "sha512-r2HV5qFkUICyoaKlBEpLKHjxMXATUf/l+h8UZPGBHGLy4DDiY2sOLcIctax4eRnTw5wH2jTMExLntGPJ8eOJxw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      }
+    },
+    "node_modules/diagnostic-channel-publishers": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-1.0.8.tgz",
+      "integrity": "sha512-HmSm9hXxSPxA9BaLGY98QU1zsdjeCk113KjAYGPCen1ZP6mhVaTPzHd6UYv5r21DnWANi+f+NyPOHruGT9jpqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "diagnostic-channel": "*"
       }
     },
     "node_modules/diff": {
@@ -1877,6 +3192,15 @@
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -1967,6 +3291,15 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2128,6 +3461,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -2188,6 +3527,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded-parse": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.2.tgz",
+      "integrity": "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==",
+      "license": "MIT"
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2210,6 +3555,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-func-name": {
@@ -2466,6 +3820,18 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/import-in-the-middle": {
+      "version": "1.14.4",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-1.14.4.tgz",
+      "integrity": "sha512-eWjxh735SJLFJJDs5X82JQ2405OdJeAHDBnaoFCfdr5GVc7AWc9xU7KbrF+3Xd5F2ccP1aQFKtY+65X6EfKZ7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "acorn": "^8.14.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^1.2.2",
+        "module-details-from-path": "^1.0.3"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2498,6 +3864,21 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-docker": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
@@ -2520,6 +3901,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-interactive": {
@@ -2649,6 +4063,28 @@
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "license": "ISC"
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsprim": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
@@ -2662,6 +4098,27 @@
       },
       "engines": {
         "node": ">=0.6.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/local-pkg": {
@@ -2687,6 +4144,54 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -2701,6 +4206,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/long": {
@@ -2800,6 +4322,12 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -3010,6 +4538,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -3032,6 +4566,37 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
       "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3088,6 +4653,45 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -3115,6 +4719,36 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/protobufjs/node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -3281,6 +4915,49 @@
         "uuid": "bin/uuid"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-7.5.2.tgz",
+      "integrity": "sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3",
+        "resolve": "^1.22.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/restore-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -3336,6 +5013,18 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -3374,6 +5063,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -3385,6 +5083,18 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
       "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==",
       "license": "ISC"
+    },
+    "node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/sequin": {
       "version": "0.1.1",
@@ -3417,6 +5127,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -3659,6 +5375,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -3727,6 +5455,15 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -4153,6 +5890,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -4165,6 +5916,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/wsl-utils/node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml2js": {
@@ -4187,6 +5968,51 @@
       "license": "MIT",
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
     "node": ">=20.0.0 <21"
   },
   "dependencies": {
+    "@azure/data-tables": "^13.2.2",
     "@azure/functions": "^4.5.0",
     "@sendgrid/client": "^8.1.0",
     "@sendgrid/mail": "^8.1.0",
-    "@azure/data-tables": "^13.2.2",
+    "applicationinsights": "^3.12.0",
     "jsforce": "^3.10.7",
     "node-quickbooks": "^2.0.46",
     "stripe": "^14.7.0",

--- a/src/config/contactMatching.ts
+++ b/src/config/contactMatching.ts
@@ -1,3 +1,4 @@
+import { logger } from '../lib/logger';
 export interface ContactMatchWeights {
   emailExact: number;
   phoneExact: number;
@@ -121,7 +122,7 @@ export function validateConfig(config: ContactMatchConfig): true {
 
   const totalMaxWeight = Object.values(config.weights).reduce((sum, weight) => sum + weight, 0);
   if (totalMaxWeight < config.thresholds.high) {
-    console.warn(
+    logger.warn(
       `Warning: Maximum possible score (${totalMaxWeight}) is less than high threshold (${config.thresholds.high})`,
     );
   }

--- a/src/handlers/processTransaction.js
+++ b/src/handlers/processTransaction.js
@@ -1,3 +1,4 @@
+const { logger } = require('../lib/logger');
 const { randomUUID } = require('crypto');
 const { z } = require('zod');
 const Stripe = require('stripe');
@@ -329,10 +330,10 @@ const initializeServices = (isLiveMode) => {
         try {
             sgMail.setApiKey(sendgridKey);
         } catch (error) {
-            console.error('Failed to initialize SendGrid:', error.message);
+            logger.error('Failed to initialize SendGrid:', error.message);
         }
     } else {
-        console.log('SendGrid API key not configured. Email notifications disabled.');
+        logger.info('SendGrid API key not configured. Email notifications disabled.');
     }
 
     return { stripe };
@@ -343,7 +344,7 @@ const getCrmConfig = () => {
     const provider = process.env.CRM_PROVIDER;
     
     if (!provider) {
-        console.log('No CRM provider configured, skipping CRM integration');
+        logger.info('No CRM provider configured, skipping CRM integration');
         return null;
     }
 
@@ -360,7 +361,7 @@ const getCrmConfig = () => {
             };
         
         default:
-            console.error(`Unsupported CRM provider: ${provider}`);
+            logger.error(`Unsupported CRM provider: ${provider}`);
             return null;
     }
 };
@@ -489,7 +490,7 @@ const syncContactToCrm = async (context, customerData) => {
     } catch (error) {
         // Log error but don't fail the checkout process
         context.log(`Error syncing contact to CRM: ${error.message}`);
-        console.error('CRM sync error details:', error);
+        logger.error('CRM sync error details:', error);
         return null;
     }
 };
@@ -546,7 +547,7 @@ const createPendingTransaction = async (context, session, contactId, transaction
     } catch (error) {
         // Log error but don't fail the checkout process
         context.log(`Error creating pending transaction: ${error.message}`);
-        console.error('Pending transaction creation error details:', error);
+        logger.error('Pending transaction creation error details:', error);
         return null;
     }
 };
@@ -589,7 +590,7 @@ const upsertSalesforceTransaction = async (context, session, requestData) => {
         return transactionRecord;
     } catch (error) {
         context.log(`Error upserting pending transaction: ${error.message}`);
-        console.error('Pending transaction upsert error details:', error);
+        logger.error('Pending transaction upsert error details:', error);
         return null;
     }
 };
@@ -653,7 +654,7 @@ const searchStripeCustomer = async (stripe, email, fullName) => {
         
         return validCustomers;
     } catch (error) {
-        console.error('Error searching Stripe customer:', error);
+        logger.error('Error searching Stripe customer:', error);
         throw error;
     }
 };
@@ -686,7 +687,7 @@ const createStripeCustomer = async (stripe, customerData) => {
         });
         return customer;
     } catch (error) {
-        console.error('Error creating Stripe customer:', error);
+        logger.error('Error creating Stripe customer:', error);
         throw error;
     }
 };
@@ -725,7 +726,7 @@ const updateStripeCustomer = async (stripe, customerId, customerData) => {
         const customer = await stripe.customers.update(customerId, updateData);
         return customer;
     } catch (error) {
-        console.error('Error updating Stripe customer:', error);
+        logger.error('Error updating Stripe customer:', error);
         throw error;
     }
 };
@@ -766,7 +767,7 @@ const createCheckoutSession = async (stripe, customerId, transactionData) => {
         const session = await stripe.checkout.sessions.create(baseParams);
         return session;
     } catch (error) {
-        console.error('Error creating checkout session:', error);
+        logger.error('Error creating checkout session:', error);
         throw error;
     }
 };
@@ -894,7 +895,7 @@ module.exports = async function (context, req) {
 
     } catch (error) {
         log('Error processing donation', { error: error.message });
-        console.error('Donation processing error details:', { requestId, stack: error.stack });
+        logger.error('Donation processing error details:', { requestId, stack: error.stack });
 
         context.res = {
             status: 500,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,17 +1,283 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { randomUUID } from 'crypto';
+import appInsights, { type TelemetryClient, KnownSeverityLevel } from 'applicationinsights';
+
 export interface Logger {
   log: (...args: unknown[]) => void;
-  info?: (...args: unknown[]) => void;
-  warn?: (...args: unknown[]) => void;
-  error?: (...args: unknown[]) => void;
-  debug?: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  error: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
 }
 
-export const createContextLogger = (baseLogger: Logger = console, context: Record<string, unknown> = {}): Logger => ({
-  log: (...args: unknown[]) => baseLogger.log?.(...args, context),
-  info: (...args: unknown[]) => baseLogger.info?.(...args, context),
-  warn: (...args: unknown[]) => baseLogger.warn?.(...args, context),
-  error: (...args: unknown[]) => baseLogger.error?.(...args, context),
-  debug: (...args: unknown[]) => baseLogger.debug?.(...args, context),
-});
+type LogLevel = 'log' | 'info' | 'warn' | 'error' | 'debug';
 
-export const getLogger = (): Logger => console;
+type LoggerContext = {
+  correlationId: string;
+};
+
+const STRIPE_ID_REGEX = /\b(?:bt|pi|po)_[a-zA-Z0-9]+\b/;
+const MAX_NESTED_DEPTH = 4;
+
+const baseConsole = console;
+const correlationStorage = new AsyncLocalStorage<LoggerContext>();
+
+let telemetryClient: TelemetryClient | undefined;
+let telemetryInitialized = false;
+
+function initializeTelemetry(): TelemetryClient | undefined {
+  if (telemetryInitialized) {
+    return telemetryClient;
+  }
+
+  telemetryInitialized = true;
+
+  const connectionString = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+  const instrumentationKey =
+    process.env.APPLICATIONINSIGHTS_INSTRUMENTATIONKEY ?? process.env.APPINSIGHTS_INSTRUMENTATIONKEY;
+
+  const key = connectionString ?? instrumentationKey;
+
+  if (!key) {
+    return undefined;
+  }
+
+  try {
+    appInsights
+      .setup(key)
+      .setAutoCollectConsole(false)
+      .setAutoCollectDependencies(false)
+      .setAutoCollectExceptions(true)
+      .setAutoCollectPerformance(false, false)
+      .setAutoCollectRequests(false)
+      .setUseDiskRetryCaching(true)
+      .setSendLiveMetrics(false)
+      .start();
+
+    telemetryClient = appInsights.defaultClient;
+
+    if (telemetryClient && connectionString) {
+      telemetryClient.config.connectionString = connectionString;
+    }
+
+    if (telemetryClient) {
+      const cloudRoleKey = telemetryClient.context.keys.cloudRole;
+      telemetryClient.context.tags[cloudRoleKey] = telemetryClient.context.tags[cloudRoleKey] ?? 'payment-processor';
+    }
+  } catch (error) {
+    baseConsole.warn('Failed to initialize Application Insights telemetry', error);
+    telemetryClient = undefined;
+  }
+
+  return telemetryClient;
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (value instanceof Error) {
+    return value.stack ?? value.message ?? value.name;
+  }
+
+  if (value === undefined) {
+    return 'undefined';
+  }
+
+  if (value === null) {
+    return 'null';
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return `[unserializable:${(error as Error)?.message ?? 'error'}]`;
+  }
+}
+
+function extractStripeIdFromValue(value: unknown, visited: WeakSet<object>, depth = 0): string | undefined {
+  if (typeof value === 'string') {
+    const match = value.match(STRIPE_ID_REGEX);
+    return match?.[0];
+  }
+
+  if (!value || typeof value !== 'object') {
+    return undefined;
+  }
+
+  if (visited.has(value)) {
+    return undefined;
+  }
+
+  visited.add(value);
+
+  if (value instanceof Error) {
+    return (
+      extractStripeIdFromValue(value.message, visited, depth + 1) ||
+      extractStripeIdFromValue((value as Error & { requestId?: string }).requestId, visited, depth + 1)
+    );
+  }
+
+  if (depth >= MAX_NESTED_DEPTH) {
+    return undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const result = extractStripeIdFromValue(item, visited, depth + 1);
+      if (result) {
+        return result;
+      }
+    }
+    return undefined;
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry === 'string' && key.toLowerCase().includes('correlation')) {
+      return entry;
+    }
+
+    const result = extractStripeIdFromValue(entry, visited, depth + 1);
+    if (result) {
+      return result;
+    }
+  }
+
+  return undefined;
+}
+
+function findCorrelationId(args: unknown[], context?: Record<string, unknown>): string | undefined {
+  const visited = new WeakSet<object>();
+
+  for (const arg of args) {
+    const match = extractStripeIdFromValue(arg, visited);
+    if (match) {
+      return match;
+    }
+  }
+
+  if (context) {
+    for (const value of Object.values(context)) {
+      const match = extractStripeIdFromValue(value, visited);
+      if (match) {
+        return match;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function ensureCorrelationId(args: unknown[], context?: Record<string, unknown>): string {
+  const store = correlationStorage.getStore();
+  if (store?.correlationId) {
+    return store.correlationId;
+  }
+
+  const candidate = findCorrelationId(args, context);
+  const correlationId = candidate ?? randomUUID();
+
+  if (store) {
+    store.correlationId = correlationId;
+  } else {
+    correlationStorage.enterWith({ correlationId });
+  }
+
+  return correlationId;
+}
+
+function mapSeverity(level: LogLevel): KnownSeverityLevel {
+  switch (level) {
+    case 'error':
+      return KnownSeverityLevel.Error;
+    case 'warn':
+      return KnownSeverityLevel.Warning;
+    case 'debug':
+      return KnownSeverityLevel.Verbose;
+    default:
+      return KnownSeverityLevel.Information;
+  }
+}
+
+function sendToTelemetry(level: LogLevel, args: unknown[], properties: Record<string, unknown>): void {
+  const client = initializeTelemetry();
+  if (!client) {
+    return;
+  }
+
+  const message = args.length > 0 ? args.map(safeStringify).join(' | ') : 'log';
+
+  const telemetryProperties: Record<string, string> = {};
+  for (const [key, value] of Object.entries(properties)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    if (typeof value === 'string') {
+      telemetryProperties[key] = value;
+    } else {
+      telemetryProperties[key] = safeStringify(value);
+    }
+  }
+
+  client.trackTrace({
+    message,
+    severity: mapSeverity(level),
+    properties: telemetryProperties,
+  });
+}
+
+function invokeConsole(level: LogLevel, args: unknown[]): void {
+  const method =
+    level === 'error'
+      ? baseConsole.error
+      : level === 'warn'
+      ? baseConsole.warn
+      : level === 'debug'
+      ? baseConsole.debug ?? baseConsole.log
+      : level === 'info'
+      ? baseConsole.info ?? baseConsole.log
+      : baseConsole.log;
+
+  method.apply(baseConsole, args as []);
+}
+
+function writeLog(level: LogLevel, args: unknown[], context?: Record<string, unknown>): void {
+  const correlationId = ensureCorrelationId(args, context);
+  const contextPayload = { correlationId, ...(context ?? {}) };
+  const outputArgs = [...args, contextPayload];
+
+  invokeConsole(level, outputArgs);
+  sendToTelemetry(level, args, contextPayload);
+}
+
+export function withCorrelationId<T>(correlationId: string, fn: () => T): T {
+  return correlationStorage.run({ correlationId }, fn);
+}
+
+export function getCurrentCorrelationId(): string | undefined {
+  return correlationStorage.getStore()?.correlationId;
+}
+
+export function createLogger(context: Record<string, unknown> = {}): Logger {
+  const boundContext = { ...context };
+
+  return {
+    log: (...args: unknown[]) => writeLog('log', args, boundContext),
+    info: (...args: unknown[]) => writeLog('info', args, boundContext),
+    warn: (...args: unknown[]) => writeLog('warn', args, boundContext),
+    error: (...args: unknown[]) => writeLog('error', args, boundContext),
+    debug: (...args: unknown[]) => writeLog('debug', args, boundContext),
+  };
+}
+
+export const createContextLogger = createLogger;
+
+export const logger: Logger = createLogger();
+
+export default logger;

--- a/src/services/idempotency/idempotencyService.js
+++ b/src/services/idempotency/idempotencyService.js
@@ -1,3 +1,4 @@
+const { logger: rootLogger } = require('../../lib/logger');
 /**
  * Idempotency Service
  * 
@@ -12,7 +13,7 @@
 const { createPersistentStorageClients } = require('./storage/persistentStoreFactory');
 
 class IdempotencyService {
-    constructor({ storageClient, logger = console, namespace } = {}) {
+    constructor({ storageClient, logger = rootLogger, namespace } = {}) {
         const storageNamespace = namespace || process.env.PERSISTENT_STORAGE_NAMESPACE || 'default';
 
         this.logger = logger;
@@ -50,7 +51,7 @@ class IdempotencyService {
         const result = await this.storage.get(key);
 
         if (result) {
-            this.logger.log('IdempotencyService: Found existing processing result', {
+            this.logger.info('IdempotencyService: Found existing processing result', {
                 key,
                 processedAt: result.processedAt,
                 action: result.decision?.action 
@@ -97,7 +98,7 @@ class IdempotencyService {
             }
         }
 
-        this.logger.log('IdempotencyService: Stored processing result', {
+        this.logger.info('IdempotencyService: Stored processing result', {
             key,
             action: result.decision?.action,
             score: result.decision?.bestScore
@@ -123,7 +124,7 @@ class IdempotencyService {
         const inputsChanged = currentHash !== previousResult.metadata.inputHash;
 
         if (inputsChanged) {
-            this.logger.log('IdempotencyService: Inputs changed since last processing', { 
+            this.logger.info('IdempotencyService: Inputs changed since last processing', { 
                 key,
                 previousHash: previousResult.metadata.inputHash,
                 currentHash 
@@ -171,14 +172,14 @@ class IdempotencyService {
         if (existingResult) {
             // Check if inputs have changed
             if (!await this.inputsChanged(key, transactionData)) {
-                this.logger.log('IdempotencyService: Returning cached result (no input changes)', { key });
+                this.logger.info('IdempotencyService: Returning cached result (no input changes)', { key });
                 return {
                     ...existingResult,
                     fromCache: true,
                     message: 'Transaction already processed with same inputs'
                 };
             } else {
-                this.logger.log('IdempotencyService: Inputs changed, reprocessing', { key });
+                this.logger.info('IdempotencyService: Inputs changed, reprocessing', { key });
             }
         }
 
@@ -264,7 +265,7 @@ class IdempotencyService {
      */
     async clear() {
         await this.storage.clear();
-        this.logger.log('IdempotencyService: Cleared all stored results');
+        this.logger.info('IdempotencyService: Cleared all stored results');
     }
 }
 

--- a/src/services/idempotency/storage/fileKeyValueStore.js
+++ b/src/services/idempotency/storage/fileKeyValueStore.js
@@ -1,8 +1,9 @@
+const { logger: rootLogger } = require('../../../lib/logger');
 const fs = require('fs');
 const path = require('path');
 
 class FileKeyValueStore {
-    constructor({ filePath, logger = console } = {}) {
+    constructor({ filePath, logger = rootLogger } = {}) {
         if (!filePath) {
             throw new Error('filePath is required for FileKeyValueStore');
         }

--- a/src/services/idempotency/webhookEventStore.js
+++ b/src/services/idempotency/webhookEventStore.js
@@ -1,3 +1,4 @@
+const { logger: rootLogger } = require('../../lib/logger');
 /**
  * Webhook Event Store
  * 
@@ -11,7 +12,7 @@
 const { createPersistentStorageClients } = require('./storage/persistentStoreFactory');
 
 class WebhookEventStore {
-    constructor({ storageClient, logger = console, namespace } = {}) {
+    constructor({ storageClient, logger = rootLogger, namespace } = {}) {
         const storageNamespace = namespace || process.env.PERSISTENT_STORAGE_NAMESPACE || 'default';
 
         const clients = storageClient
@@ -47,7 +48,7 @@ class WebhookEventStore {
         };
 
         await this.storage.set(event.id, record);
-        this.logger.log(`[WebhookEventStore] Recorded event: ${event.id} (${event.type})`);
+        this.logger.info(`[WebhookEventStore] Recorded event: ${event.id} (${event.type})`);
 
         return record;
     }
@@ -99,7 +100,7 @@ class WebhookEventStore {
         }
 
         await this.storage.set(eventId, event);
-        this.logger.log(`[WebhookEventStore] Updated event ${eventId} to status: ${status}`);
+        this.logger.info(`[WebhookEventStore] Updated event ${eventId} to status: ${status}`);
 
         return event;
     }
@@ -143,7 +144,7 @@ class WebhookEventStore {
         }
 
         if (removed > 0) {
-            this.logger.log(`[WebhookEventStore] Cleaned up ${removed} old events`);
+            this.logger.info(`[WebhookEventStore] Cleaned up ${removed} old events`);
         }
 
         return removed;
@@ -151,7 +152,7 @@ class WebhookEventStore {
 
     async clear() {
         await this.storage.clear();
-        this.logger.log('[WebhookEventStore] Cleared all events');
+        this.logger.info('[WebhookEventStore] Cleared all events');
     }
 }
 

--- a/src/services/idempotencyStore.ts
+++ b/src/services/idempotencyStore.ts
@@ -1,3 +1,5 @@
+import type { Logger } from '../lib/logger';
+import { logger as rootLogger } from '../lib/logger';
 import { TableClient, RestError } from '@azure/data-tables';
 import type { TableEntityResult } from '@azure/data-tables';
 
@@ -19,7 +21,7 @@ export interface AzureIdempotencyStoreOptions {
   /** Base delay (in milliseconds) between lock attempts. */
   lockRetryDelayMs?: number;
   /** Optional logger implementation. */
-  logger?: Pick<typeof console, 'debug' | 'info' | 'warn' | 'error'>;
+  logger?: Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
 }
 
 export interface IdempotencyStore {
@@ -64,7 +66,7 @@ export class AzureIdempotencyStore implements IdempotencyStore {
   private readonly lockTtlSeconds: number;
   private readonly lockMaxAttempts: number;
   private readonly lockRetryDelayMs: number;
-  private readonly logger: Pick<typeof console, 'debug' | 'info' | 'warn' | 'error'>;
+  private readonly logger: Pick<Logger, 'debug' | 'info' | 'warn' | 'error'>;
   private readonly ensureTablePromise: Promise<void>;
 
   private readonly processedKeys = new Set<string>();
@@ -73,7 +75,7 @@ export class AzureIdempotencyStore implements IdempotencyStore {
   private reschedulePersist = false;
 
   constructor(options: AzureIdempotencyStoreOptions = {}) {
-    const logger = options.logger ?? console;
+    const logger = options.logger ?? rootLogger;
     this.logger = logger;
 
     const tableName = options.tableName ?? process.env.IDEMPOTENCY_TABLE_NAME ?? DEFAULT_TABLE_NAME;

--- a/src/services/payoutRecon/accountingSyncConfig.js
+++ b/src/services/payoutRecon/accountingSyncConfig.js
@@ -1,3 +1,4 @@
+const { createLogger } = require('../../lib/logger');
 /**
  * Accounting Sync Configuration Service
  * 
@@ -11,7 +12,7 @@
 class AccountingSyncConfig {
     constructor() {
         this.config = this._loadFromEnvironment();
-        this.logger = console;
+        this.logger = createLogger({ scope: 'AccountingSyncConfig' });
         this.accountOverrides = {
             operatingBank: {}
         };

--- a/src/services/payoutRecon/contactMatcher.js
+++ b/src/services/payoutRecon/contactMatcher.js
@@ -1,3 +1,4 @@
+const { createLogger } = require('../../lib/logger');
 /**
  * ContactMatcher Service
  * 
@@ -106,7 +107,7 @@ class JaroWinkler {
 class ContactMatcher {
     constructor(config = {}) {
         this.config = this._mergeConfig(DEFAULT_CONFIG, config);
-        this.logger = console; // Can be replaced with structured logger
+        this.logger = createLogger({ scope: 'ContactMatcher' }); // Can be replaced with structured logger
     }
     
     /**
@@ -148,7 +149,7 @@ class ContactMatcher {
             normalized.fullName = `${normalized.firstName} ${normalized.lastName}`;
         }
         
-        this.logger.log('ContactMatcher: Normalized input', { 
+        this.logger.info('ContactMatcher: Normalized input', { 
             original: this._redactPII(payload), 
             normalized: this._redactPII(normalized) 
         });
@@ -374,7 +375,7 @@ class ContactMatcher {
             decision.reviewRequired = false;
         }
         
-        this.logger.log('ContactMatcher: Decision made', {
+        this.logger.info('ContactMatcher: Decision made', {
             action: decision.action,
             reason: decision.reason,
             score: decision.bestScore,

--- a/src/services/payoutRecon/emailService.js
+++ b/src/services/payoutRecon/emailService.js
@@ -1,3 +1,4 @@
+const { logger } = require('../../lib/logger');
 const sgMail = require('@sendgrid/mail');
 
 const sendGridApiKey = process.env.SENDGRID_API_KEY;
@@ -8,10 +9,10 @@ if (sendGridApiKey) {
         sgMail.setApiKey(sendGridApiKey);
         isSendGridEnabled = true;
     } catch (error) {
-        console.error('Failed to initialize SendGrid API key:', error.message);
+        logger.error('Failed to initialize SendGrid API key:', error.message);
     }
 } else {
-    console.warn('SENDGRID_API_KEY not configured. Email delivery disabled.');
+    logger.warn('SENDGRID_API_KEY not configured. Email delivery disabled.');
 }
 
 /**
@@ -55,7 +56,7 @@ const shouldSendNotification = async (stripe, customer, amount, notificationPoli
             // If this is the first successful payment, send notification
             return succeededPayments.length <= 1;
         } catch (error) {
-            console.error('Error checking payment history for FIRST policy:', error);
+            logger.error('Error checking payment history for FIRST policy:', error);
             // On error, default to sending the notification
             return true;
         }
@@ -67,7 +68,7 @@ const shouldSendNotification = async (stripe, customer, amount, notificationPoli
         const threshold = parseFloat(thresholdStr);
         
         if (isNaN(threshold)) {
-            console.error(`Invalid ABOVE threshold: ${thresholdStr}, defaulting to send notification`);
+            logger.error(`Invalid ABOVE threshold: ${thresholdStr}, defaulting to send notification`);
             return true;
         }
 
@@ -82,7 +83,7 @@ const shouldSendNotification = async (stripe, customer, amount, notificationPoli
         const threshold = parseFloat(thresholdStr);
         
         if (isNaN(threshold)) {
-            console.error(`Invalid MINIMUM threshold: ${thresholdStr}, defaulting to send notification`);
+            logger.error(`Invalid MINIMUM threshold: ${thresholdStr}, defaulting to send notification`);
             return true;
         }
 
@@ -92,14 +93,14 @@ const shouldSendNotification = async (stripe, customer, amount, notificationPoli
     }
 
     // Unknown policy, default to sending notification
-    console.warn(`Unknown notification policy: ${notificationPolicy}, defaulting to ALL`);
+    logger.warn(`Unknown notification policy: ${notificationPolicy}, defaulting to ALL`);
     return true;
 };
 
 // Send notification email for successful payment
 const sendPaymentSuccessEmail = async (paymentData, paymentIntent, stripe) => {
     if (!isSendGridEnabled) {
-        console.warn('SendGrid API key not configured. Skipping payment success email delivery.');
+        logger.warn('SendGrid API key not configured. Skipping payment success email delivery.');
         return { status: 'skipped', reason: 'sendgrid_disabled' };
     }
 
@@ -109,7 +110,7 @@ const sendPaymentSuccessEmail = async (paymentData, paymentIntent, stripe) => {
         : process.env.NOTIFICATION_EMAIL_TEST;
 
     if (!toEmail) {
-        console.log('No notification email configured');
+        logger.info('No notification email configured');
         return { status: 'skipped', reason: 'missing_recipient' };
     }
 
@@ -127,7 +128,7 @@ const sendPaymentSuccessEmail = async (paymentData, paymentIntent, stripe) => {
     );
 
     if (!shouldSend) {
-        console.log(`Notification skipped based on policy: ${notificationPolicy}`);
+        logger.info(`Notification skipped based on policy: ${notificationPolicy}`);
         return { status: 'skipped', reason: 'policy_skip' };
     }
     
@@ -180,10 +181,10 @@ const sendPaymentSuccessEmail = async (paymentData, paymentIntent, stripe) => {
     
     try {
         await sgMail.send(msg);
-        console.log('Payment success notification email sent successfully');
+        logger.info('Payment success notification email sent successfully');
         return { status: 'sent' };
     } catch (error) {
-        console.error('Error sending payment success notification email:', error);
+        logger.error('Error sending payment success notification email:', error);
         // Don't throw here - email failure shouldn't break the payment flow
         return { status: 'failed', error };
     }

--- a/src/services/payoutRecon/metricsService.js
+++ b/src/services/payoutRecon/metricsService.js
@@ -1,3 +1,4 @@
+const { createLogger } = require('../../lib/logger');
 /**
  * Metrics Service
  * 
@@ -44,7 +45,7 @@ class MetricsService {
             errors: 0,
             cacheHits: 0
         };
-        this.logger = console;
+        this.logger = createLogger({ scope: 'MetricsService' });
     }
 
     /**
@@ -99,7 +100,7 @@ class MetricsService {
             this.metrics.noMatchesFound++;
         }
 
-        this.logger.log('MetricsService: Recorded decision', {
+        this.logger.info('MetricsService: Recorded decision', {
             action: decision.action,
             reason: decision.reason,
             confidence: decision.confidence,
@@ -309,7 +310,7 @@ class MetricsService {
             cacheHits: 0
         };
         
-        this.logger.log('MetricsService: Reset all metrics');
+        this.logger.info('MetricsService: Reset all metrics');
     }
 }
 

--- a/src/services/payoutRecon/payoutProcessor.js
+++ b/src/services/payoutRecon/payoutProcessor.js
@@ -1,3 +1,4 @@
+const { logger } = require('../../lib/logger');
 const AccountingSyncConfig = require('../payoutRecon/accountingSyncConfig');
 const AccountingProviderFactory = require('../qbo/accountingProviderFactory');
 const PayoutSyncService = require('../payoutRecon/payoutSyncService');
@@ -35,7 +36,7 @@ function getCrmServiceInstance() {
         
         return CrmFactory.createCrmService(crmConfig);
     } catch (error) {
-        console.warn('Failed to initialize CRM service:', error.message);
+        logger.warn('Failed to initialize CRM service:', error.message);
         return null;
     }
 }

--- a/src/services/payoutRecon/payoutSyncService.js
+++ b/src/services/payoutRecon/payoutSyncService.js
@@ -1,3 +1,4 @@
+const { createLogger } = require('../../lib/logger');
 const Stripe = require('stripe');
 
 /**
@@ -19,7 +20,7 @@ class PayoutSyncService {
         this.syncLedger = syncLedger;
         this.reviewTaskService = reviewTaskService;
         this.crmService = crmService;
-        this.logger = console;
+        this.logger = createLogger({ scope: 'PayoutSyncService' });
         this.platformAccountId = null;
     }
 

--- a/src/services/payoutRecon/reviewTaskService.js
+++ b/src/services/payoutRecon/reviewTaskService.js
@@ -1,3 +1,4 @@
+const { createLogger } = require('../../lib/logger');
 /**
  * Review Task Service
  * 
@@ -16,7 +17,7 @@ class ReviewTaskService {
             deepLinkBaseUrl: config.deepLinkBaseUrl || 'https://example.com/admin',
             ...config
         };
-        this.logger = console;
+        this.logger = createLogger({ scope: 'ReviewTaskService' });
     }
 
     /**
@@ -52,7 +53,7 @@ class ReviewTaskService {
             // Create the task in CRM
             const createdTask = await this.crmService.createTask(contactId, taskData);
             
-            this.logger.log('ReviewTaskService: Created review task', {
+            this.logger.info('ReviewTaskService: Created review task', {
                 taskId: createdTask.Id,
                 reason: matchResult.decision.reason,
                 score: matchResult.decision.bestScore,

--- a/src/services/payoutRecon/syncLedger.js
+++ b/src/services/payoutRecon/syncLedger.js
@@ -1,3 +1,4 @@
+const { logger: rootLogger } = require('../../lib/logger');
 const crypto = require('crypto');
 const { createPersistentStorageClients } = require('../idempotency/storage/persistentStoreFactory');
 
@@ -13,7 +14,7 @@ const { createPersistentStorageClients } = require('../idempotency/storage/persi
  */
 
 class SyncLedger {
-    constructor({ storageClient, logger = console, namespace } = {}) {
+    constructor({ storageClient, logger = rootLogger, namespace } = {}) {
         const storageNamespace = namespace || process.env.PERSISTENT_STORAGE_NAMESPACE || 'default';
 
         const clients = storageClient
@@ -106,7 +107,7 @@ class SyncLedger {
         };
 
         await this.storage.set(key, record);
-        this.logger.log(`[SyncLedger] Recorded sync for payout: ${payoutId}`);
+        this.logger.info(`[SyncLedger] Recorded sync for payout: ${payoutId}`);
 
         return record;
     }
@@ -161,7 +162,7 @@ class SyncLedger {
         }
 
         await this.storage.set(key, record);
-        this.logger.log(`[SyncLedger] Updated sync status for payout ${payoutId} to: ${status}`);
+        this.logger.info(`[SyncLedger] Updated sync status for payout ${payoutId} to: ${status}`);
 
         return record;
     }
@@ -212,7 +213,7 @@ class SyncLedger {
 
     async clear() {
         await this.storage.clear();
-        this.logger.log('[SyncLedger] Cleared all records');
+        this.logger.info('[SyncLedger] Cleared all records');
     }
 }
 

--- a/src/services/qbo/accountingProviderFactory.js
+++ b/src/services/qbo/accountingProviderFactory.js
@@ -1,3 +1,4 @@
+const { logger } = require('../../lib/logger');
 const QuickBooksProvider = require('./quickbooksProvider');
 
 /**
@@ -91,7 +92,7 @@ class AccountingProviderFactory {
 
         if (!config.oauthTokens.refreshToken) {
             // Warning but not fatal - can still work without refresh
-            console.warn('[QBO] Warning: No refresh token provided. Token refresh will not be available.');
+            logger.warn('[QBO] Warning: No refresh token provided. Token refresh will not be available.');
         }
 
         return { isValid: true };

--- a/src/services/qbo/quickbooksProvider.js
+++ b/src/services/qbo/quickbooksProvider.js
@@ -1,3 +1,4 @@
+const { logger: rootLogger, createLogger } = require('../../lib/logger');
 const BaseAccountingProvider = require('./baseAccountingProvider');
 const QuickBooks = require('node-quickbooks');
 
@@ -14,7 +15,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
         this.companyId = config.companyId;
         this.oauthTokens = config.oauthTokens || {};
         this.environment = config.environment || 'sandbox'; // 'sandbox' or 'production'
-        this.logger = console;
+        this.logger = createLogger({ scope: 'QuickBooksProvider' });
         
         // Initialize QuickBooks client if tokens are available
         this.qbo = null;
@@ -51,7 +52,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
         } catch (error) {
             // If 401, try to refresh token and retry once
             if (error.fault && error.fault.type === 'AUTHENTICATION') {
-                this.logger.log('[QBO] Access token expired, refreshing...');
+                this.logger.info('[QBO] Access token expired, refreshing...');
                 await this.refreshTokens();
                 return await apiCall();
             }
@@ -144,7 +145,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      * Ensure required chart of accounts exist
      */
     async ensureChartOfAccounts(accounts) {
-        this.logger.log('[QBO] Ensuring chart of accounts:', accounts.map(a => a.name));
+        this.logger.info('[QBO] Ensuring chart of accounts:', accounts.map(a => a.name));
 
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
@@ -167,7 +168,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 if (existingAccounts.length > 0) {
                     // Account exists
                     accountMap[account.name] = existingAccounts[0].Id;
-                    this.logger.log(`[QBO] Found existing account: ${account.name} (ID: ${existingAccounts[0].Id})`);
+                    this.logger.info(`[QBO] Found existing account: ${account.name} (ID: ${existingAccounts[0].Id})`);
                 } else {
                     // Create new account
                     const newAccount = {
@@ -186,7 +187,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                     );
 
                     accountMap[account.name] = created.Id;
-                    this.logger.log(`[QBO] Created account: ${account.name} (ID: ${created.Id})`);
+                    this.logger.info(`[QBO] Created account: ${account.name} (ID: ${created.Id})`);
                 }
             } catch (error) {
                 this.logger.error(`[QBO] Error ensuring account ${account.name}:`, error.message);
@@ -271,7 +272,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
         });
 
         if (matchedCustomer) {
-            this.logger.log(`[QBO] Found existing customer: ${matchedCustomer.DisplayName} (ID: ${matchedCustomer.Id})`);
+            this.logger.info(`[QBO] Found existing customer: ${matchedCustomer.DisplayName} (ID: ${matchedCustomer.Id})`);
             return {
                 id: matchedCustomer.Id,
                 displayName: matchedCustomer.DisplayName || displayName
@@ -305,7 +306,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 })
             );
 
-            this.logger.log(`[QBO] Created customer: ${created.DisplayName || displayName} (ID: ${created.Id})`);
+            this.logger.info(`[QBO] Created customer: ${created.DisplayName || displayName} (ID: ${created.Id})`);
 
             return {
                 id: created.Id,
@@ -393,7 +394,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
         });
 
         if (matchedVendor) {
-            this.logger.log(`[QBO] Found existing vendor: ${matchedVendor.DisplayName} (ID: ${matchedVendor.Id})`);
+            this.logger.info(`[QBO] Found existing vendor: ${matchedVendor.DisplayName} (ID: ${matchedVendor.Id})`);
             return {
                 id: matchedVendor.Id,
                 displayName: matchedVendor.DisplayName || displayName
@@ -423,7 +424,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 })
             );
 
-            this.logger.log(`[QBO] Created vendor: ${created.DisplayName || displayName} (ID: ${created.Id})`);
+            this.logger.info(`[QBO] Created vendor: ${created.DisplayName || displayName} (ID: ${created.Id})`);
 
             return {
                 id: created.Id,
@@ -440,7 +441,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      * Upsert a journal entry (idempotent)
      */
     async upsertJournalEntry(journalEntry) {
-        this.logger.log('[QBO] Upserting journal entry:', journalEntry.docNumber);
+        this.logger.info('[QBO] Upserting journal entry:', journalEntry.docNumber);
 
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
@@ -469,7 +470,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
             }
         }
 
-        this.logger.log(`[QBO] Journal entry has ${journalEntry.lines.length} lines, debits=$${(totalDebits / 100).toFixed(2)}, credits=$${(totalCredits / 100).toFixed(2)}`);
+        this.logger.info(`[QBO] Journal entry has ${journalEntry.lines.length} lines, debits=$${(totalDebits / 100).toFixed(2)}, credits=$${(totalCredits / 100).toFixed(2)}`);
 
         try {
             // Search for existing JE by DocNumber using findJournalEntries
@@ -485,7 +486,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
             if (existingEntries.length > 0) {
                 // Entry exists - return existing
                 const existing = existingEntries[0];
-                this.logger.log(`[QBO] Journal entry already exists: ${journalEntry.docNumber} (ID: ${existing.Id})`);
+                this.logger.info(`[QBO] Journal entry already exists: ${journalEntry.docNumber} (ID: ${existing.Id})`);
                 return {
                     id: existing.Id,
                     docNumber: existing.DocNumber,
@@ -603,7 +604,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 })
             );
 
-            this.logger.log(`[QBO] Created journal entry: ${created.DocNumber} (ID: ${created.Id})`);
+            this.logger.info(`[QBO] Created journal entry: ${created.DocNumber} (ID: ${created.Id})`);
             
             return {
                 id: created.Id,
@@ -636,7 +637,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      * Upsert a transfer between accounts (idempotent)
      */
     async upsertTransfer(transfer) {
-        this.logger.log('[QBO] Upserting transfer:', transfer.docNumber);
+        this.logger.info('[QBO] Upserting transfer:', transfer.docNumber);
         
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
@@ -681,7 +682,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
             });
 
             if (matchingTransfer) {
-                this.logger.log(`[QBO] Transfer already exists: ${transfer.docNumber} (ID: ${matchingTransfer.Id})`);
+                this.logger.info(`[QBO] Transfer already exists: ${transfer.docNumber} (ID: ${matchingTransfer.Id})`);
                 return {
                     id: matchingTransfer.Id,
                     docNumber: transfer.docNumber,
@@ -720,7 +721,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 })
             );
 
-            this.logger.log(`[QBO] Created transfer: ${transfer.docNumber} (ID: ${created.Id})`);
+            this.logger.info(`[QBO] Created transfer: ${transfer.docNumber} (ID: ${created.Id})`);
             
             return {
                 id: created.Id,
@@ -750,7 +751,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      * Upsert a bank deposit (idempotent)
      */
     async upsertDeposit(deposit) {
-        this.logger.log('[QBO] Upserting deposit:', deposit.docNumber);
+        this.logger.info('[QBO] Upserting deposit:', deposit.docNumber);
         
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
@@ -778,7 +779,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
             if (existingDeposits.length > 0) {
                 // Deposit exists - return existing
                 const existing = existingDeposits[0];
-                this.logger.log(`[QBO] Deposit already exists: ${deposit.docNumber} (ID: ${existing.Id})`);
+                this.logger.info(`[QBO] Deposit already exists: ${deposit.docNumber} (ID: ${existing.Id})`);
                 return {
                     id: existing.Id,
                     docNumber: deposit.docNumber,
@@ -824,7 +825,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 })
             );
 
-            this.logger.log(`[QBO] Created deposit: ${deposit.docNumber} (ID: ${created.Id})`);
+            this.logger.info(`[QBO] Created deposit: ${deposit.docNumber} (ID: ${created.Id})`);
             
             return {
                 id: created.Id,
@@ -853,7 +854,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      * Attach a document to a transaction
      */
     async attachDocument(transactionId, attachment) {
-        this.logger.log('[QBO] Attaching document to transaction:', transactionId);
+        this.logger.info('[QBO] Attaching document to transaction:', transactionId);
         
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
@@ -916,7 +917,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 })
             );
 
-            this.logger.log(`[QBO] Successfully connected to: ${companyInfo.CompanyName}`);
+            this.logger.info(`[QBO] Successfully connected to: ${companyInfo.CompanyName}`);
             
             return {
                 healthy: true,
@@ -942,7 +943,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      * Get account by ID
      */
     async getAccount(accountId) {
-        this.logger.log('[QBO] Getting account:', accountId);
+        this.logger.info('[QBO] Getting account:', accountId);
         
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
@@ -975,7 +976,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      * Find accounts by criteria
      */
     async findAccounts(criteria) {
-        this.logger.log('[QBO] Finding accounts:', criteria);
+        this.logger.info('[QBO] Finding accounts:', criteria);
         
         if (!this.qbo) {
             throw new Error('QuickBooks client not initialized. Check configuration.');
@@ -1025,7 +1026,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
      */
     async refreshTokens(options = {}) {
         const { persist = true } = options;
-        this.logger.log(`[QBO] Refreshing OAuth tokens${persist ? '' : ' (validation only)'}`);
+        this.logger.info(`[QBO] Refreshing OAuth tokens${persist ? '' : ' (validation only)'}`);
 
         if (!this.oauthTokens.refreshToken) {
             throw new Error('No refresh token available');
@@ -1073,7 +1074,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 // Reinitialize client with new token
                 this._initializeClient();
 
-                this.logger.log('[QBO] Successfully refreshed OAuth tokens');
+                this.logger.info('[QBO] Successfully refreshed OAuth tokens');
 
                 // Note: In production, you should persist these tokens to storage
                 // so they can be used across sessions
@@ -1084,7 +1085,7 @@ class QuickBooksProvider extends BaseAccountingProvider {
                 return true;
             }
 
-            this.logger.log('[QBO] Successfully validated OAuth token exchange');
+            this.logger.info('[QBO] Successfully validated OAuth token exchange');
             return refreshedTokens;
         } catch (error) {
             this.logger.error('[QBO] Failed to refresh tokens:', error);

--- a/src/services/qbo/stripe/attachments.js
+++ b/src/services/qbo/stripe/attachments.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { logger: rootLogger } = require('../../../lib/logger');
+
 const MAX_ATTACHMENT_BYTES = 1.5 * 1024 * 1024; // 1.5MB guardrail
 
 function serializeArtifact(artifact) {
@@ -48,7 +50,7 @@ async function attachStripeArtifacts(quickbooksProvider, transactionId, artifact
         throw new Error('QuickBooks provider with attachDocument is required to attach artifacts');
     }
 
-    const logger = options.logger || console;
+    const logger = options.logger || rootLogger;
     const attachments = artifacts
         .map((artifact, index) => buildAttachment(artifact, index))
         .filter(Boolean);

--- a/src/services/qbo/stripe/customerResolver.js
+++ b/src/services/qbo/stripe/customerResolver.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { logger: rootLogger } = require('../../../lib/logger');
+
 const UNKNOWN_DONOR_NAME = 'Unknown Donor (Stripe)';
 
 function sanitizeString(value) {
@@ -39,7 +41,7 @@ async function resolveQboCustomer(charge, quickbooksProvider, options = {}) {
         throw new Error('A QuickBooks provider with ensureCustomer is required to resolve customers');
     }
 
-    const logger = options.logger || console;
+    const logger = options.logger || rootLogger;
     const customerDetails = extractCustomerDetails(charge);
 
     const payload = {

--- a/src/services/qbo/stripe/fetchStripe.js
+++ b/src/services/qbo/stripe/fetchStripe.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { logger: rootLogger } = require('../../../lib/logger');
+
 const DEFAULT_LIMIT = 100;
 const MAX_AUTOPAGE = 1000;
 
@@ -30,7 +32,7 @@ function normalizeSince(since) {
     throw new Error(`Unsupported since value: ${since}`);
 }
 
-async function fetchAll(stripeListFn, params, logger = console) {
+async function fetchAll(stripeListFn, params, logger = rootLogger) {
     const items = [];
     let startingAfter;
     let page = 0;
@@ -73,7 +75,7 @@ function createListFetcher({ listFn, baseParams }) {
 
         const sinceEpoch = normalizeSince(since);
         const limit = options.limit || DEFAULT_LIMIT;
-        const logger = options.logger || console;
+        const logger = options.logger || rootLogger;
 
         const { createdField, expand: baseExpandParam, ...restBaseParams } = baseParams || {};
 
@@ -188,7 +190,7 @@ async function fetchBalanceTransactionsForPayout(stripe, payoutId, options = {})
         throw new Error('A payoutId is required to fetch balance transactions');
     }
 
-    const logger = options.logger || console;
+    const logger = options.logger || rootLogger;
     const expand = Array.from(new Set([
         'data.source',
         'data.source.charge',

--- a/src/services/qbo/stripe/idempotencyStore.js
+++ b/src/services/qbo/stripe/idempotencyStore.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { logger: rootLogger } = require('../../../lib/logger');
+
 const fs = require('fs/promises');
 const path = require('path');
 
@@ -8,7 +10,7 @@ class ProcessedStripeStore {
         this.storagePath = options.storagePath
             || process.env.STRIPE_QBO_STATE_PATH
             || path.join(process.cwd(), '.data', 'stripe-qbo-state.json');
-        this.logger = options.logger || console;
+        this.logger = options.logger || rootLogger;
         this.fs = options.fs || fs;
         this.records = new Map();
         this.pending = new Set();

--- a/src/services/qbo/stripe/index.js
+++ b/src/services/qbo/stripe/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { logger: rootLogger } = require('../../../lib/logger');
+
 const {
     fetchStripeChargesSince,
     fetchStripeRefundsSince,
@@ -33,7 +35,7 @@ async function postJEIfNew(journalEntry, quickbooksProvider, options = {}) {
     }
 
     const store = options.store || defaultStore;
-    const logger = options.logger || console;
+    const logger = options.logger || rootLogger;
     const stripeId = options.stripeId || (journalEntry.docNumber.startsWith('STRIPE-')
         ? journalEntry.docNumber.substring(7)
         : journalEntry.docNumber);

--- a/src/services/qbo/stripe/transactions.js
+++ b/src/services/qbo/stripe/transactions.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { logger: rootLogger } = require('../../../lib/logger');
+
 const { UNKNOWN_DONOR_NAME } = require('./customerResolver');
 
 const CENT_TOLERANCE = 1; // one cent
@@ -276,7 +278,7 @@ function mapCharge(balanceTransaction, context) {
         throw new Error('Customer reference is required for revenue postings');
     }
 
-    const logger = context.logger || console;
+    const logger = context.logger || rootLogger;
     const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
     validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
 
@@ -370,7 +372,7 @@ function createFeeLine(amounts, accounts, vendor, context, descriptionBuilder) {
 
 function mapRefund(balanceTransaction, context) {
     const accounts = ensureAccounts(context.accounts);
-    const logger = context.logger || console;
+    const logger = context.logger || rootLogger;
     const vendor = context.vendor;
     const refund = context.refund || {};
     const charge = context.charge || {};
@@ -431,7 +433,7 @@ function mapRefund(balanceTransaction, context) {
 
 function mapDispute(balanceTransaction, context) {
     const accounts = ensureAccounts(context.accounts);
-    const logger = context.logger || console;
+    const logger = context.logger || rootLogger;
     const vendor = context.vendor;
     const dispute = context.dispute || {};
     const charge = context.charge || {};
@@ -490,7 +492,7 @@ function mapDispute(balanceTransaction, context) {
 
 function mapDisputeReversal(balanceTransaction, context) {
     const accounts = ensureAccounts(context.accounts);
-    const logger = context.logger || console;
+    const logger = context.logger || rootLogger;
     const vendor = context.vendor;
     const dispute = context.dispute || {};
     const charge = context.charge || {};
@@ -550,7 +552,7 @@ function mapDisputeReversal(balanceTransaction, context) {
 function mapFee(balanceTransaction, context) {
     const accounts = ensureAccounts(context.accounts);
     const vendor = context.vendor;
-    const logger = context.logger || console;
+    const logger = context.logger || rootLogger;
     const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
     validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
 
@@ -604,7 +606,7 @@ function mapFee(balanceTransaction, context) {
 function mapFeeRefund(balanceTransaction, context) {
     const accounts = ensureAccounts(context.accounts);
     const vendor = context.vendor;
-    const logger = context.logger || console;
+    const logger = context.logger || rootLogger;
     const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
     validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
 
@@ -657,7 +659,7 @@ function mapFeeRefund(balanceTransaction, context) {
 
 function mapAdjustment(balanceTransaction, context) {
     const accounts = ensureAccounts(context.accounts);
-    const logger = context.logger || console;
+    const logger = context.logger || rootLogger;
     const amounts = computeAmounts(balanceTransaction, context.companyHomeCurrency);
     validateAmounts(amounts, logger, { balanceTransactionId: balanceTransaction.id });
 
@@ -763,7 +765,7 @@ function buildChargeJE(charge, accounts, vendor, customer, options = {}) {
         customer,
         charge,
         companyHomeCurrency: options.companyHomeCurrency || process.env.COMPANY_HOME_CURRENCY,
-        logger: options.logger || console
+        logger: options.logger || rootLogger
     };
 
     const mapped = mapCharge(balanceTransaction, context);

--- a/src/services/qbo/stripe/vendor.js
+++ b/src/services/qbo/stripe/vendor.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { logger: rootLogger } = require('../../../lib/logger');
+
 const DEFAULT_STRIPE_VENDOR = {
     displayName: 'Stripe',
     email: 'support@stripe.com',
@@ -11,7 +13,7 @@ async function ensureStripeVendor(quickbooksProvider, options = {}) {
         throw new Error('A QuickBooks provider with ensureVendor is required to resolve the Stripe vendor');
     }
 
-    const logger = options.logger || console;
+    const logger = options.logger || rootLogger;
     const configuredVendorId = options.vendorId || process.env.VENDOR_STRIPE_ID;
 
     if (configuredVendorId) {

--- a/src/services/salesforce/salesforceCrm.js
+++ b/src/services/salesforce/salesforceCrm.js
@@ -1,3 +1,4 @@
+const { logger } = require('../../lib/logger');
 const jsforce = require('jsforce');
 const BaseCrmService = require('./baseCrm');
 
@@ -25,10 +26,10 @@ class SalesforceCrmService extends BaseCrmService {
 
         try {
             await this.conn.login(this.config.username, this.config.password + (this.config.securityToken || ''));
-            console.log('Successfully connected to Salesforce');
+            logger.info('Successfully connected to Salesforce');
             return this.conn;
         } catch (error) {
-            console.error('Failed to connect to Salesforce:', error);
+            logger.error('Failed to connect to Salesforce:', error);
             throw new Error(`Salesforce connection failed: ${error.message}`);
         }
     }
@@ -97,13 +98,13 @@ class SalesforceCrmService extends BaseCrmService {
                           ORDER BY CreatedDate DESC 
                           LIMIT 10`;
 
-            console.log('Executing Salesforce query:', query);
+            logger.info('Executing Salesforce query:', query);
             const result = await this.conn.query(query);
             
-            console.log(`Found ${result.records.length} matching contacts`);
+            logger.info(`Found ${result.records.length} matching contacts`);
             return result.records;
         } catch (error) {
-            console.error('Error searching Salesforce contacts:', error);
+            logger.error('Error searching Salesforce contacts:', error);
             throw new Error(`Salesforce contact search failed: ${error.message}`);
         }
     }
@@ -135,7 +136,7 @@ class SalesforceCrmService extends BaseCrmService {
             const result = await this.conn.sobject('Contact').create(contactRecord);
             
             if (result.success) {
-                console.log(`Created new Salesforce contact with ID: ${result.id}`);
+                logger.info(`Created new Salesforce contact with ID: ${result.id}`);
                 
                 // Fetch the created contact to return complete data
                 const createdContact = await this.conn.sobject('Contact').retrieve(result.id);
@@ -144,7 +145,7 @@ class SalesforceCrmService extends BaseCrmService {
                 throw new Error(`Contact creation failed: ${JSON.stringify(result.errors)}`);
             }
         } catch (error) {
-            console.error('Error creating Salesforce contact:', error);
+            logger.error('Error creating Salesforce contact:', error);
             throw new Error(`Salesforce contact creation failed: ${error.message}`);
         }
     }
@@ -182,7 +183,7 @@ class SalesforceCrmService extends BaseCrmService {
 
         // Only proceed if we have at least one field to update
         if (Object.keys(updateRecord).length === 0) {
-            console.log('No meaningful address data to update');
+            logger.info('No meaningful address data to update');
             return null;
         }
         try {
@@ -192,7 +193,7 @@ class SalesforceCrmService extends BaseCrmService {
             });
             
             if (result.success) {
-                console.log(`Updated Salesforce contact ${contactId} with address information`);
+                logger.info(`Updated Salesforce contact ${contactId} with address information`);
                 
                 // Fetch the updated contact to return complete data
                 const updatedContact = await this.conn.sobject('Contact').retrieve(contactId);
@@ -201,7 +202,7 @@ class SalesforceCrmService extends BaseCrmService {
                 throw new Error(`Contact update failed: ${JSON.stringify(result.errors)}`);
             }
         } catch (error) {
-            console.error('Error updating Salesforce contact:', error);
+            logger.error('Error updating Salesforce contact:', error);
             throw new Error(`Salesforce contact update failed: ${error.message}`);
         }
     }
@@ -231,7 +232,7 @@ class SalesforceCrmService extends BaseCrmService {
             const result = await this.conn.sobject('Task').create(taskRecord);
             
             if (result.success) {
-                console.log(`Created Salesforce task with ID: ${result.id}`);
+                logger.info(`Created Salesforce task with ID: ${result.id}`);
                 
                 // Fetch the created task to return complete data
                 const createdTask = await this.conn.sobject('Task').retrieve(result.id);
@@ -240,7 +241,7 @@ class SalesforceCrmService extends BaseCrmService {
                 throw new Error(`Task creation failed: ${JSON.stringify(result.errors)}`);
             }
         } catch (error) {
-            console.error('Error creating Salesforce task:', error);
+            logger.error('Error creating Salesforce task:', error);
             throw new Error(`Salesforce task creation failed: ${error.message}`);
         }
     }
@@ -256,7 +257,7 @@ class SalesforceCrmService extends BaseCrmService {
         try {
             // First try custom Transaction object
             const query = `SELECT Id, Name, Transaction_ID__c, Status__c FROM Transaction__c WHERE Transaction_ID__c = '${stripeId}' LIMIT 1`;
-            console.log(`Executing Salesforce query: ${query}`);
+            logger.info(`Executing Salesforce query: ${query}`);
             
             const result = await this.conn.query(query);
             
@@ -264,14 +265,14 @@ class SalesforceCrmService extends BaseCrmService {
                 return result.records[0];
             }
         } catch (error) {
-            console.log('Custom Transaction object not available, checking Opportunities');
+            logger.info('Custom Transaction object not available, checking Opportunities');
         }
 
         try {
             // Fallback to Opportunity records (if using them as transaction fallback)
             // Search in Description field for "Payment Intent: {stripeId}"
             const query = `SELECT Id, Name, Description, StageName FROM Opportunity WHERE Description LIKE '%${stripeId}%' LIMIT 1`;
-            console.log(`Executing Salesforce query: ${query}`);
+            logger.info(`Executing Salesforce query: ${query}`);
             
             const result = await this.conn.query(query);
             
@@ -279,7 +280,7 @@ class SalesforceCrmService extends BaseCrmService {
                 return result.records[0];
             }
         } catch (error) {
-            console.log('Error checking Opportunities for existing transaction:', error.message);
+            logger.info('Error checking Opportunities for existing transaction:', error.message);
         }
 
         return null;
@@ -334,14 +335,14 @@ class SalesforceCrmService extends BaseCrmService {
             const result = await this.conn.sobject('Transaction__c').create(transactionRecord);
             
             if (result.success) {
-                console.log(`Created Salesforce transaction with ID: ${result.id}`);
+                logger.info(`Created Salesforce transaction with ID: ${result.id}`);
                 const createdTransaction = await this.conn.sobject('Transaction__c').retrieve(result.id);
                 return createdTransaction;
             } else {
                 throw new Error(`Transaction creation failed: ${JSON.stringify(result.errors)}`);
             }
         } catch (error) {
-            console.log('Custom Transaction object not available, falling back to Opportunity');
+            logger.info('Custom Transaction object not available, falling back to Opportunity');
             
             // Fallback to Opportunity record
             return await this.createOpportunityAsTransaction(contactId, transactionData);
@@ -379,7 +380,7 @@ class SalesforceCrmService extends BaseCrmService {
 
             return result;
         } catch (error) {
-            console.error('Error upserting Salesforce transaction:', error);
+            logger.error('Error upserting Salesforce transaction:', error);
             throw new Error(`Salesforce transaction upsert failed: ${error.message}`);
         }
     }
@@ -434,14 +435,14 @@ class SalesforceCrmService extends BaseCrmService {
             const result = await this.conn.sobject('Opportunity').create(opportunityRecord);
             
             if (result.success) {
-                console.log(`Created Salesforce opportunity with ID: ${result.id}`);
+                logger.info(`Created Salesforce opportunity with ID: ${result.id}`);
                 const createdOpportunity = await this.conn.sobject('Opportunity').retrieve(result.id);
                 return createdOpportunity;
             } else {
                 throw new Error(`Opportunity creation failed: ${JSON.stringify(result.errors)}`);
             }
         } catch (error) {
-            console.error('Error creating Salesforce opportunity:', error);
+            logger.error('Error creating Salesforce opportunity:', error);
             throw new Error(`Salesforce opportunity creation failed: ${error.message}`);
         }
     }
@@ -478,7 +479,7 @@ class SalesforceCrmService extends BaseCrmService {
 
         // Only proceed if we have at least one field to update
         if (Object.keys(updateRecord).length === 0) {
-            console.log('No transaction data to update');
+            logger.info('No transaction data to update');
             return null;
         }
 
@@ -490,14 +491,14 @@ class SalesforceCrmService extends BaseCrmService {
             });
             
             if (result.success) {
-                console.log(`Updated Salesforce transaction ${transactionId} with status: ${status}`);
+                logger.info(`Updated Salesforce transaction ${transactionId} with status: ${status}`);
                 const updatedTransaction = await this.conn.sobject('Transaction__c').retrieve(transactionId);
                 return updatedTransaction;
             } else {
                 throw new Error(`Transaction update failed: ${JSON.stringify(result.errors)}`);
             }
         } catch (error) {
-            console.log('Custom Transaction object not available, trying Opportunity');
+            logger.info('Custom Transaction object not available, trying Opportunity');
             
             // Fallback to Opportunity record
             try {
@@ -524,14 +525,14 @@ class SalesforceCrmService extends BaseCrmService {
                 });
                 
                 if (result.success) {
-                    console.log(`Updated Salesforce opportunity ${transactionId}`);
+                    logger.info(`Updated Salesforce opportunity ${transactionId}`);
                     const updatedOpportunity = await this.conn.sobject('Opportunity').retrieve(transactionId);
                     return updatedOpportunity;
                 } else {
                     throw new Error(`Opportunity update failed: ${JSON.stringify(result.errors)}`);
                 }
             } catch (oppError) {
-                console.error('Error updating Salesforce opportunity:', oppError);
+                logger.error('Error updating Salesforce opportunity:', oppError);
                 throw new Error(`Salesforce transaction/opportunity update failed: ${oppError.message}`);
             }
         }
@@ -548,7 +549,7 @@ class SalesforceCrmService extends BaseCrmService {
         try {
             // First try custom Transaction object
             const query = `SELECT Id, Name, Transaction_ID__c, Status__c, Session_ID__c FROM Transaction__c WHERE Session_ID__c = '${sessionId}' LIMIT 1`;
-            console.log(`Executing Salesforce query: ${query}`);
+            logger.info(`Executing Salesforce query: ${query}`);
             
             const result = await this.conn.query(query);
             
@@ -556,7 +557,7 @@ class SalesforceCrmService extends BaseCrmService {
                 return result.records[0];
             }
         } catch (error) {
-            console.log('Custom Transaction object not available or Session_ID__c field not found, checking Opportunities');
+            logger.info('Custom Transaction object not available or Session_ID__c field not found, checking Opportunities');
         }
 
         try {
@@ -564,7 +565,7 @@ class SalesforceCrmService extends BaseCrmService {
             // Note: Opportunities don't have a standard field for session ID, 
             // so we'll look in the Description field
             const query = `SELECT Id, Name, StageName, Description FROM Opportunity WHERE Description LIKE '%${sessionId}%' LIMIT 1`;
-            console.log(`Executing Salesforce query: ${query}`);
+            logger.info(`Executing Salesforce query: ${query}`);
             
             const result = await this.conn.query(query);
             
@@ -572,7 +573,7 @@ class SalesforceCrmService extends BaseCrmService {
                 return result.records[0];
             }
         } catch (error) {
-            console.log('Error checking Opportunities for existing transaction:', error.message);
+            logger.info('Error checking Opportunities for existing transaction:', error.message);
         }
 
         return null;
@@ -635,18 +636,18 @@ class SalesforceCrmService extends BaseCrmService {
             const result = await this.conn.sobject('Payout__c').create(payoutRecord);
             
             if (result.success) {
-                console.log(`Created Salesforce payout with ID: ${result.id}`);
+                logger.info(`Created Salesforce payout with ID: ${result.id}`);
                 const createdPayout = await this.conn.sobject('Payout__c').retrieve(result.id);
                 return createdPayout;
             } else {
                 throw new Error(`Payout creation failed: ${JSON.stringify(result.errors)}`);
             }
         } catch (error) {
-            console.error('Error creating Salesforce payout:', error);
+            logger.error('Error creating Salesforce payout:', error);
             
             // If custom Payout object doesn't exist, log and return null gracefully
             if (error.message.includes('sObject type') || error.message.includes('Payout__c')) {
-                console.log('Custom Payout__c object not available in Salesforce - skipping payout storage in CRM');
+                logger.info('Custom Payout__c object not available in Salesforce - skipping payout storage in CRM');
                 return null;
             }
             
@@ -683,7 +684,7 @@ class SalesforceCrmService extends BaseCrmService {
 
         // If no contacts have matching names, return null to create new contact
         if (contactsWithMatchingNames.length === 0) {
-            console.log('No contacts found with matching name, will create new contact');
+            logger.info('No contacts found with matching name, will create new contact');
             return null;
         }
 
@@ -721,7 +722,7 @@ class SalesforceCrmService extends BaseCrmService {
         // Sort by score (highest first) and return best match
         const bestMatch = scoredContacts.sort((a, b) => b.score - a.score)[0];
         
-        console.log(`Selected contact with score ${bestMatch.score}: ${bestMatch.contact.FirstName} ${bestMatch.contact.LastName} (${bestMatch.contact.Email})`);
+        logger.info(`Selected contact with score ${bestMatch.score}: ${bestMatch.contact.FirstName} ${bestMatch.contact.LastName} (${bestMatch.contact.Email})`);
         
         return bestMatch.contact;
     }


### PR DESCRIPTION
## Summary
- implement a shared logger that derives correlation IDs, supports context scoping, and forwards traces to Application Insights
- add the logger dependency and wire it through configuration helpers and services
- replace direct console usage across handlers and services so operational logs include correlation metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e821fe2384832c87236f82930a193b