### PR TITLE
Add QuickBooks item configuration for sales receipts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       QBO_CLIENT_SECRET: ${{ secrets.QBO_CLIENT_SECRET }}
       QBO_COMPANY_ID: ${{ secrets.QBO_COMPANY_ID }}
       QBO_ENV: ${{ secrets.QBO_ENV }}
+      QBO_ITEM_REVENUE: ${{ secrets.QBO_ITEM_REVENUE }}
       QBO_REALM_ID: ${{ secrets.QBO_REALM_ID }}
       QBO_REFRESH_TOKEN: ${{ secrets.QBO_REFRESH_TOKEN }}
       SALESFORCE_CONTACT_LEAD_SOURCE: ${{ secrets.SALESFORCE_CONTACT_LEAD_SOURCE }}

--- a/README.md
+++ b/README.md
@@ -88,20 +88,20 @@ Copy the template in `local.settings.json.template` and populate the following k
 | `QBO_ACCOUNT_STRIPE_CLEARING` | QuickBooks ID (or `Name|ID`) of the Stripe clearing account. |
 | `QBO_ACCOUNT_OPERATING_BANK` | QuickBooks ID (or `Name|ID`) of the operating bank account. |
 | `QBO_ACCOUNT_REVENUE` | QuickBooks ID (or `Name|ID`) for revenue recognition. |
+| `QBO_ITEM_REVENUE` | QuickBooks product/service item ID (or `Name|ID`) used on sales receipts. |
 | `QBO_ACCOUNT_FEES` | QuickBooks ID (or `Name|ID`) for Stripe fee expense. |
 | `QBO_ACCOUNT_REFUNDS` | QuickBooks ID (or `Name|ID`) for refunds liability. |
 | `QBO_ACCOUNT_DISPUTES` | QuickBooks ID (or `Name|ID`) for dispute losses. |
 | `ACCOUNTING_SYNC_ENABLED` | Set to `true` to post into accounting after validation. |
 | `ACCOUNTING_POSTING_STRATEGY` | Chooses how transactions post into QuickBooks. |
 
-When specifying account mappings you should provide the QuickBooks account ID.
+When specifying account or item mappings you should provide the QuickBooks ID.
 You can either supply the raw ID (for example, `123`) or a `Name|ID` pair such
 as `Stripe Clearing|123`. JSON strings of the form `{"value":"123","name":"Stripe
 Clearing"}` are also accepted. If only a name is supplied the service will
 attempt to resolve the ID by querying QuickBooks before submitting the
-transaction. This adds an extra API call and will fail if the account name is
-ambiguous or missing, so providing the ID up front is still strongly
-recommended.
+transaction. This adds an extra API call and will fail if the name is ambiguous
+or missing, so providing the ID up front is still strongly recommended.
 
 ### Salesforce field mapping
 

--- a/__tests__/qboSvc.test.ts
+++ b/__tests__/qboSvc.test.ts
@@ -11,6 +11,10 @@ const defaultAccounts = {
   disputeLosses: 'Dispute Losses|QBO_ACCOUNT_DISPUTE_LOSSES',
 };
 
