### PR TITLE
Add transaction and customer detail to QBO journal descriptions

### DIFF
--- a/src/services/payoutRecon/payoutSyncService.js
+++ b/src/services/payoutRecon/payoutSyncService.js
@@ -583,16 +583,42 @@ class PayoutSyncService {
                 }
 
                 for (const line of lines) {
+                    const metadata = line.metadata || {};
+                    const entity = line.entity || {};
+
+                    const chargeIdentifier = metadata.chargeId
+                        || metadata.paymentIntentId
+                        || metadata.source
+                        || (typeof line.name === 'string' && line.name.trim().length > 0 ? line.name.trim() : null);
+
+                    const customerName = metadata.customerName
+                        || (typeof entity.name === 'string' ? entity.name : null);
+                    const customerEmail = metadata.customerEmail
+                        || (typeof entity.email === 'string' ? entity.email : null);
+                    const stripeCustomerId = metadata.stripeCustomerId
+                        || (typeof entity.stripeCustomerId === 'string' ? entity.stripeCustomerId : null);
+
+                    let customerSegment = null;
+                    if (customerName && customerEmail) {
+                        customerSegment = `Customer: ${customerName} <${customerEmail}>`;
+                    } else if (customerName) {
+                        customerSegment = `Customer: ${customerName}`;
+                    } else if (customerEmail) {
+                        customerSegment = `Customer email: ${customerEmail}`;
+                    }
+
+                    const customerIdSegment = stripeCustomerId ? `Customer ID: ${stripeCustomerId}` : null;
+
                     const detailSegments = [
-                        line.metadata && line.metadata.balanceTransactionId
-                            ? `Transaction: ${line.metadata.balanceTransactionId}`
+                        metadata.balanceTransactionId
+                            ? `Transaction: ${metadata.balanceTransactionId}`
                             : null,
-                        (!usePerTransactionLines && line.metadata && (line.metadata.chargeId || line.metadata.paymentIntentId || line.metadata.source))
-                            ? `Source: ${line.metadata.chargeId || line.metadata.paymentIntentId || line.metadata.source}`
-                            : null,
+                        chargeIdentifier ? `Charge: ${chargeIdentifier}` : null,
+                        customerSegment,
+                        customerIdSegment,
                         formatCurrency(line.amount) ? `Amount: ${formatCurrency(line.amount)}` : null,
-                        (!usePerTransactionLines && line.metadata && line.metadata.component)
-                            ? `Component: ${line.metadata.component}`
+                        (!usePerTransactionLines && metadata.component)
+                            ? `Component: ${metadata.component}`
                             : null
                     ];
 

--- a/tests/payoutSync.test.js
+++ b/tests/payoutSync.test.js
@@ -673,6 +673,15 @@ async function runTests() {
                 currency: 'usd',
                 description: 'Donation A',
                 source: 'ch_123',
+                customer: {
+                    id: 'cus_txn_1',
+                    name: 'Ada Lovelace',
+                    email: 'ada@example.com'
+                },
+                billing_details: {
+                    name: 'Ada Lovelace',
+                    email: 'ada@example.com'
+                },
                 metadata: { donationId: 'don_1' },
                 created: baseTime - 3600,
                 available_on: baseTime,
@@ -749,6 +758,9 @@ async function runTests() {
             'Donation A',
             'Gross: $50.00, Fees: $1.50, Net: $48.50',
             'Transaction: txn_charge_1',
+            'Charge: ch_123',
+            'Customer: Ada Lovelace <ada@example.com>',
+            'Customer ID: cus_txn_1',
             'Amount: $48.50'
         ].join(' | ');
 


### PR DESCRIPTION
## Summary
- include transaction, charge, and customer context when building per-transaction QuickBooks journal line descriptions
- extend payout sync test coverage to assert the richer journal descriptions and sample customer data

## Testing
- npm run build
- node tests/payoutSync.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ea35cbff68832ca722eb1ca543a3b4