### PR TITLE
Add secret redaction preflight and sanitize health check output

### DIFF
--- a/__tests__/healthCheck.test.js
+++ b/__tests__/healthCheck.test.js
@@ -187,4 +187,57 @@ describe('healthCheck', () => {
         expect(environmentComponent).toBeDefined();
         expect(environmentComponent.status).toBe('unhealthy');
     });
+
+    it('redacts secret values from responses and logs', async () => {
+        process.env.STRIPE_TEST_SECRET_KEY = 'sk_test_secret_value';
+        process.env.STRIPE_LIVE_SECRET_KEY = 'sk_live_secret_value';
+        process.env.SENDGRID_API_KEY = 'SG.secret_value';
+        delete process.env.CRM_PROVIDER;
+        delete process.env.ACCOUNTING_SYNC_ENABLED;
+
+        const stripeFactory = vi.fn(secretKey => ({
+            payouts: {
+                list: vi.fn().mockRejectedValue(new Error(`Invalid API Key provided: ${secretKey}`))
+            }
+        }));
+
+        const sendGridRequest = vi.fn().mockRejectedValue(new Error(`invalid key ${process.env.SENDGRID_API_KEY}`));
+
+        internals.setDependencies({
+            stripeFactory,
+            sendGridClientFactory: () => ({
+                setApiKey: vi.fn(),
+                request: sendGridRequest
+            }),
+            accountingSyncConfigFactory: () => ({
+                isEnabled: () => false
+            }),
+            persistentStorageFactory: () => ({
+                syncLedgerStore: {
+                    set: vi.fn().mockResolvedValue(undefined),
+                    delete: vi.fn().mockResolvedValue(undefined)
+                }
+            })
+        });
+
+        const { context, logs } = createContext();
+
+        await handler(context, {});
+
+        const serializedBody = JSON.stringify(context.res.body);
+        expect(serializedBody).not.toContain('sk_test_secret_value');
+        expect(serializedBody).not.toContain('sk_live_secret_value');
+        expect(serializedBody).not.toContain('SG.secret_value');
+        expect(serializedBody).toContain('***REDACTED***');
+
+        const serializedLogs = logs.map(args => JSON.stringify(args)).join(' ');
+        expect(serializedLogs).not.toContain('sk_test_secret_value');
+        expect(serializedLogs).not.toContain('sk_live_secret_value');
+        expect(serializedLogs).not.toContain('SG.secret_value');
+        expect(serializedLogs).toContain('***REDACTED***');
+
+        expect(stripeFactory).toHaveBeenCalledWith('sk_test_secret_value', expect.any(Object));
+        expect(stripeFactory).toHaveBeenCalledWith('sk_live_secret_value', expect.any(Object));
+        expect(sendGridRequest).toHaveBeenCalled();
+    });
 });

--- a/__tests__/payoutSyncTrigger.test.js
+++ b/__tests__/payoutSyncTrigger.test.js
@@ -15,7 +15,7 @@ describe('payoutSyncTrigger', () => {
     beforeEach(() => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date('2024-05-20T12:00:00Z'));
-        handler = require('../src/handlers/payoutSyncTrigger.js');
+        handler = require('../payoutSyncTrigger');
         internals = handler.__internals;
     });
 

--- a/src/handlers/healthCheck.js
+++ b/src/handlers/healthCheck.js
@@ -1,9 +1,12 @@
+require('../preflight');
+
 const Stripe = require('stripe');
 const { Client: SendGridClient } = require('@sendgrid/client');
 const AccountingSyncConfig = require('../services/payoutRecon/accountingSyncConfig');
 const AccountingProviderFactory = require('../services/qbo/accountingProviderFactory');
 const CrmFactory = require('../services/salesforce/crmFactory');
 const { createPersistentStorageClients } = require('../services/idempotency/storage/persistentStoreFactory');
