### PR TITLE
Ensure QuickBooks sales receipts include Stripe customer data

### DIFF
--- a/__tests__/qboSvc.test.ts
+++ b/__tests__/qboSvc.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import type Stripe from 'stripe';
 
 type RequestRecord = { url: string; init: any };
 
@@ -134,6 +135,45 @@ const createFetchMock = (...payloads: unknown[]) => {
   return { fetcher, requests };
 };
 
+const createStripeCharge = (overrides: Partial<Stripe.Charge> = {}): Stripe.Charge => {
+  const base: Partial<Stripe.Charge> = {
+    id: 'ch_test',
+    billing_details: {
+      name: 'Donor Example',
+      email: 'donor@example.com',
+      phone: '555-0100',
+      address: {
+        line1: '123 Donation Ave',
+        line2: 'Suite 100',
+        city: 'Givington',
+        state: 'CA',
+        postal_code: '94105',
+        country: 'US',
+      },
+    },
+    shipping: {
+      name: 'Donor Example',
+      phone: '555-0100',
+      address: {
+        line1: '123 Donation Ave',
+        line2: 'Suite 100',
+        city: 'Givington',
+        state: 'CA',
+        postal_code: '94105',
+        country: 'US',
+      },
+    },
+  };
+
+  return { ...base, ...overrides } as Stripe.Charge;
+};
+
+const buildStripeContext = (chargeOverrides: Partial<Stripe.Charge> = {}) => ({
+  charge: createStripeCharge(chargeOverrides),
+  paymentIntent: null,
+  customer: null,
+});
+
 afterEach(() => {
   vi.clearAllMocks();
   baseEnv.accounting.postingStrategy = 'sales-receipt';
@@ -145,6 +185,9 @@ describe('postChargeToQbo', () => {
   it('posts sales receipt to clearing account and creates fee journal entry when using sales receipt strategy', async () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
     const { fetcher, requests } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-1', DisplayName: 'Donor Example' } },
       { SalesReceipt: { Id: 'sr-1' } },
       { JournalEntry: { Id: 'fee-je-1' } },
     );
@@ -155,16 +198,37 @@ describe('postChargeToQbo', () => {
       fee: 325,
       memo: 'Charge memo',
       date: new Date('2024-03-01'),
+      stripe: buildStripeContext(),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-1', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(2);
-    const [salesReceiptRequest, feeJournalRequest] = requests;
-    expect(salesReceiptRequest.url).toContain('salesreceipt');
-    expect(feeJournalRequest.url).toContain('journalentry');
+    expect(fetcher).toHaveBeenCalledTimes(5);
 
-    const salesReceiptBody = JSON.parse((salesReceiptRequest.init?.body ?? '{}') as string);
+    const [emailLookupRequest, nameLookupRequest, customerCreateRequest] = requests;
+    expect(emailLookupRequest.url).toContain('/query?query=');
+    expect(nameLookupRequest.url).toContain('/query?query=');
+    expect(customerCreateRequest.url).toContain('/customer');
+    expect(customerCreateRequest.init?.method).toBe('POST');
+
+    const customerBody = JSON.parse((customerCreateRequest.init?.body ?? '{}') as string);
+    expect(customerBody).toMatchObject({
+      DisplayName: 'Donor Example',
+      PrimaryEmailAddr: { Address: 'donor@example.com' },
+      BillAddr: expect.objectContaining({ Line1: '123 Donation Ave', City: 'Givington' }),
+    });
+
+    const salesReceiptRequest = requests.find((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    const feeJournalRequest = requests.find((request) =>
+      request.url.includes('journalentry'),
+    );
+
+    expect(salesReceiptRequest).toBeDefined();
+    expect(feeJournalRequest).toBeDefined();
+
+    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
     expect(salesReceiptBody.DepositToAccountRef).toMatchObject({
       value: 'QBO_ACCOUNT_STRIPE_CLEARING',
       name: 'Stripe Clearing',
@@ -173,8 +237,22 @@ describe('postChargeToQbo', () => {
       value: 'QBO_ITEM_REVENUE',
       name: 'Stripe Sales Item',
     });
+    expect(salesReceiptBody.CustomerRef).toMatchObject({
+      value: 'cust-1',
+      name: 'Donor Example',
+    });
+    expect(salesReceiptBody.BillEmail).toEqual({ Address: 'donor@example.com' });
+    expect(salesReceiptBody.BillAddr).toMatchObject({
+      Line1: '123 Donation Ave',
+      City: 'Givington',
+      PostalCode: '94105',
+    });
+    expect(salesReceiptBody.ShipAddr).toMatchObject({
+      Line1: '123 Donation Ave',
+      City: 'Givington',
+    });
 
-    const feeJournalBody = JSON.parse((feeJournalRequest.init?.body ?? '{}') as string);
+    const feeJournalBody = JSON.parse((feeJournalRequest?.init?.body ?? '{}') as string);
     const feeLines = feeJournalBody.Line.map((line: any) => ({
       type: line.JournalEntryLineDetail.PostingType,
       accountRef: line.JournalEntryLineDetail.AccountRef,
@@ -219,6 +297,9 @@ describe('postChargeToQbo', () => {
     };
 
     const { fetcher, requests } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-2', DisplayName: 'Donor Example' } },
       {
         ok: false,
         status: 400,
@@ -239,19 +320,25 @@ describe('postChargeToQbo', () => {
       fee: 0,
       memo: 'Charge memo',
       date: new Date('2024-04-01'),
+      stripe: buildStripeContext(),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-2', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(fetcher).toHaveBeenCalledTimes(6);
 
-    const [initialPost, itemLookup, retryPost] = requests;
-    expect(initialPost.url).toContain('salesreceipt');
-    expect(itemLookup.url).toContain('/query');
-    expect(retryPost.url).toContain('salesreceipt');
+    const salesReceiptRequests = requests.filter((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    expect(salesReceiptRequests).toHaveLength(2);
+    const [initialPost, retryPost] = salesReceiptRequests;
+    const itemLookup = requests.find(
+      (request) => request.url.includes('/query') && request !== requests[0] && request !== requests[1],
+    );
+    expect(itemLookup?.url).toContain('/query');
 
-    const initialBody = JSON.parse((initialPost.init?.body ?? '{}') as string);
-    const retryBody = JSON.parse((retryPost.init?.body ?? '{}') as string);
+    const initialBody = JSON.parse((initialPost?.init?.body ?? '{}') as string);
+    const retryBody = JSON.parse((retryPost?.init?.body ?? '{}') as string);
 
     expect(initialBody.Line[0].SalesItemLineDetail.ItemRef.value).toBe('STALE_ID');
     expect(retryBody.Line[0].SalesItemLineDetail.ItemRef.value).toBe('QBO_ITEM_REVENUE');
@@ -319,6 +406,9 @@ describe('postChargeToQbo', () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
     baseEnv.quickBooks.accounts.stripeClearing = 'Stripe Clearing';
     const { fetcher, requests } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-3', DisplayName: 'Donor Example' } },
       {
         QueryResponse: {
           Account: [{ Id: '999', Name: 'Stripe Clearing' }],
@@ -334,15 +424,27 @@ describe('postChargeToQbo', () => {
       fee: 325,
       memo: 'Lookup memo',
       date: new Date('2024-05-01'),
+      stripe: buildStripeContext(),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-2', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(3);
-    expect(requests[0].url).toContain('/query?query=');
-    expect(requests[0].init?.method).toBe('GET');
+    expect(fetcher).toHaveBeenCalledTimes(6);
 
-    const salesReceiptBody = JSON.parse((requests[1].init?.body ?? '{}') as string);
+    const accountLookupRequest = requests.find(
+      (request) => request.url.includes('/query?query=') && request !== requests[0] && request !== requests[1],
+    );
+    expect(accountLookupRequest?.url).toContain('/query?query=');
+    expect(accountLookupRequest?.init?.method).toBe('GET');
+
+    const salesReceiptRequest = requests.find((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    const journalRequest = requests.find((request) =>
+      request.url.includes('journalentry'),
+    );
+
+    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
     expect(salesReceiptBody.DepositToAccountRef).toMatchObject({
       value: '999',
       name: 'Stripe Clearing',
@@ -352,7 +454,7 @@ describe('postChargeToQbo', () => {
       name: 'Stripe Sales Item',
     });
 
-    const journalBody = JSON.parse((requests[2].init?.body ?? '{}') as string);
+    const journalBody = JSON.parse((journalRequest?.init?.body ?? '{}') as string);
     const clearingLine = journalBody.Line.find(
       (line: any) => line.JournalEntryLineDetail.AccountRef.name === 'Stripe Clearing',
     );
@@ -363,6 +465,9 @@ describe('postChargeToQbo', () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
     baseEnv.quickBooks.items.revenue = 'Stripe Sales Item';
     const { fetcher, requests } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-4', DisplayName: 'Donor Example' } },
       {
         QueryResponse: {
           Item: [{ Id: '123', Name: 'Stripe Sales Item' }],
@@ -378,15 +483,23 @@ describe('postChargeToQbo', () => {
       fee: 300,
       memo: 'Item lookup memo',
       date: new Date('2024-06-01'),
+      stripe: buildStripeContext(),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-3', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(3);
-    expect(requests[0].url).toContain('/query?query=');
-    expect(requests[0].init?.method).toBe('GET');
+    expect(fetcher).toHaveBeenCalledTimes(6);
 
-    const salesReceiptBody = JSON.parse((requests[1].init?.body ?? '{}') as string);
+    const itemLookupRequest = requests.find(
+      (request) => request.url.includes('/query?query=') && request !== requests[0] && request !== requests[1],
+    );
+    expect(itemLookupRequest?.url).toContain('/query?query=');
+    expect(itemLookupRequest?.init?.method).toBe('GET');
+
+    const salesReceiptRequest = requests.find((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
     expect(salesReceiptBody.Line[0].SalesItemLineDetail.ItemRef).toMatchObject({
       value: '123',
       name: 'Stripe Sales Item',
@@ -395,7 +508,12 @@ describe('postChargeToQbo', () => {
 
   it('throws a helpful error when QuickBooks cannot resolve the configured account name', async () => {
     baseEnv.quickBooks.accounts.stripeClearing = 'Stripe Clearing';
-    const { fetcher } = createFetchMock({ QueryResponse: { Account: [] } });
+    const { fetcher } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-err', DisplayName: 'Donor Example' } },
+      { QueryResponse: { Account: [] } },
+    );
     const { postChargeToQbo } = await importQboSvc();
 
     await expect(
@@ -404,6 +522,7 @@ describe('postChargeToQbo', () => {
         fee: 0,
         memo: 'Missing ID',
         date: new Date('2024-04-01'),
+        stripe: buildStripeContext(),
         options: { fetcher, accessToken: 'token' },
       }),
     ).rejects.toThrow(/could not be found/i);

--- a/__tests__/stripeWebhook.test.ts
+++ b/__tests__/stripeWebhook.test.ts
@@ -179,6 +179,13 @@ describe('stripeWebhook', () => {
       charges: {
         retrieve: vi.fn(),
       },
+      customers: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: 'cus_123',
+          name: 'Donor Example',
+          email: 'donor@example.com',
+        }),
+      },
       checkout: {
         sessions: {
           list: vi.fn().mockResolvedValue({
@@ -239,7 +246,16 @@ describe('stripeWebhook', () => {
       { overrideId: 'sf_existing' },
     );
     expect(accounting.postChargeToQbo).toHaveBeenCalledWith(
-      expect.objectContaining({ gross: 1_000, fee: 100 }),
+      expect.objectContaining({
+        gross: 1_000,
+        fee: 100,
+        stripe: expect.objectContaining({
+          charge: expect.objectContaining({ id: 'ch_test' }),
+          paymentIntent: expect.objectContaining({ id: 'pi_test' }),
+          customer: expect.objectContaining({ id: 'cus_123' }),
+          checkoutSession: expect.objectContaining({ id: 'cs_test' }),
+        }),
+      }),
     );
     expect(salesforce.markPostedToQbo).toHaveBeenCalledWith('sf_1', {
       id: '123',

--- a/src/handlers/stripeTrueUp.ts
+++ b/src/handlers/stripeTrueUp.ts
@@ -307,6 +307,46 @@ const ensureStripeBalanceTransaction = (
   return value;
 };
 
+const extractStripeId = (value: unknown): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object' && value !== null && 'id' in (value as Record<string, unknown>)) {
+    const idValue = (value as Record<string, unknown>).id;
+    return typeof idValue === 'string' ? idValue : null;
+  }
+
+  return null;
+};
+
+const resolveCustomerForCharge = async (
+  stripe: Stripe,
+  charge: Stripe.Charge,
+  logger: (...args: unknown[]) => void,
+): Promise<(Stripe.Customer | Stripe.DeletedCustomer) | null> => {
+  const customerId = extractStripeId(charge.customer);
+  if (!customerId) {
+    return null;
+  }
+
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    return customer as Stripe.Customer | Stripe.DeletedCustomer;
+  } catch (error) {
+    logger('[StripeTrueUp] Failed to retrieve Stripe customer', {
+      chargeId: charge.id,
+      customerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};
+
 const processPayments = async (
   context: HttpContext,
   stripe: Stripe,
@@ -370,6 +410,12 @@ const processPayments = async (
         );
         summary.salesforceUpdates += 1;
 
+        const stripeCustomer = await resolveCustomerForCharge(
+          stripe,
+          charge as Stripe.Charge,
+          context.log,
+        );
+
         const posting = await dependencies.accounting.postChargeToQbo({
           gross: Math.abs(balanceTransaction.amount ?? 0),
           fee: Math.abs(balanceTransaction.fee ?? 0),
@@ -377,6 +423,11 @@ const processPayments = async (
           date: timestampToDate(
             balanceTransaction.available_on ?? balanceTransaction.created ?? null,
           ),
+          stripe: {
+            charge: charge as Stripe.Charge,
+            paymentIntent: null,
+            customer: stripeCustomer,
+          },
         });
         summary.qboPosts += 1;
 

--- a/src/handlers/stripeWebhook.ts
+++ b/src/handlers/stripeWebhook.ts
@@ -345,6 +345,32 @@ const resolveBalanceTransaction = async (
   return null;
 };
 
+const resolveStripeCustomer = async (
+  stripe: Stripe,
+  charge: Stripe.Charge | null,
+  paymentIntent: Stripe.PaymentIntent | null,
+  logger: (...args: unknown[]) => void,
+): Promise<(Stripe.Customer | Stripe.DeletedCustomer) | null> => {
+  const customerId =
+    normalizeStripeId(charge?.customer) ||
+    normalizeStripeId(paymentIntent?.customer);
+
+  if (!customerId) {
+    return null;
+  }
+
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    return customer as Stripe.Customer | Stripe.DeletedCustomer;
+  } catch (error) {
+    logger('[StripeWebhook] Failed to retrieve Stripe customer', {
+      customerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};
+
 const findCheckoutSessionForPaymentIntent = async (
   stripe: Stripe,
   paymentIntentId: string | null | undefined,
@@ -504,6 +530,13 @@ const handlePaymentIntentSucceeded = async (
   await deps.idempotencyStore.withLock(
     `bt_${balanceTransactionId}`,
     async () => {
+      const stripeCustomer = await resolveStripeCustomer(
+        stripe,
+        charge,
+        paymentIntent,
+        context.log,
+      );
+
       const posting = await deps.accounting.postChargeToQbo({
         gross: Math.abs(balanceTransaction.amount ?? 0),
         fee: Math.abs(balanceTransaction.fee ?? 0),
@@ -511,6 +544,12 @@ const handlePaymentIntentSucceeded = async (
         date: timestampToDate(
           balanceTransaction.available_on ?? balanceTransaction.created ?? null,
         ),
+        stripe: {
+          charge: charge ?? undefined,
+          paymentIntent,
+          customer: stripeCustomer,
+          checkoutSession: checkoutSession ?? undefined,
+        },
       });
 
       await markPosted(salesforce, upsertResult, posting);

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'node:buffer';
 
+import type Stripe from 'stripe';
+
 import env from '../config/env';
 
 const QBO_BASE_URL: Record<'sandbox' | 'production', string> = {
@@ -45,6 +47,21 @@ type ItemRefWithMetadata = QuickBooksReference & {
   [ITEM_LOOKUP_METADATA]?: ItemRefLookupMetadata;
 };
 
+interface QuickBooksEmailAddress {
+  Address: string;
+}
+
+interface QuickBooksPhysicalAddress {
+  Line1?: string;
+  Line2?: string;
+  Line3?: string;
+  Line4?: string;
+  City?: string;
+  CountrySubDivisionCode?: string;
+  PostalCode?: string;
+  Country?: string;
+}
+
 interface QuickBooksSalesItemLineDetail {
   ItemRef: QuickBooksReference;
   ItemAccountRef?: QuickBooksReference;
@@ -63,6 +80,10 @@ export interface QuickBooksSalesReceipt {
   TxnDate: string;
   PrivateNote?: string;
   DepositToAccountRef: QuickBooksReference;
+  CustomerRef?: QuickBooksReference;
+  BillEmail?: QuickBooksEmailAddress;
+  BillAddr?: QuickBooksPhysicalAddress;
+  ShipAddr?: QuickBooksPhysicalAddress;
   Line: QuickBooksSalesReceiptLine[];
 }
 
@@ -123,6 +144,40 @@ interface BuildSalesReceiptInput {
   revenueAccountName?: string;
   revenueItemName?: string;
   depositAccountName?: string;
+  customer?: SalesReceiptCustomerDetails | null;
+}
+
+type StripeCustomerContext = {
+  charge?: Stripe.Charge | null;
+  paymentIntent?: Stripe.PaymentIntent | null;
+  customer?: (Stripe.Customer | Stripe.DeletedCustomer) | null;
+  checkoutSession?: Stripe.Checkout.Session | null;
+};
+
+interface SalesReceiptCustomerDetails {
+  ref: QuickBooksReference;
+  email?: string | null;
+  billingAddress?: QuickBooksPhysicalAddress | null;
+  shippingAddress?: QuickBooksPhysicalAddress | null;
+}
+
+interface EnsureCustomerInput {
+  displayName: string;
+  email?: string | null;
+  givenName?: string | null;
+  familyName?: string | null;
+  phone?: string | null;
+  billingAddress?: QuickBooksPhysicalAddress | null;
+  shippingAddress?: QuickBooksPhysicalAddress | null;
+  stripeCustomerId?: string | null;
+  chargeId?: string | null;
+}
+
+interface EnsureCustomerResult {
+  ref: QuickBooksReference;
+  email?: string | null;
+  billingAddress?: QuickBooksPhysicalAddress | null;
+  shippingAddress?: QuickBooksPhysicalAddress | null;
 }
 
 interface BuildFeesJournalEntryInput {
@@ -154,6 +209,7 @@ export interface PostChargeToQboInput {
   fee: number;
   memo?: string;
   date: string | Date;
+  stripe?: StripeCustomerContext;
   options?: PostOptions;
 }
 
@@ -189,6 +245,238 @@ const centsToDollars = (value: number): number => {
   return Math.round(value) / 100;
 };
 
+const toTrimmed = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeEmail = (value: unknown): string | null => {
+  const trimmed = toTrimmed(value);
+  return trimmed ? trimmed.toLowerCase() : null;
+};
+
+const truncate = (value: string | null | undefined, length: number): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.length > length ? trimmed.slice(0, length) : trimmed;
+};
+
+const mapStripeAddress = (
+  address: Stripe.Address | null | undefined,
+): QuickBooksPhysicalAddress | null => {
+  if (!address) {
+    return null;
+  }
+
+  const extract = (key: keyof Stripe.Address): string | null => {
+    const candidate = (address as Stripe.Address)[key];
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+    return null;
+  };
+
+  const mapped: QuickBooksPhysicalAddress = {};
+
+  const line1 = extract('line1');
+  const line2 = extract('line2');
+  const city = extract('city');
+  const state = extract('state');
+  const postalCode = extract('postal_code');
+  const country = extract('country');
+
+  if (line1) {
+    mapped.Line1 = truncate(line1, 500) ?? undefined;
+  }
+  if (line2) {
+    mapped.Line2 = truncate(line2, 500) ?? undefined;
+  }
+  if (city) {
+    mapped.City = truncate(city, 255) ?? undefined;
+  }
+  if (state) {
+    mapped.CountrySubDivisionCode = truncate(state, 255) ?? undefined;
+  }
+  if (postalCode) {
+    mapped.PostalCode = truncate(postalCode, 30) ?? undefined;
+  }
+  if (country) {
+    mapped.Country = truncate(country, 255) ?? undefined;
+  }
+
+  return Object.keys(mapped).length > 0 ? mapped : null;
+};
+
+const sanitizeAddress = (
+  address: QuickBooksPhysicalAddress | null | undefined,
+): QuickBooksPhysicalAddress | undefined => {
+  if (!address) {
+    return undefined;
+  }
+
+  const sanitized: QuickBooksPhysicalAddress = {};
+
+  if (address.Line1) {
+    sanitized.Line1 = truncate(address.Line1, 500) ?? undefined;
+  }
+  if (address.Line2) {
+    sanitized.Line2 = truncate(address.Line2, 500) ?? undefined;
+  }
+  if (address.Line3) {
+    sanitized.Line3 = truncate(address.Line3, 500) ?? undefined;
+  }
+  if (address.Line4) {
+    sanitized.Line4 = truncate(address.Line4, 500) ?? undefined;
+  }
+  if (address.City) {
+    sanitized.City = truncate(address.City, 255) ?? undefined;
+  }
+  if (address.CountrySubDivisionCode) {
+    sanitized.CountrySubDivisionCode = truncate(address.CountrySubDivisionCode, 255) ?? undefined;
+  }
+  if (address.PostalCode) {
+    sanitized.PostalCode = truncate(address.PostalCode, 30) ?? undefined;
+  }
+  if (address.Country) {
+    sanitized.Country = truncate(address.Country, 255) ?? undefined;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+};
+
+const splitName = (
+  name: string | null | undefined,
+): { givenName?: string | null; familyName?: string | null } => {
+  const trimmed = toTrimmed(name);
+  if (!trimmed) {
+    return {};
+  }
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 0) {
+    return {};
+  }
+
+  if (parts.length === 1) {
+    return { givenName: truncate(parts[0], 100) };
+  }
+
+  const givenName = parts.shift() ?? '';
+  const familyName = parts.join(' ');
+
+  return {
+    givenName: truncate(givenName, 100),
+    familyName: truncate(familyName, 100),
+  };
+};
+
+const isDeletedCustomer = (
+  customer: (Stripe.Customer | Stripe.DeletedCustomer) | null | undefined,
+): customer is Stripe.DeletedCustomer => {
+  return Boolean(customer && 'deleted' in customer && customer.deleted);
+};
+
+const deriveSalesReceiptCustomer = (
+  source: StripeCustomerContext,
+): EnsureCustomerInput => {
+  const activeCustomer =
+    source.customer && !isDeletedCustomer(source.customer)
+      ? (source.customer as Stripe.Customer)
+      : null;
+
+  const billingDetails = source.charge?.billing_details ?? null;
+  const chargeShipping = source.charge?.shipping ?? null;
+  const paymentShipping = source.paymentIntent?.shipping ?? null;
+  const checkoutDetails = source.checkoutSession?.customer_details ?? null;
+
+  const stripeCustomerId =
+    toTrimmed(
+      (typeof source.charge?.customer === 'string'
+        ? source.charge.customer
+        : source.charge?.customer && 'id' in source.charge.customer
+        ? (source.charge.customer as { id?: string }).id
+        : undefined) ||
+        (typeof source.paymentIntent?.customer === 'string'
+          ? source.paymentIntent.customer
+          : source.paymentIntent?.customer && 'id' in source.paymentIntent.customer
+          ? (source.paymentIntent.customer as { id?: string }).id
+          : undefined) ||
+        (activeCustomer?.id ?? null) ||
+        (typeof source.checkoutSession?.customer === 'string'
+          ? source.checkoutSession.customer
+          : source.checkoutSession?.customer && 'id' in source.checkoutSession.customer
+          ? (source.checkoutSession.customer as { id?: string }).id
+          : undefined),
+    ) ?? null;
+
+  const preferredName =
+    toTrimmed(billingDetails?.name) ||
+    toTrimmed(paymentShipping?.name) ||
+    toTrimmed(chargeShipping?.name) ||
+    toTrimmed(activeCustomer?.name) ||
+    toTrimmed(checkoutDetails?.name);
+
+  const email =
+    normalizeEmail(billingDetails?.email) ||
+    normalizeEmail(source.paymentIntent?.receipt_email) ||
+    normalizeEmail(checkoutDetails?.email) ||
+    normalizeEmail(activeCustomer?.email) ||
+    normalizeEmail(source.checkoutSession?.customer_email);
+
+  const phone =
+    toTrimmed(billingDetails?.phone) ||
+    toTrimmed(paymentShipping?.phone) ||
+    toTrimmed(chargeShipping?.phone) ||
+    toTrimmed(activeCustomer?.phone) ||
+    toTrimmed(activeCustomer?.shipping?.phone) ||
+    toTrimmed(checkoutDetails?.phone);
+
+  const billingAddress =
+    mapStripeAddress(billingDetails?.address) ||
+    mapStripeAddress(activeCustomer?.address) ||
+    mapStripeAddress(checkoutDetails?.address);
+
+  const shippingAddress =
+    mapStripeAddress(paymentShipping?.address) ||
+    mapStripeAddress(chargeShipping?.address) ||
+    mapStripeAddress(activeCustomer?.shipping?.address) ||
+    mapStripeAddress(checkoutDetails?.address);
+
+  const fallbackName =
+    preferredName ||
+    email ||
+    (stripeCustomerId ? `Stripe Customer ${stripeCustomerId}` : null) ||
+    (source.charge?.id ? `Stripe Charge ${source.charge.id}` : null) ||
+    (source.paymentIntent?.id ? `Stripe Payment ${source.paymentIntent.id}` : null) ||
+    'Stripe Customer';
+
+  const { givenName, familyName } = splitName(preferredName ?? fallbackName);
+
+  return {
+    displayName: truncate(fallbackName, 99) ?? 'Stripe Customer',
+    email,
+    givenName,
+    familyName,
+    phone,
+    billingAddress,
+    shippingAddress,
+    stripeCustomerId,
+    chargeId: source.charge?.id ?? null,
+  };
+};
+
 const normalizeDate = (value: string | Date): string => {
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -222,6 +510,257 @@ const ensureReferenceValue = <T extends QuickBooksReference>(
   }
 
   return { ...ref, ...normalized } as T;
+};
+
+const queryQuickBooks = async <T = unknown>(
+  query: string,
+  context: QuickBooksRequestContext,
+): Promise<T[]> => {
+  const url = buildQboQueryUrl(query);
+  const response = await context.request(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+    throw new Error(
+      `QuickBooks query failed (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const queryResponse =
+    data && typeof data === 'object'
+      ? ((data as Record<string, unknown>).QueryResponse as Record<string, unknown> | undefined)
+      : undefined;
+
+  if (!queryResponse) {
+    return [];
+  }
+
+  const values = Object.values(queryResponse).find((value) =>
+    Array.isArray(value) || (value && typeof value === 'object'),
+  );
+
+  if (!values) {
+    return [];
+  }
+
+  if (Array.isArray(values)) {
+    return values as T[];
+  }
+
+  return [values as T];
+};
+
+const findCustomerByEmail = async (
+  email: string,
+  context: QuickBooksRequestContext,
+) => {
+  const query = `select Id, DisplayName, PrimaryEmailAddr from Customer where PrimaryEmailAddr = '${escapeQueryValue(
+    email,
+  )}'`;
+  const customers = await queryQuickBooks<Record<string, unknown>>(query, context);
+
+  return (
+    customers.find((customer) => {
+      const addr = customer?.PrimaryEmailAddr as { Address?: string } | undefined;
+      const value = addr?.Address;
+      return typeof value === 'string' && value.trim().toLowerCase() === email.toLowerCase();
+    }) ?? null
+  );
+};
+
+const findCustomerByDisplayName = async (
+  displayName: string,
+  context: QuickBooksRequestContext,
+) => {
+  const query = `select Id, DisplayName from Customer where DisplayName = '${escapeQueryValue(displayName)}'`;
+  const customers = await queryQuickBooks<Record<string, unknown>>(query, context);
+
+  return (
+    customers.find((customer) => {
+      const name = customer?.DisplayName;
+      return typeof name === 'string' && name.trim().toLowerCase() === displayName.toLowerCase();
+    }) ?? null
+  );
+};
+
+const ensureSalesReceiptCustomer = async (
+  input: EnsureCustomerInput,
+  context: QuickBooksRequestContext,
+): Promise<EnsureCustomerResult | null> => {
+  const displayName = truncate(input.displayName, 99) ?? 'Stripe Customer';
+  const email = input.email ? normalizeEmail(input.email) : null;
+  const givenName = truncate(input.givenName ?? null, 100);
+  const familyName = truncate(input.familyName ?? null, 100);
+  const phone = truncate(input.phone ?? null, 30);
+  const billingAddress = sanitizeAddress(input.billingAddress);
+  const shippingAddress = sanitizeAddress(input.shippingAddress);
+
+  let existing: Record<string, unknown> | null = null;
+
+  if (email) {
+    try {
+      existing = await findCustomerByEmail(email, context);
+    } catch (error) {
+      throw new Error(
+        `Failed to look up QuickBooks customer by email "${email}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  if (!existing) {
+    try {
+      existing = await findCustomerByDisplayName(displayName, context);
+    } catch (error) {
+      throw new Error(
+        `Failed to look up QuickBooks customer "${displayName}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  if (existing) {
+    const id = existing.Id;
+    if (typeof id === 'string' || typeof id === 'number') {
+      const value = typeof id === 'number' ? id.toString() : id.trim();
+      if (value) {
+        return {
+          ref: {
+            value,
+            name:
+              typeof existing.DisplayName === 'string'
+                ? existing.DisplayName
+                : displayName,
+          },
+          email,
+          billingAddress,
+          shippingAddress,
+        };
+      }
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    DisplayName: displayName,
+  };
+
+  if (email) {
+    payload.PrimaryEmailAddr = { Address: email } satisfies QuickBooksEmailAddress;
+  }
+  if (givenName) {
+    payload.GivenName = givenName;
+  }
+  if (familyName) {
+    payload.FamilyName = familyName;
+  }
+  if (phone) {
+    payload.PrimaryPhone = { FreeFormNumber: phone };
+  }
+  if (billingAddress) {
+    payload.BillAddr = billingAddress;
+  }
+  if (shippingAddress) {
+    payload.ShipAddr = shippingAddress;
+  }
+
+  const note = input.stripeCustomerId
+    ? `Stripe Customer ID: ${input.stripeCustomerId}`
+    : input.chargeId
+    ? `Stripe Charge ID: ${input.chargeId}`
+    : null;
+  if (note) {
+    payload.Notes = truncate(note, 500);
+  }
+
+  const url = buildQboUrl('customer');
+  const response = await context.request(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+
+    if (
+      response.status === 400 &&
+      errorText &&
+      /Duplicate Name Exists Error/i.test(errorText)
+    ) {
+      const duplicate = await findCustomerByDisplayName(displayName, context);
+      if (duplicate) {
+        const id = duplicate.Id;
+        if (typeof id === 'string' || typeof id === 'number') {
+          const value = typeof id === 'number' ? id.toString() : id.trim();
+          if (value) {
+            return {
+              ref: {
+                value,
+                name:
+                  typeof duplicate.DisplayName === 'string'
+                    ? duplicate.DisplayName
+                    : displayName,
+              },
+              email,
+              billingAddress,
+              shippingAddress,
+            };
+          }
+        }
+      }
+    }
+
+    throw new Error(
+      `Failed to create QuickBooks customer "${displayName}" (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const customer =
+    data && typeof data === 'object'
+      ? ((data as Record<string, unknown>).Customer as Record<string, unknown> | undefined)
+      : undefined;
+
+  const idValue = customer?.Id;
+  const resolvedDisplayName =
+    typeof customer?.DisplayName === 'string'
+      ? customer.DisplayName
+      : displayName;
+
+  if (typeof idValue === 'string' && idValue.trim()) {
+    return {
+      ref: { value: idValue.trim(), name: resolvedDisplayName },
+      email,
+      billingAddress,
+      shippingAddress,
+    };
+  }
+
+  if (typeof idValue === 'number' && Number.isFinite(idValue)) {
+    return {
+      ref: { value: idValue.toString(), name: resolvedDisplayName },
+      email,
+      billingAddress,
+      shippingAddress,
+    };
+  }
+
+  throw new Error('QuickBooks customer creation response did not include an identifier.');
 };
 
 const parseDelimitedReference = (
@@ -366,6 +905,7 @@ export const buildSalesReceipt = ({
   revenueAccountName = env.quickBooks.accounts.revenue,
   revenueItemName = env.quickBooks.items?.revenue,
   depositAccountName = env.quickBooks.accounts.stripeClearing,
+  customer = null,
 }: BuildSalesReceiptInput): QuickBooksSalesReceipt => {
   const amount = ensurePositiveAmount(amountCents, 'Sales receipt amount');
   if (amount === 0) {
@@ -379,7 +919,7 @@ export const buildSalesReceipt = ({
     );
   }
 
-  return {
+  const receipt: QuickBooksSalesReceipt = {
     DocNumber: docNumber,
     TxnDate: normalizeDate(date),
     PrivateNote: memo,
@@ -396,6 +936,30 @@ export const buildSalesReceipt = ({
       },
     ],
   };
+
+  if (customer?.ref?.value) {
+    receipt.CustomerRef = {
+      value: customer.ref.value,
+      name: customer.ref.name,
+    };
+  }
+
+  const customerEmail = normalizeEmail(customer?.email ?? null);
+  if (customerEmail) {
+    receipt.BillEmail = { Address: customerEmail };
+  }
+
+  const billingAddress = sanitizeAddress(customer?.billingAddress);
+  if (billingAddress) {
+    receipt.BillAddr = billingAddress;
+  }
+
+  const shippingAddress = sanitizeAddress(customer?.shippingAddress);
+  if (shippingAddress) {
+    receipt.ShipAddr = shippingAddress;
+  }
+
+  return receipt;
 };
 
 const createJournalEntryLine = (
@@ -1239,6 +1803,7 @@ export const postChargeToQbo = async ({
   fee,
   memo,
   date,
+  stripe,
   options,
 }: PostChargeToQboInput): Promise<PostChargeToQboResult> => {
   const grossAmount = ensurePositiveAmount(gross, 'Gross amount');
@@ -1249,11 +1814,34 @@ export const postChargeToQbo = async ({
 
   if (strategy === 'sales-receipt') {
     const salesReceiptDocNumber = buildDocNumber('CHG', date, grossAmount);
+    let receiptCustomer: SalesReceiptCustomerDetails | null = null;
+
+    try {
+      const derived = deriveSalesReceiptCustomer({ ...(stripe ?? {}) });
+      const context = createRequestContext(options);
+      const ensured = await ensureSalesReceiptCustomer(derived, context);
+      if (ensured) {
+        receiptCustomer = {
+          ref: ensured.ref,
+          email: ensured.email ?? null,
+          billingAddress: ensured.billingAddress ?? null,
+          shippingAddress: ensured.shippingAddress ?? null,
+        };
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to ensure QuickBooks customer for sales receipt: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
     const salesReceipt = buildSalesReceipt({
       docNumber: salesReceiptDocNumber,
       amountCents: grossAmount,
       memo: normalizedMemo,
       date,
+      customer: receiptCustomer,
     });
 
     const salesReceiptResult = await postSalesReceipt(salesReceipt, options);

--- a/tests/stripeTrueUp.test.js
+++ b/tests/stripeTrueUp.test.js
@@ -26,7 +26,11 @@ async function runDryRunTest() {
 
         setDependencies({
             stripe: {
-                getClient: () => ({}),
+                getClient: () => ({
+                    customers: {
+                        retrieve: async () => ({ id: 'cus_test', name: 'Donor Example' }),
+                    },
+                }),
             },
             fetchers: {
                 payments: async () => [


### PR DESCRIPTION
## Summary
- derive QuickBooks customer details from Stripe data and ensure the customer exists before building sales receipts
- enrich sales receipt payloads with CustomerRef, billing email, and address details while handling QuickBooks customer creation gracefully
- fetch Stripe customer records in webhook and true-up handlers and extend tests to cover customer lookups and sales receipt composition

## Testing
- `npm run typecheck` *(fails: missing zod/applicationinsights/@azure/data-tables types in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eab2c36b54832cb7ffde61e9e874e6