### PR TITLE
Link CRM contacts to pending transaction creation

### DIFF
--- a/__tests__/processTransaction.test.js
+++ b/__tests__/processTransaction.test.js
@@ -98,6 +98,7 @@ describe('processTransaction', () => {
         process.env.SALESFORCE_PASSWORD = 'password123';
 
         const upsertMock = vi.fn().mockResolvedValue({ success: true, id: 'txn_test' });
+        const createTransactionMock = vi.fn().mockResolvedValue({ Id: 'a1TTEST' });
         const crmServiceMock = {
             searchContact: vi.fn().mockResolvedValue([]),
             createContact: vi.fn().mockResolvedValue({
@@ -107,7 +108,8 @@ describe('processTransaction', () => {
                 Email: 'donor@example.com'
             }),
             updateContact: vi.fn(),
-            upsertTransactionsRecord: upsertMock
+            upsertTransactionsRecord: upsertMock,
+            createTransaction: createTransactionMock
         };
 
         const CrmFactory = require('../dist/services/salesforce/crmFactory');
@@ -133,12 +135,86 @@ describe('processTransaction', () => {
 
         await handler(context, req);
 
+        expect(createTransactionMock).toHaveBeenCalledWith(
+            '003TEST',
+            expect.objectContaining({
+                amount: 7500,
+                currency: 'usd',
+                paymentMethod: 'Pending',
+                sessionId: 'cs_test',
+                status: 'Pending'
+            })
+        );
+
         expect(upsertMock).toHaveBeenCalledWith(
             {
                 stripe_checkout_session_id__c: 'cs_test',
                 transaction_type__c: 'charge',
                 status__c: 'pending',
                 attribution__c: 'referral-program'
+            },
+            'stripe_checkout_session_id__c'
+        );
+    });
+
+    it('skips pending transaction creation when no CRM contact is available', async () => {
+        const stripeMock = {
+            customers: {
+                search: vi.fn().mockResolvedValue({ data: [] }),
+                create: vi.fn().mockResolvedValue({ id: 'cus_test' }),
+                update: vi.fn().mockResolvedValue({ id: 'cus_test' })
+            },
+            checkout: {
+                sessions: {
+                    create: vi.fn().mockResolvedValue({
+                        id: 'cs_test',
+                        url: 'https://stripe.test/session'
+                    })
+                }
+            }
+        };
+
+        internals.setStripeClientFactory(() => stripeMock);
+
+        process.env.CRM_PROVIDER = 'salesforce';
+        process.env.SALESFORCE_USERNAME = 'test@example.com';
+        process.env.SALESFORCE_PASSWORD = 'password123';
+
+        const upsertMock = vi.fn().mockResolvedValue({ success: true, id: 'txn_test' });
+        const createTransactionMock = vi.fn();
+        const crmServiceMock = {
+            searchContact: vi.fn().mockResolvedValue([]),
+            createContact: vi.fn().mockRejectedValue(new Error('Contact creation failed')),
+            updateContact: vi.fn(),
+            upsertTransactionsRecord: upsertMock,
+            createTransaction: createTransactionMock
+        };
+
+        const CrmFactory = require('../dist/services/salesforce/crmFactory');
+        vi.spyOn(CrmFactory, 'validateConfig').mockReturnValue({ isValid: true });
+        vi.spyOn(CrmFactory, 'createCrmService').mockReturnValue(crmServiceMock);
+
+        const { context } = createContext();
+        const req = {
+            body: {
+                amount: 5000,
+                frequency: 'onetime',
+                customer: {
+                    email: 'donor@example.com',
+                    firstName: 'Donor',
+                    lastName: 'Example'
+                }
+            }
+        };
+
+        await handler(context, req);
+
+        expect(createTransactionMock).not.toHaveBeenCalled();
+        expect(upsertMock).toHaveBeenCalledWith(
+            {
+                stripe_checkout_session_id__c: 'cs_test',
+                transaction_type__c: 'charge',
+                status__c: 'pending'
             },
             'stripe_checkout_session_id__c'
         );

--- a/src/handlers/processTransaction.js
+++ b/src/handlers/processTransaction.js
@@ -498,6 +498,11 @@ const syncContactToCrm = async (context, customerData) => {
 // Create pending transaction in CRM after checkout session is created
 const createPendingTransaction = async (context, session, contactId, transactionData) => {
     try {
+        if (!contactId) {
+            context.log('No contact ID provided - skipping pending transaction creation');
+            return null;
+        }
+
         const crmConfig = getCrmConfig();
 
         if (!crmConfig) {
@@ -874,9 +879,15 @@ module.exports = async function (context, req) {
 
         // Sync contact to CRM (Salesforce) if configured
         // This happens after checkout session creation to not block the payment flow
-        await syncContactToCrm(context, customerDetails);
+        const contact = await syncContactToCrm(context, customerDetails);
 
-        // Upsert pending transaction in CRM
+        if (contact?.Id) {
+            await createPendingTransaction(context, session, contact.Id, requestData);
+        } else {
+            context.log('No CRM contact available - skipping pending transaction creation');
+        }
+
+        // Upsert pending transaction in CRM as a fallback
         await upsertSalesforceTransaction(context, session, requestData);
 
         // Return success response with checkout URL


### PR DESCRIPTION
## Summary
- capture the synced CRM contact and pass its ID when creating pending transactions
- skip pending transaction creation when no contact ID is available while keeping the existing upsert fallback
- update the processTransaction unit tests to cover contact-aware transaction creation scenarios

## Testing
- npm run test:unit -- processTransaction.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e863f9af64832ca33ac87255c25026