+const { initializeSecretRedactor, redactSecrets } = require('../lib/secretRedactor');
 
 const defaultDependencies = {
     stripeFactory: (secretKey, options) => new Stripe(secretKey, options),
@@ -432,6 +435,8 @@ module.exports = async function healthCheck(context, req) {
     const now = new Date();
     context.log('Health check requested');
 
+    initializeSecretRedactor();
+
     const connectionChecks = [
         checkStripeConnection('test', process.env.STRIPE_TEST_SECRET_KEY),
         checkStripeConnection('live', process.env.STRIPE_LIVE_SECRET_KEY),
@@ -446,27 +451,34 @@ module.exports = async function healthCheck(context, req) {
     const degraded = connections.some(connection => connection.healthy === false);
     const overallStatus = degraded ? 'degraded' : 'ok';
 
-    context.log('Health check connection statuses', connections);
-
     const components = connections.map(connection => ({
         component: connection.name,
         status: connection.status,
         healthy: connection.healthy
     }));
 
+    const responseBody = {
+        status: overallStatus,
+        timestamp: now.toISOString(),
+        uptime: process.uptime(),
+        version: process.env.APP_VERSION || null,
+        connections,
+        components
+    };
+
+    const sanitizedBody = redactSecrets(responseBody);
+    const safeConnections = Array.isArray(sanitizedBody?.connections)
+        ? sanitizedBody.connections
+        : redactSecrets(connections);
+
+    context.log('Health check connection statuses', safeConnections);
+
     context.res = {
         status: 200,
         headers: {
             'Content-Type': 'application/json'
         },
-        body: {
-            status: overallStatus,
-            timestamp: now.toISOString(),
-            uptime: process.uptime(),
-            version: process.env.APP_VERSION || null,
-            connections,
-            components
-        }
+        body: sanitizedBody
     };
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import type { FunctionHandler } from '@azure/functions';
 
+import './preflight';
 import './config/env';
 
 const healthCheck: FunctionHandler = require('./handlers/healthCheck');

--- a/src/lib/secretRedactor.ts
+++ b/src/lib/secretRedactor.ts
@@ -1,0 +1,423 @@
+import type { EnvConfig } from '../config/env';
+
+export const SECRET_REDACTION_PLACEHOLDER = '***REDACTED***';
+
+const MIN_SECRET_LENGTH = 4;
+const PLACEHOLDER_PATTERNS = [
+  /YOUR_[A-Z0-9_]+/i,
+  /REPLACE_ME/i,
+  /CHANGE_ME/i,
+  /EXAMPLE_KEY/i,
+  /DUMMY_VALUE/i,
+];
+
+const SECRET_ENV_KEY_ALLOWLIST = new Set<string>([
+  'NODE_ENV',
+  'WEBSITE_SITE_NAME',
+  'WEBSITE_INSTANCE_ID',
+  'WEBSITE_HOSTNAME',
+  'WEBSITE_CONTENTSHARE',
+  'WEBSITE_OWNER_NAME',
+  'APPSETTING_WEBSITE_TIME_ZONE',
+  'APPSETTING_FUNCTIONS_WORKER_RUNTIME',
+  'APPSETTING_AZURE_FUNCTIONS_ENVIRONMENT',
+  'GITHUB_SHA',
+  'APP_VERSION',
+  'CRM_PROVIDER',
+  'ACCOUNTING_PROVIDER',
+  'ACCOUNTING_SYNC_ENABLED',
+  'ACCOUNTING_POSTING_STRATEGY',
+]);
+
+const SECRET_ENV_KEY_PATTERNS = [
+  /SECRET/i,
+  /TOKEN/i,
+  /PASSWORD/i,
+  /PRIVATE/i,
+  /CERT/i,
+  /CONNECTION/i,
+  /ENDPOINT/i,
+  /APIKEY/i,
+  /API_KEY/i,
+  /SIGNATURE/i,
+  /KEY$/i,
+  /^KEY/i,
+];
+
+const SECRET_VALUE_PATTERNS = [
+  /^@microsoft\.keyvault/i,
+  /secreturi=/i,
+  /accountkey=/i,
+  /signature=/i,
+];
+
+const secretPatterns = new Map<string, RegExp>();
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function isPlaceholderValue(value: string): boolean {
+  return PLACEHOLDER_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function shouldRegisterToken(value: string): boolean {
+  if (value.length < MIN_SECRET_LENGTH) {
+    return false;
+  }
+
+  if (value === SECRET_REDACTION_PLACEHOLDER) {
+    return false;
+  }
+
+  if (isPlaceholderValue(value)) {
+    return false;
+  }
+
+  const normalized = value.toLowerCase();
+
+  if (normalized.startsWith('acct_')) {
+    return false;
+  }
+
+  if (/^pk_(?:test|live)/.test(normalized)) {
+    return false;
+  }
+
+  if (/^whsec_/.test(normalized)) {
+    return true;
+  }
+
+  if (/^sk_(?:test|live)/.test(normalized)) {
+    return true;
+  }
+
+  if (/^rk_(?:test|live)/.test(normalized)) {
+    return true;
+  }
+
+  if (/^sg\./.test(value)) {
+    return true;
+  }
+
+  if (/secret|token|password|key/.test(normalized)) {
+    return true;
+  }
+
+  if (/^@microsoft\.keyvault/.test(normalized)) {
+    return true;
+  }
+
+  if (/^[a-z0-9+/=]{24,}$/i.test(value)) {
+    return true;
+  }
+
+  return value.length >= 32;
+}
+
+function buildPattern(value: string): RegExp | null {
+  if (secretPatterns.has(value)) {
+    return null;
+  }
+
+  try {
+    return new RegExp(escapeRegExp(value), 'g');
+  } catch (error) {
+    return null;
+  }
+}
+
+export function registerSecretValue(value: unknown, options: { force?: boolean } = {}): void {
+  if (typeof value !== 'string') {
+    return;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return;
+  }
+
+  if (!options.force && !shouldRegisterToken(trimmed)) {
+    return;
+  }
+
+  const pattern = buildPattern(trimmed);
+  if (!pattern) {
+    return;
+  }
+
+  secretPatterns.set(trimmed, pattern);
+}
+
+export function registerSecretCollection(collection: unknown, options: { force?: boolean } = {}): void {
+  if (!collection) {
+    return;
+  }
+
+  const visited = new WeakSet<object>();
+
+  const walk = (value: unknown): void => {
+    if (typeof value === 'string') {
+      registerSecretValue(value, options);
+      return;
+    }
+
+    if (!value) {
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        walk(item);
+      }
+      return;
+    }
+
+    if (typeof value === 'object') {
+      if (visited.has(value as object)) {
+        return;
+      }
+      visited.add(value as object);
+
+      if (value instanceof Map) {
+        for (const mapValue of value.values()) {
+          walk(mapValue);
+        }
+        return;
+      }
+
+      if (value instanceof Set) {
+        for (const setValue of value.values()) {
+          walk(setValue);
+        }
+        return;
+      }
+
+      const entries = Object.entries(value as Record<string, unknown>);
+      for (const [, nested] of entries) {
+        walk(nested);
+      }
+    }
+  };
+
+  walk(collection);
+}
+
+function tokenizePotentialSecrets(value: string): string[] {
+  const segments = value.split(/[,;\s]+/);
+  const tokens: string[] = [];
+
+  for (const segment of segments) {
+    if (!segment) {
+      continue;
+    }
+
+    const parts = segment.split(/[:=]/);
+    for (const part of parts) {
+      const candidate = part.trim();
+      if (candidate.length === 0) {
+        continue;
+      }
+
+      if (shouldRegisterToken(candidate)) {
+        tokens.push(candidate);
+      }
+    }
+  }
+
+  return tokens;
+}
+
+function shouldCaptureEnvKey(key: string): boolean {
+  if (!key) {
+    return false;
+  }
+
+  const normalized = key.toUpperCase();
+  if (SECRET_ENV_KEY_ALLOWLIST.has(normalized)) {
+    return false;
+  }
+
+  return SECRET_ENV_KEY_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
+function shouldCaptureEnvValue(value: string): boolean {
+  return SECRET_VALUE_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+export function initializeSecretRedactor(): void {
+  for (const [key, rawValue] of Object.entries(process.env)) {
+    if (typeof rawValue !== 'string' || rawValue.length === 0) {
+      continue;
+    }
+
+    const shouldCapture = shouldCaptureEnvKey(key) || shouldCaptureEnvValue(rawValue);
+    if (!shouldCapture) {
+      continue;
+    }
+
+    registerSecretValue(rawValue, { force: true });
+    const tokens = tokenizePotentialSecrets(rawValue);
+    for (const token of tokens) {
+      registerSecretValue(token);
+    }
+  }
+}
+
+function redactString(value: string): string {
+  let result = value;
+  for (const pattern of secretPatterns.values()) {
+    result = result.replace(pattern, SECRET_REDACTION_PLACEHOLDER);
+  }
+  return result;
+}
+
+function cloneDate(value: Date): Date {
+  return new Date(value.getTime());
+}
+
+function redactObject(value: Record<string, unknown>, seen: WeakMap<object, unknown>): Record<string, unknown> {
+  if (seen.has(value)) {
+    return seen.get(value) as Record<string, unknown>;
+  }
+
+  const clone: Record<string, unknown> = {};
+  seen.set(value, clone);
+
+  for (const [key, nested] of Object.entries(value)) {
+    clone[key] = redactUnknown(nested, seen);
+  }
+
+  return clone;
+}
+
+function redactArray(value: unknown[], seen: WeakMap<object, unknown>): unknown[] {
+  if (seen.has(value)) {
+    return seen.get(value) as unknown[];
+  }
+
+  const clone: unknown[] = [];
+  seen.set(value, clone);
+
+  for (const item of value) {
+    clone.push(redactUnknown(item, seen));
+  }
+
+  return clone;
+}
+
+function redactMap(value: Map<unknown, unknown>, seen: WeakMap<object, unknown>): Map<unknown, unknown> {
+  if (seen.has(value)) {
+    return seen.get(value) as Map<unknown, unknown>;
+  }
+
+  const clone = new Map<unknown, unknown>();
+  seen.set(value, clone);
+
+  for (const [key, nested] of value.entries()) {
+    clone.set(key, redactUnknown(nested, seen));
+  }
+
+  return clone;
+}
+
+function redactSet(value: Set<unknown>, seen: WeakMap<object, unknown>): Set<unknown> {
+  if (seen.has(value)) {
+    return seen.get(value) as Set<unknown>;
+  }
+
+  const clone = new Set<unknown>();
+  seen.set(value, clone);
+
+  for (const item of value.values()) {
+    clone.add(redactUnknown(item, seen));
+  }
+
+  return clone;
+}
+
+function redactError(value: Error, seen: WeakMap<object, unknown>): Record<string, unknown> {
+  if (seen.has(value)) {
+    return seen.get(value) as Record<string, unknown>;
+  }
+
+  const clone: Record<string, unknown> = {
+    name: value.name,
+    message: redactString(value.message ?? ''),
+  };
+
+  if (value.stack) {
+    clone.stack = redactString(value.stack);
+  }
+
+  seen.set(value, clone);
+  return clone;
+}
+
+function redactUnknown(value: unknown, seen: WeakMap<object, unknown>): unknown {
+  if (typeof value === 'string') {
+    return redactString(value);
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint' || typeof value === 'undefined') {
+    return value;
+  }
+
+  if (value === null) {
+    return value;
+  }
+
+  if (value instanceof Date) {
+    return cloneDate(value);
+  }
+
+  if (Buffer.isBuffer(value)) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return redactArray(value, seen);
+  }
+
+  if (value instanceof Map) {
+    return redactMap(value, seen);
+  }
+
+  if (value instanceof Set) {
+    return redactSet(value, seen);
+  }
+
+  if (value instanceof Error) {
+    return redactError(value, seen);
+  }
+
+  if (typeof value === 'object') {
+    return redactObject(value as Record<string, unknown>, seen);
+  }
+
+  return value;
+}
+
+export function redactSecrets<T>(value: T): T {
+  return redactUnknown(value, new WeakMap<object, unknown>()) as T;
+}
+
+export function registerEnvConfigSecrets(config: EnvConfig | null | undefined): void {
+  if (!config) {
+    return;
+  }
+
+  registerSecretValue(config.stripe.secret, { force: true });
+  registerSecretValue(config.stripe.webhookSecret, { force: true });
+
+  if (config.salesforce.jwtPrivateKey) {
+    registerSecretValue(config.salesforce.jwtPrivateKey, { force: true });
+  }
+
+  registerSecretCollection(config.quickBooks, { force: true });
+}
+
+export function registeredSecretCount(): number {
+  return secretPatterns.size;
+}
+

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,0 +1,59 @@
+import { initializeSecretRedactor, registerSecretValue } from './lib/secretRedactor';
+
+const FORCE_REGISTER_ENV_KEYS = [
+  'STRIPE_SECRET',
+  'STRIPE_LIVE_SECRET_KEY',
+  'STRIPE_TEST_SECRET_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'STRIPE_WEBHOOK_SECRET_LIVE',
+  'STRIPE_WEBHOOK_SECRET_TEST',
+  'STRIPE_WEBHOOK_SECRETS',
+  'STRIPE_ACCOUNTS',
+  'SENDGRID_API_KEY',
+  'SALESFORCE_PASSWORD',
+  'SALESFORCE_SECURITY_TOKEN',
+  'SALESFORCE_CLIENT_SECRET',
+  'SF_CLIENT_SECRET',
+  'SF_JWT_PRIVATE_KEY',
+  'QBO_CLIENT_SECRET',
+  'QBO_REFRESH_TOKEN',
+  'QBO_ACCESS_TOKEN',
+  'APPLICATIONINSIGHTS_CONNECTION_STRING',
+  'APPLICATIONINSIGHTS_INSTRUMENTATIONKEY',
+  'APPINSIGHTS_INSTRUMENTATIONKEY',
+  'APPINSIGHTS_INSTRUMENTATION_KEY',
+  'AZURE_TABLES_CONNECTION_STRING',
+  'AZURE_STORAGE_CONNECTION_STRING',
+  'PERSISTENT_STORAGE_CONNECTION_STRING',
+];
+
+const DELIMITED_SECRET_ENV_KEYS = ['STRIPE_ACCOUNTS', 'STRIPE_WEBHOOK_SECRETS'];
+
+initializeSecretRedactor();
+
+for (const key of FORCE_REGISTER_ENV_KEYS) {
+  const value = process.env[key];
+  if (typeof value === 'string' && value.length > 0) {
+    registerSecretValue(value, { force: true });
+  }
+}
+
+for (const key of DELIMITED_SECRET_ENV_KEYS) {
+  const value = process.env[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    continue;
+  }
+
+  const entries = value.split(',');
+  for (const entry of entries) {
+    const segments = entry.split(':');
+    for (const segment of segments) {
+      const candidate = segment.trim();
+      if (candidate.length === 0) {
+        continue;
+      }
+      registerSecretValue(candidate);
+    }
+  }
+}
+

--- a/src/services/payoutRecon/accountingSyncConfig.js
+++ b/src/services/payoutRecon/accountingSyncConfig.js
@@ -1,4 +1,5 @@
 const { createLogger } = require('../../lib/logger');
+const { registerSecretValue } = require('../../lib/secretRedactor');
 /**
  * Accounting Sync Configuration Service
  * 
@@ -98,6 +99,9 @@ class AccountingSyncConfig {
         accountsEnv.split(',').forEach(entry => {
             const [accountId, mode, secretKey] = entry.trim().split(':');
             if (accountId && mode) {
+                if (secretKey) {
+                    registerSecretValue(secretKey);
+                }
                 accounts[accountId] = { mode, secretKey };
             }
         });
@@ -122,6 +126,7 @@ class AccountingSyncConfig {
         secretsEnv.split(',').forEach(entry => {
             const [accountId, secret] = entry.trim().split(':');
             if (accountId && secret) {
+                registerSecretValue(secret);
                 secrets[accountId] = secret;
             }
         });


### PR DESCRIPTION
## Summary
- add a secret redaction utility and preflight bootstrapping so environment-provided secrets are resolved via process.env and ready for Azure App Config/Key Vault references
- sanitize health check responses and logs to redact registered secrets, and register parsed secrets from accounting sync configuration
- strengthen unit coverage for the health check redaction path and load the payout sync handler through its function entry to mirror production wiring

## Testing
- npm run build
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68e82f0ace98832ca084c1da4c50647a