+const defaultItems = {
+  revenue: 'Stripe Sales Item|QBO_ITEM_REVENUE',
+};
+
 const baseEnv = {
   quickBooks: {
     environment: 'sandbox',
@@ -19,6 +23,7 @@ const baseEnv = {
     clientSecret: 'secret',
     refreshToken: 'refresh',
     accounts: { ...defaultAccounts },
+    items: { ...defaultItems },
   },
   accounting: {
     postingStrategy: 'sales-receipt',
@@ -34,6 +39,7 @@ const importQboSvc = async () => {
 
 const resetAccounts = () => {
   Object.assign(baseEnv.quickBooks.accounts, defaultAccounts);
+  Object.assign(baseEnv.quickBooks.items, defaultItems);
 };
 
 const resetTokens = () => {
@@ -163,6 +169,10 @@ describe('postChargeToQbo', () => {
       value: 'QBO_ACCOUNT_STRIPE_CLEARING',
       name: 'Stripe Clearing',
     });
+    expect(salesReceiptBody.Line[0].SalesItemLineDetail.ItemRef).toMatchObject({
+      value: 'QBO_ITEM_REVENUE',
+      name: 'Stripe Sales Item',
+    });
 
     const feeJournalBody = JSON.parse((feeJournalRequest.init?.body ?? '{}') as string);
     const feeLines = feeJournalBody.Line.map((line: any) => ({
@@ -280,12 +290,50 @@ describe('postChargeToQbo', () => {
       value: '999',
       name: 'Stripe Clearing',
     });
+    expect(salesReceiptBody.Line[0].SalesItemLineDetail.ItemRef).toMatchObject({
+      value: 'QBO_ITEM_REVENUE',
+      name: 'Stripe Sales Item',
+    });
 
     const journalBody = JSON.parse((requests[2].init?.body ?? '{}') as string);
     const clearingLine = journalBody.Line.find(
       (line: any) => line.JournalEntryLineDetail.AccountRef.name === 'Stripe Clearing',
     );
     expect(clearingLine?.JournalEntryLineDetail.AccountRef.value).toBe('999');
+  });
+
+  it('looks up item IDs when configuration only provides a name', async () => {
+    baseEnv.accounting.postingStrategy = 'sales-receipt';
+    baseEnv.quickBooks.items.revenue = 'Stripe Sales Item';
+    const { fetcher, requests } = createFetchMock(
+      {
+        QueryResponse: {
+          Item: [{ Id: '123', Name: 'Stripe Sales Item' }],
+        },
+      },
+      { SalesReceipt: { Id: 'sr-3' } },
+      { JournalEntry: { Id: 'fee-je-3' } },
+    );
+    const { postChargeToQbo } = await importQboSvc();
+
+    const result = await postChargeToQbo({
+      gross: 8_000,
+      fee: 300,
+      memo: 'Item lookup memo',
+      date: new Date('2024-06-01'),
+      options: { fetcher, accessToken: 'token' },
+    });
+
+    expect(result).toEqual({ qboId: 'sr-3', type: 'sales-receipt' });
+    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(requests[0].url).toContain('/query?query=');
+    expect(requests[0].init?.method).toBe('GET');
+
+    const salesReceiptBody = JSON.parse((requests[1].init?.body ?? '{}') as string);
+    expect(salesReceiptBody.Line[0].SalesItemLineDetail.ItemRef).toMatchObject({
+      value: '123',
+      name: 'Stripe Sales Item',
+    });
   });
 
   it('throws a helpful error when QuickBooks cannot resolve the configured account name', async () => {

--- a/docs/END_TO_END_TESTING.md
+++ b/docs/END_TO_END_TESTING.md
@@ -50,6 +50,7 @@ that mirror those tenants.
 | `QBO_REFRESH_TOKEN` | Refresh token paired with the access token. |
 | `QBO_REALM_ID` | QuickBooks company id. |
 | `QBO_ENV` | `sandbox` or `production`. |
+| `QBO_ITEM_REVENUE` | QuickBooks product/service item ID used for sales receipts. |
 | `AZURE_TABLES_CONNECTION_STRING` | Backing store for webhook idempotency keys. |
 
 > ⚠️ **Important:** The script refuses to run if any of the variables above are

--- a/local.settings.json.example
+++ b/local.settings.json.example
@@ -31,6 +31,7 @@
     "QBO_ACCOUNT_STRIPE_CLEARING": "Stripe Clearing|123",
     "QBO_ACCOUNT_OPERATING_BANK": "Operating Bank|456",
     "QBO_ACCOUNT_REVENUE": "Revenue|789",
+    "QBO_ITEM_REVENUE": "Stripe Sales Item|987",
     "QBO_ACCOUNT_FEES": "Stripe Fees|321",
     "ACCOUNTING_POSTING_STRATEGY": "je-transfer",
     "ACCOUNTING_SYNC_ENABLED": "false",

--- a/local.settings.json.template
+++ b/local.settings.json.template
@@ -35,6 +35,7 @@
     "QBO_ACCOUNT_STRIPE_CLEARING": "Stripe Clearing|123",
     "QBO_ACCOUNT_OPERATING_BANK": "Operating Bank|456",
     "QBO_ACCOUNT_REVENUE": "Revenue|789",
+    "QBO_ITEM_REVENUE": "Stripe Sales Item|987",
     "QBO_ACCOUNT_FEES": "Stripe Fees|321",
     "ACCOUNTING_POSTING_STRATEGY": "je-transfer",
     "ACCOUNTING_SYNC_ENABLED": "false",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -30,6 +30,9 @@ export interface EnvConfig {
       refunds: string;
       disputeLosses: string;
     };
+    items?: {
+      revenue?: string;
+    };
   };
   accounting: {
     postingStrategy: AccountingPostingStrategy;
@@ -193,6 +196,11 @@ function loadEnv(): EnvConfig {
           defaultValue: 'Dispute Losses',
         }) ?? 'Dispute Losses',
     },
+    items: {
+      revenue: resolveEnv('QBO_ITEM_REVENUE', {
+        fallbackNames: ['ACCOUNTING_REVENUE_ITEM'],
+      }),
+    },
   };
 
   const quickBooksSchema = z.object({
@@ -209,6 +217,11 @@ function loadEnv(): EnvConfig {
       refunds: z.string().min(1),
       disputeLosses: z.string().min(1),
     }),
+    items: z
+      .object({
+        revenue: z.string().min(1).optional(),
+      })
+      .optional(),
   });
 
   const quickBooks = quickBooksSchema.parse(quickBooksRaw);
@@ -245,6 +258,13 @@ function loadEnv(): EnvConfig {
     }
   }
 
+  if (postingStrategy.success && postingStrategy.data === 'sales-receipt') {
+    const revenueItem = quickBooks.items?.revenue?.trim();
+    if (!revenueItem) {
+      missing.push('QBO_ITEM_REVENUE');
+    }
+  }
+
   const appInsightsInstrumentationKey = resolveEnv('APPINSIGHTS_INSTRUMENTATIONKEY', {
     fallbackNames: ['APPINSIGHTS_INSTRUMENTATION_KEY'],
   });
@@ -278,6 +298,7 @@ function loadEnv(): EnvConfig {
       clientSecret: quickBooks.clientSecret,
       refreshToken: quickBooks.refreshToken,
       accounts: quickBooks.accounts,
+      items: quickBooks.items,
     },
     accounting: {
       postingStrategy: (postingStrategy.success

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -32,6 +32,17 @@ type AccountRefWithMetadata = QuickBooksReference & {
   [ACCOUNT_LOOKUP_METADATA]?: AccountRefLookupMetadata;
 };
 
+type ItemRefLookupMetadata = {
+  original: string;
+  lookupName: string;
+};
+
+const ITEM_LOOKUP_METADATA: unique symbol = Symbol('QuickBooksItemLookup');
+
+type ItemRefWithMetadata = QuickBooksReference & {
+  [ITEM_LOOKUP_METADATA]?: ItemRefLookupMetadata;
+};
+
 interface QuickBooksSalesItemLineDetail {
   ItemRef: QuickBooksReference;
   ItemAccountRef?: QuickBooksReference;
@@ -108,6 +119,7 @@ interface BuildSalesReceiptInput {
   memo?: string;
   date: string | Date;
   revenueAccountName?: string;
+  revenueItemName?: string;
   depositAccountName?: string;
 }
 
@@ -184,10 +196,37 @@ const normalizeDate = (value: string | Date): string => {
   return date.toISOString().slice(0, 10);
 };
 
-const parseDelimitedAccount = (
+type ReferenceType = 'account' | 'item';
+
+const ensureReferenceValue = <T extends QuickBooksReference>(
+  ref: T,
+  original: string,
+  type: ReferenceType,
+): T => {
+  const value = typeof ref.value === 'string' ? ref.value.trim() : '';
+  if (!value) {
+    throw new Error(
+      `QuickBooks ${type} reference configuration is missing an ID: "${original}".`,
+    );
+  }
+
+  const normalized: QuickBooksReference = { value };
+
+  if (typeof ref.name === 'string') {
+    const name = ref.name.trim();
+    if (name) {
+      normalized.name = name;
+    }
+  }
+
+  return { ...ref, ...normalized } as T;
+};
+
+const parseDelimitedReference = (
   raw: string,
   delimiter: string,
-): AccountRefWithMetadata | null => {
+  type: ReferenceType,
+): QuickBooksReference | null => {
   const index = raw.indexOf(delimiter);
   if (index === -1) {
     return null;
@@ -197,11 +236,11 @@ const parseDelimitedAccount = (
   const right = raw.slice(index + delimiter.length).trim();
   if (!right) {
     throw new Error(
-      'QuickBooks account reference delimiter provided without an ID value.',
+      `QuickBooks ${type} reference delimiter provided without an ID value.`,
     );
   }
 
-  const reference: AccountRefWithMetadata = {
+  const reference: QuickBooksReference = {
     value: right,
     name: left || undefined,
   };
@@ -209,70 +248,91 @@ const parseDelimitedAccount = (
   return reference;
 };
 
-const ensureAccountRefValue = (
-  ref: AccountRefWithMetadata,
-  original: string,
-): AccountRefWithMetadata => {
-  const value = ref.value.trim();
-  if (!value) {
-    throw new Error(
-      `QuickBooks account reference configuration is missing an ID: "${original}".`,
-    );
-  }
-
-  return { ...ref, value };
-};
-
-const createAccountRef = (input: string): AccountRefWithMetadata => {
+const parseReferenceInput = (
+  input: string,
+  type: ReferenceType,
+): { reference: QuickBooksReference; lookupName?: string } => {
   const trimmed = input.trim();
   if (!trimmed) {
-    throw new Error('QuickBooks account name must be provided.');
+    throw new Error(`QuickBooks ${type} reference must be provided.`);
   }
 
   if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
     try {
       const parsed = JSON.parse(trimmed);
       if (!parsed || typeof parsed !== 'object') {
-        throw new Error('Invalid QuickBooks account reference JSON.');
+        throw new Error(`Invalid QuickBooks ${type} reference JSON.`);
       }
 
-      const value = typeof parsed.value === 'string' ? parsed.value.trim() : '';
-      const name = typeof parsed.name === 'string' ? parsed.name.trim() : undefined;
+      const value = typeof parsed.value === 'string' ? parsed.value : '';
+      const name = typeof parsed.name === 'string' ? parsed.name : undefined;
 
-      if (!value) {
-        throw new Error('QuickBooks account reference JSON must include a value.');
-      }
-
-      const reference: AccountRefWithMetadata = { value, name };
-      return reference;
+      const reference = ensureReferenceValue(
+        { value, name },
+        input,
+        type,
+      );
+      return { reference };
     } catch (error) {
       throw new Error(
         error instanceof Error
-          ? `Unable to parse QuickBooks account reference JSON: ${error.message}`
-          : 'Unable to parse QuickBooks account reference JSON.',
+          ? `Unable to parse QuickBooks ${type} reference JSON: ${error.message}`
+          : `Unable to parse QuickBooks ${type} reference JSON.`,
       );
     }
   }
 
   const delimiters = ['::', '|'];
   for (const delimiter of delimiters) {
-    const parsed = parseDelimitedAccount(trimmed, delimiter);
+    const parsed = parseDelimitedReference(trimmed, delimiter, type);
     if (parsed) {
-      return ensureAccountRefValue(parsed, input);
+      return {
+        reference: ensureReferenceValue(parsed, input, type),
+      };
     }
   }
 
   const isNumericId = /^\d+$/.test(trimmed);
   if (isNumericId) {
-    return ensureAccountRefValue({ value: trimmed }, input);
+    return {
+      reference: ensureReferenceValue({ value: trimmed }, input, type),
+    };
   }
 
-  const reference = ensureAccountRefValue({ value: trimmed, name: trimmed }, input);
-  reference[ACCOUNT_LOOKUP_METADATA] = {
-    original: input,
-    lookupName: trimmed,
-  };
-  return reference;
+  const reference = ensureReferenceValue(
+    { value: trimmed, name: trimmed },
+    input,
+    type,
+  );
+  return { reference, lookupName: trimmed };
+};
+
+const createAccountRef = (input: string): AccountRefWithMetadata => {
+  const { reference, lookupName } = parseReferenceInput(input, 'account');
+  const accountRef = reference as AccountRefWithMetadata;
+
+  if (lookupName) {
+    accountRef[ACCOUNT_LOOKUP_METADATA] = {
+      original: input,
+      lookupName,
+    };
+  }
+
+  return accountRef;
+};
+
+const createItemRef = (input: string): ItemRefWithMetadata => {
+  const { reference, lookupName } = parseReferenceInput(input, 'item');
+  const itemRef = reference as ItemRefWithMetadata;
+
+  if (lookupName) {
+    itemRef[ITEM_LOOKUP_METADATA] = {
+      original: input,
+      lookupName,
+    };
+  }
+
+  return itemRef;
 };
 
 const buildDocNumber = (prefix: string, date: string | Date, amountCents: number): string => {
@@ -291,11 +351,19 @@ export const buildSalesReceipt = ({
   memo,
   date,
   revenueAccountName = env.quickBooks.accounts.revenue,
+  revenueItemName = env.quickBooks.items?.revenue,
   depositAccountName = env.quickBooks.accounts.stripeClearing,
 }: BuildSalesReceiptInput): QuickBooksSalesReceipt => {
   const amount = ensurePositiveAmount(amountCents, 'Sales receipt amount');
   if (amount === 0) {
     throw new Error('Sales receipt amount must be greater than zero.');
+  }
+
+  const itemReference = revenueItemName?.trim();
+  if (!itemReference) {
+    throw new Error(
+      'QuickBooks revenue item reference must be provided for sales receipts.',
+    );
   }
 
   return {
@@ -309,7 +377,7 @@ export const buildSalesReceipt = ({
         DetailType: 'SalesItemLineDetail',
         Description: memo,
         SalesItemLineDetail: {
-          ItemRef: createAccountRef(revenueAccountName),
+          ItemRef: createItemRef(itemReference),
           ItemAccountRef: createAccountRef(revenueAccountName),
         },
       },
@@ -468,6 +536,7 @@ const buildQboUrl = (entity: string): string => {
 };
 
 const accountLookupCache = new Map<string, string>();
+const itemLookupCache = new Map<string, string>();
 
 const QUICKBOOKS_TOKEN_URL =
   'https://oauth.platform.intuit.com/oauth2/v1/tokens/bearer';
@@ -695,54 +764,64 @@ const resolveAccountId = async (
   return id;
 };
 
-const collectAccountReferences = (
+type ReferenceCollections = {
+  accounts: AccountRefWithMetadata[];
+  items: ItemRefWithMetadata[];
+};
+
+const collectReferences = (
   entity: QuickBooksDocType,
   payload: QuickBooksSalesReceipt | QuickBooksJournalEntry | QuickBooksBankDeposit,
-): AccountRefWithMetadata[] => {
-  const references: AccountRefWithMetadata[] = [];
+): ReferenceCollections => {
+  const accounts: AccountRefWithMetadata[] = [];
+  const items: ItemRefWithMetadata[] = [];
 
-  const addRef = (ref: QuickBooksReference | undefined) => {
+  const addAccountRef = (ref: QuickBooksReference | undefined) => {
     if (ref) {
-      references.push(ref as AccountRefWithMetadata);
+      accounts.push(ref as AccountRefWithMetadata);
+    }
+  };
+
+  const addItemRef = (ref: QuickBooksReference | undefined) => {
+    if (ref) {
+      items.push(ref as ItemRefWithMetadata);
     }
   };
 
   if (entity === 'sales-receipt') {
     const receipt = payload as QuickBooksSalesReceipt;
-    addRef(receipt.DepositToAccountRef);
+    addAccountRef(receipt.DepositToAccountRef);
     for (const line of receipt.Line) {
       if (line.DetailType === 'SalesItemLineDetail') {
-        addRef(line.SalesItemLineDetail.ItemRef);
-        addRef(line.SalesItemLineDetail.ItemAccountRef);
-        addRef(line.SalesItemLineDetail.TaxCodeRef);
+        addItemRef(line.SalesItemLineDetail.ItemRef);
+        addAccountRef(line.SalesItemLineDetail.ItemAccountRef);
+        addAccountRef(line.SalesItemLineDetail.TaxCodeRef);
       }
     }
   } else if (entity === 'journal-entry') {
     const journal = payload as QuickBooksJournalEntry;
     for (const line of journal.Line) {
       if (line.DetailType === 'JournalEntryLineDetail') {
-        addRef(line.JournalEntryLineDetail.AccountRef);
+        addAccountRef(line.JournalEntryLineDetail.AccountRef);
       }
     }
   } else {
     const deposit = payload as QuickBooksBankDeposit;
-    addRef(deposit.DepositToAccountRef);
+    addAccountRef(deposit.DepositToAccountRef);
     for (const line of deposit.Line) {
       if (line.DetailType === 'DepositLineDetail') {
-        addRef(line.DepositLineDetail.AccountRef);
+        addAccountRef(line.DepositLineDetail.AccountRef);
       }
     }
   }
 
-  return references;
+  return { accounts, items };
 };
 
 const resolveAccountReferences = async (
-  entity: QuickBooksDocType,
-  payload: QuickBooksSalesReceipt | QuickBooksJournalEntry | QuickBooksBankDeposit,
+  references: AccountRefWithMetadata[],
   context: QuickBooksRequestContext,
 ): Promise<void> => {
-  const references = collectAccountReferences(entity, payload);
   const lookups = new Map<string, AccountRefWithMetadata[]>();
 
   for (const ref of references) {
@@ -777,6 +856,140 @@ const resolveAccountReferences = async (
   }
 };
 
+const getItemLookupName = (ref: ItemRefWithMetadata): string | undefined => {
+  const metadata = ref[ITEM_LOOKUP_METADATA];
+  if (metadata?.lookupName) {
+    return metadata.lookupName;
+  }
+  if (ref.name) {
+    return ref.name;
+  }
+  const value = ref.value.trim();
+  if (value.length > 0) {
+    return value;
+  }
+  return undefined;
+};
+
+const isItemLookupRequired = (ref: ItemRefWithMetadata): boolean => {
+  return Boolean(ref[ITEM_LOOKUP_METADATA]);
+};
+
+const resolveItemId = async (
+  name: string,
+  context: QuickBooksRequestContext,
+): Promise<string> => {
+  const cacheKey = `${env.quickBooks.environment}:${env.quickBooks.realmId ?? ''}:item:${name.toLowerCase()}`;
+  const cached = itemLookupCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  const query = `select Id, Name from Item where Name = '${escapeQueryValue(name)}'`;
+  const url = buildQboQueryUrl(query);
+  const response = await context.request(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+    throw new Error(
+      `Failed to resolve QuickBooks item "${name}" (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const queryResponse = (data as Record<string, unknown>).QueryResponse;
+  const items =
+    queryResponse && typeof queryResponse === 'object'
+      ? (queryResponse as Record<string, unknown>).Item
+      : undefined;
+  const itemList = Array.isArray(items)
+    ? items
+    : items
+    ? [items]
+    : [];
+
+  const match = itemList.find((item) => {
+    if (!item || typeof item !== 'object') {
+      return false;
+    }
+    const itemName = (item as Record<string, unknown>).Name;
+    if (typeof itemName !== 'string') {
+      return false;
+    }
+    return itemName.trim().toLowerCase() === name.trim().toLowerCase();
+  }) ?? itemList[0];
+
+  if (!match || typeof match !== 'object') {
+    throw new Error(
+      `QuickBooks item "${name}" could not be found. ` +
+        'Provide the item ID in configuration or ensure the item exists in QuickBooks.',
+    );
+  }
+
+  const idValue = (match as Record<string, unknown>).Id;
+  if (typeof idValue !== 'string' && typeof idValue !== 'number') {
+    throw new Error(
+      `QuickBooks item "${name}" does not provide a usable ID. ` +
+        'Update the configuration to include the item ID.',
+    );
+  }
+
+  const id = typeof idValue === 'number' ? idValue.toString() : idValue.trim();
+  if (!id) {
+    throw new Error(
+      `QuickBooks item "${name}" returned an empty ID. Update the configuration to include the item ID.`,
+    );
+  }
+
+  itemLookupCache.set(cacheKey, id);
+  return id;
+};
+
+const resolveItemReferences = async (
+  references: ItemRefWithMetadata[],
+  context: QuickBooksRequestContext,
+): Promise<void> => {
+  const lookups = new Map<string, ItemRefWithMetadata[]>();
+
+  for (const ref of references) {
+    if (!isItemLookupRequired(ref)) {
+      continue;
+    }
+
+    const lookupName = getItemLookupName(ref);
+    if (!lookupName) {
+      throw new Error(
+        'QuickBooks item configuration must include an ID. ' +
+          'Provide an "Item Name|Item ID" pair or a JSON string with a "value" field.',
+      );
+    }
+
+    const normalizedName = lookupName.trim();
+    if (!lookups.has(normalizedName)) {
+      lookups.set(normalizedName, []);
+    }
+    lookups.get(normalizedName)?.push(ref);
+  }
+
+  for (const [name, refs] of lookups.entries()) {
+    const id = await resolveItemId(name, context);
+    for (const ref of refs) {
+      ref.value = id;
+      if (!ref.name) {
+        ref.name = name;
+      }
+      delete ref[ITEM_LOOKUP_METADATA];
+    }
+  }
+};
+
 const postToQbo = async <T extends QuickBooksDocType>(
   entity: T,
   payload: T extends 'sales-receipt'
@@ -795,7 +1008,9 @@ const postToQbo = async <T extends QuickBooksDocType>(
   );
   const context = createRequestContext(options);
 
-  await resolveAccountReferences(entity, payload, context);
+  const references = collectReferences(entity, payload);
+  await resolveAccountReferences(references.accounts, context);
+  await resolveItemReferences(references.items, context);
 
   const response = await context.request(url, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- require a configurable QuickBooks revenue item when using the sales-receipt posting strategy
- build sales receipts with item references and resolve missing item IDs before posting to QuickBooks
- document the new configuration and extend unit tests to cover item lookups

## Testing
- `npm run typecheck` *(fails: missing local dependencies such as zod/applicationinsights)*
- `npm run test:unit` *(fails: vitest binary not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ea48c10530832caf7a4a963dcdcd42