### PR TITLE
Auto-create QuickBooks items from Stripe checkout metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,6 @@ Copy the template in `local.settings.json.template` and populate the following k
 | `QBO_ACCOUNT_STRIPE_CLEARING` | QuickBooks ID (or `Name|ID`) of the Stripe clearing account. |
 | `QBO_ACCOUNT_OPERATING_BANK` | QuickBooks ID (or `Name|ID`) of the operating bank account. |
 | `QBO_ACCOUNT_REVENUE` | QuickBooks ID (or `Name|ID`) for revenue recognition. |
-| `QBO_ITEM_REVENUE` | QuickBooks product/service item ID (or `Name|ID`) used on sales receipts. |
 | `QBO_ACCOUNT_FEES` | QuickBooks ID (or `Name|ID`) for Stripe fee expense. |
 | `QBO_ACCOUNT_REFUNDS` | QuickBooks ID (or `Name|ID`) for refunds liability. |
 | `QBO_ACCOUNT_DISPUTES` | QuickBooks ID (or `Name|ID`) for dispute losses. |
@@ -102,6 +101,12 @@ Clearing"}` are also accepted. If only a name is supplied the service will
 attempt to resolve the ID by querying QuickBooks before submitting the
 transaction. This adds an extra API call and will fail if the name is ambiguous
 or missing, so providing the ID up front is still strongly recommended.
+
+When posting sales receipts the integration derives the QuickBooks
+Product/Service item name from the Stripe Checkout Session's
+`transactionType` metadata. If the named item is missing in QuickBooks, the
+service will automatically create a Service item tied to the configured
+revenue account before posting the receipt.
 
 ### Salesforce field mapping
 

--- a/__tests__/qboSvc.test.ts
+++ b/__tests__/qboSvc.test.ts
@@ -325,6 +325,84 @@ describe('postChargeToQbo', () => {
     ]);
   });
 
+  it('updates an existing QuickBooks customer with Stripe-provided details before posting the sales receipt', async () => {
+    baseEnv.accounting.postingStrategy = 'sales-receipt';
+    const { fetcher, requests } = createFetchMock(
+      {
+        QueryResponse: {
+          Customer: [
+            {
+              Id: 'cust-1',
+              DisplayName: 'test',
+              PrimaryEmailAddr: { Address: 'donor@example.com' },
+            },
+          ],
+        },
+      },
+      {
+        Customer: {
+          Id: 'cust-1',
+          DisplayName: 'test',
+          SyncToken: '0',
+          PrimaryEmailAddr: { Address: 'donor@example.com' },
+        },
+      },
+      {
+        Customer: {
+          Id: 'cust-1',
+          DisplayName: 'Donor Example',
+          SyncToken: '1',
+          PrimaryEmailAddr: { Address: 'donor@example.com' },
+        },
+      },
+      {
+        QueryResponse: {
+          Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
+        },
+      },
+      { SalesReceipt: { Id: 'sr-3' } },
+    );
+
+    const { postChargeToQbo } = await importQboSvc();
+
+    const result = await postChargeToQbo({
+      gross: 10_000,
+      fee: 0,
+      memo: 'Charge memo',
+      date: new Date('2024-06-01'),
+      stripe: buildStripeContext(),
+      options: { fetcher, accessToken: 'token' },
+    });
+
+    expect(result).toEqual({ qboId: 'sr-3', type: 'sales-receipt' });
+    expect(fetcher).toHaveBeenCalledTimes(5);
+
+    const [emailLookup, customerGet, customerUpdate, itemLookup, salesReceiptPost] = requests;
+
+    expect(emailLookup.url).toContain('/query?query=');
+    expect(customerGet.url).toContain('/customer/');
+    expect(customerGet.init?.method ?? 'GET').toBe('GET');
+
+    expect(customerUpdate.url).toContain('/customer?operation=update');
+    expect(customerUpdate.init?.method).toBe('POST');
+    const updateBody = JSON.parse((customerUpdate.init?.body ?? '{}') as string);
+    expect(updateBody).toMatchObject({
+      DisplayName: 'Donor Example',
+      PrimaryEmailAddr: { Address: 'donor@example.com' },
+      sparse: true,
+    });
+
+    expect(itemLookup.url).toContain('/query?query=');
+    expect(itemLookup.init?.method ?? 'GET').toBe('GET');
+
+    const salesReceiptBody = JSON.parse((salesReceiptPost.init?.body ?? '{}') as string);
+    expect(salesReceiptBody.CustomerRef).toMatchObject({
+      value: 'cust-1',
+      name: 'Donor Example',
+    });
+    expect(salesReceiptBody.BillEmail).toEqual({ Address: 'donor@example.com' });
+  });
+
   it('retries sales receipt with looked up item id when QuickBooks rejects provided item reference', async () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
     const invalidReferenceResponse = {

--- a/__tests__/qboSvc.test.ts
+++ b/__tests__/qboSvc.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import type Stripe from 'stripe';
 
 type RequestRecord = { url: string; init: any };
 
@@ -11,10 +12,6 @@ const defaultAccounts = {
   disputeLosses: 'Dispute Losses|QBO_ACCOUNT_DISPUTE_LOSSES',
 };
 
-const defaultItems = {
-  revenue: 'Stripe Sales Item|QBO_ITEM_REVENUE',
-};
-
 const baseEnv = {
   quickBooks: {
     environment: 'sandbox',
@@ -23,7 +20,6 @@ const baseEnv = {
     clientSecret: 'secret',
     refreshToken: 'refresh',
     accounts: { ...defaultAccounts },
-    items: { ...defaultItems },
   },
   accounting: {
     postingStrategy: 'sales-receipt',
@@ -39,7 +35,6 @@ const importQboSvc = async () => {
 
 const resetAccounts = () => {
   Object.assign(baseEnv.quickBooks.accounts, defaultAccounts);
-  Object.assign(baseEnv.quickBooks.items, defaultItems);
 };
 
 const resetTokens = () => {
@@ -134,6 +129,84 @@ const createFetchMock = (...payloads: unknown[]) => {
   return { fetcher, requests };
 };
 
+const createStripeCharge = (overrides: Partial<Stripe.Charge> = {}): Stripe.Charge => {
+  const base: Partial<Stripe.Charge> = {
+    id: 'ch_test',
+    billing_details: {
+      name: 'Donor Example',
+      email: 'donor@example.com',
+      phone: '555-0100',
+      address: {
+        line1: '123 Donation Ave',
+        line2: 'Suite 100',
+        city: 'Givington',
+        state: 'CA',
+        postal_code: '94105',
+        country: 'US',
+      },
+    },
+    shipping: {
+      name: 'Donor Example',
+      phone: '555-0100',
+      address: {
+        line1: '123 Donation Ave',
+        line2: 'Suite 100',
+        city: 'Givington',
+        state: 'CA',
+        postal_code: '94105',
+        country: 'US',
+      },
+    },
+  };
+
+  return { ...base, ...overrides } as Stripe.Charge;
+};
+
+const createCheckoutSession = (
+  overrides: Partial<Stripe.Checkout.Session> = {},
+): Stripe.Checkout.Session => {
+  const baseMetadata = { transactionType: 'Stripe Sales Item' } as Record<string, string>;
+  const overrideMetadata =
+    overrides.metadata && typeof overrides.metadata === 'object'
+      ? (overrides.metadata as Record<string, string>)
+      : undefined;
+
+  const base: Partial<Stripe.Checkout.Session> = {
+    id: 'cs_test',
+    customer_email: 'donor@example.com',
+    customer_details: {
+      email: 'donor@example.com',
+      name: 'Donor Example',
+      phone: '555-0100',
+      address: {
+        line1: '123 Donation Ave',
+        line2: 'Suite 100',
+        city: 'Givington',
+        state: 'CA',
+        postal_code: '94105',
+        country: 'US',
+      },
+    },
+    metadata: { ...baseMetadata, ...(overrideMetadata ?? {}) },
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    metadata: { ...baseMetadata, ...(overrideMetadata ?? {}) },
+  } as Stripe.Checkout.Session;
+};
+
+const buildStripeContext = (
+  chargeOverrides: Partial<Stripe.Charge> = {},
+  checkoutOverrides: Partial<Stripe.Checkout.Session> = {},
+) => ({
+  charge: createStripeCharge(chargeOverrides),
+  paymentIntent: null,
+  customer: null,
+  checkoutSession: createCheckoutSession(checkoutOverrides),
+});
+
 afterEach(() => {
   vi.clearAllMocks();
   baseEnv.accounting.postingStrategy = 'sales-receipt';
@@ -145,6 +218,14 @@ describe('postChargeToQbo', () => {
   it('posts sales receipt to clearing account and creates fee journal entry when using sales receipt strategy', async () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
     const { fetcher, requests } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-1', DisplayName: 'Donor Example' } },
+      {
+        QueryResponse: {
+          Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
+        },
+      },
       { SalesReceipt: { Id: 'sr-1' } },
       { JournalEntry: { Id: 'fee-je-1' } },
     );
@@ -155,16 +236,46 @@ describe('postChargeToQbo', () => {
       fee: 325,
       memo: 'Charge memo',
       date: new Date('2024-03-01'),
+      stripe: buildStripeContext(),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-1', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(2);
-    const [salesReceiptRequest, feeJournalRequest] = requests;
-    expect(salesReceiptRequest.url).toContain('salesreceipt');
-    expect(feeJournalRequest.url).toContain('journalentry');
+    expect(fetcher).toHaveBeenCalledTimes(6);
 
-    const salesReceiptBody = JSON.parse((salesReceiptRequest.init?.body ?? '{}') as string);
+    const [emailLookupRequest, nameLookupRequest, customerCreateRequest] = requests;
+    expect(emailLookupRequest.url).toContain('/query?query=');
+    expect(nameLookupRequest.url).toContain('/query?query=');
+    expect(customerCreateRequest.url).toContain('/customer');
+    expect(customerCreateRequest.init?.method).toBe('POST');
+
+    const itemLookupRequest = requests.find((request) =>
+      request !== emailLookupRequest &&
+      request !== nameLookupRequest &&
+      request !== customerCreateRequest &&
+      request.url.includes('/query?query=')
+    );
+    expect(itemLookupRequest?.url).toContain('/query?query=');
+    expect(itemLookupRequest?.init?.method ?? 'GET').toBe('GET');
+
+    const customerBody = JSON.parse((customerCreateRequest.init?.body ?? '{}') as string);
+    expect(customerBody).toMatchObject({
+      DisplayName: 'Donor Example',
+      PrimaryEmailAddr: { Address: 'donor@example.com' },
+      BillAddr: expect.objectContaining({ Line1: '123 Donation Ave', City: 'Givington' }),
+    });
+
+    const salesReceiptRequest = requests.find((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    const feeJournalRequest = requests.find((request) =>
+      request.url.includes('journalentry'),
+    );
+
+    expect(salesReceiptRequest).toBeDefined();
+    expect(feeJournalRequest).toBeDefined();
+
+    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
     expect(salesReceiptBody.DepositToAccountRef).toMatchObject({
       value: 'QBO_ACCOUNT_STRIPE_CLEARING',
       name: 'Stripe Clearing',
@@ -173,8 +284,22 @@ describe('postChargeToQbo', () => {
       value: 'QBO_ITEM_REVENUE',
       name: 'Stripe Sales Item',
     });
+    expect(salesReceiptBody.CustomerRef).toMatchObject({
+      value: 'cust-1',
+      name: 'Donor Example',
+    });
+    expect(salesReceiptBody.BillEmail).toEqual({ Address: 'donor@example.com' });
+    expect(salesReceiptBody.BillAddr).toMatchObject({
+      Line1: '123 Donation Ave',
+      City: 'Givington',
+      PostalCode: '94105',
+    });
+    expect(salesReceiptBody.ShipAddr).toMatchObject({
+      Line1: '123 Donation Ave',
+      City: 'Givington',
+    });
 
-    const feeJournalBody = JSON.parse((feeJournalRequest.init?.body ?? '{}') as string);
+    const feeJournalBody = JSON.parse((feeJournalRequest?.init?.body ?? '{}') as string);
     const feeLines = feeJournalBody.Line.map((line: any) => ({
       type: line.JournalEntryLineDetail.PostingType,
       accountRef: line.JournalEntryLineDetail.AccountRef,
@@ -202,8 +327,6 @@ describe('postChargeToQbo', () => {
 
   it('retries sales receipt with looked up item id when QuickBooks rejects provided item reference', async () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
-    baseEnv.quickBooks.items.revenue = 'Stripe Sales Item|STALE_ID';
-
     const invalidReferenceResponse = {
       Fault: {
         Error: [
@@ -219,6 +342,14 @@ describe('postChargeToQbo', () => {
     };
 
     const { fetcher, requests } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-2', DisplayName: 'Donor Example' } },
+      {
+        QueryResponse: {
+          Item: { Id: 'STALE_ID', Name: 'Stripe Sales Item' },
+        },
+      },
       {
         ok: false,
         status: 400,
@@ -239,19 +370,30 @@ describe('postChargeToQbo', () => {
       fee: 0,
       memo: 'Charge memo',
       date: new Date('2024-04-01'),
+      stripe: buildStripeContext(),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-2', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(3);
+    expect(fetcher).toHaveBeenCalledTimes(7);
 
-    const [initialPost, itemLookup, retryPost] = requests;
-    expect(initialPost.url).toContain('salesreceipt');
-    expect(itemLookup.url).toContain('/query');
-    expect(retryPost.url).toContain('salesreceipt');
+    const salesReceiptRequests = requests.filter((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    expect(salesReceiptRequests).toHaveLength(2);
+    const [initialPost, retryPost] = salesReceiptRequests;
+    const itemLookupRequests = requests.filter((request, index) => {
+      if (!request.url.includes('/query?query=')) {
+        return false;
+      }
+      return index > 1;
+    });
+    expect(itemLookupRequests).toHaveLength(2);
+    expect(itemLookupRequests[0]?.url).toContain('/query?query=');
+    expect(itemLookupRequests[1]?.url).toContain('/query?query=');
 
-    const initialBody = JSON.parse((initialPost.init?.body ?? '{}') as string);
-    const retryBody = JSON.parse((retryPost.init?.body ?? '{}') as string);
+    const initialBody = JSON.parse((initialPost?.init?.body ?? '{}') as string);
+    const retryBody = JSON.parse((retryPost?.init?.body ?? '{}') as string);
 
     expect(initialBody.Line[0].SalesItemLineDetail.ItemRef.value).toBe('STALE_ID');
     expect(retryBody.Line[0].SalesItemLineDetail.ItemRef.value).toBe('QBO_ITEM_REVENUE');
@@ -319,6 +461,14 @@ describe('postChargeToQbo', () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
     baseEnv.quickBooks.accounts.stripeClearing = 'Stripe Clearing';
     const { fetcher, requests } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-3', DisplayName: 'Donor Example' } },
+      {
+        QueryResponse: {
+          Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
+        },
+      },
       {
         QueryResponse: {
           Account: [{ Id: '999', Name: 'Stripe Clearing' }],
@@ -334,15 +484,30 @@ describe('postChargeToQbo', () => {
       fee: 325,
       memo: 'Lookup memo',
       date: new Date('2024-05-01'),
+      stripe: buildStripeContext(),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-2', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(3);
-    expect(requests[0].url).toContain('/query?query=');
-    expect(requests[0].init?.method).toBe('GET');
+    expect(fetcher).toHaveBeenCalledTimes(7);
 
-    const salesReceiptBody = JSON.parse((requests[1].init?.body ?? '{}') as string);
+    const accountLookupRequest = requests.find((request, index) => {
+      if (!request.url.includes('/query?query=')) {
+        return false;
+      }
+      return index > 2;
+    });
+    expect(accountLookupRequest?.url).toContain('/query?query=');
+    expect(accountLookupRequest?.init?.method).toBe('GET');
+
+    const salesReceiptRequest = requests.find((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    const journalRequest = requests.find((request) =>
+      request.url.includes('journalentry'),
+    );
+
+    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
     expect(salesReceiptBody.DepositToAccountRef).toMatchObject({
       value: '999',
       name: 'Stripe Clearing',
@@ -352,22 +517,21 @@ describe('postChargeToQbo', () => {
       name: 'Stripe Sales Item',
     });
 
-    const journalBody = JSON.parse((requests[2].init?.body ?? '{}') as string);
+    const journalBody = JSON.parse((journalRequest?.init?.body ?? '{}') as string);
     const clearingLine = journalBody.Line.find(
       (line: any) => line.JournalEntryLineDetail.AccountRef.name === 'Stripe Clearing',
     );
     expect(clearingLine?.JournalEntryLineDetail.AccountRef.value).toBe('999');
   });
 
-  it('looks up item IDs when configuration only provides a name', async () => {
+  it('creates QuickBooks item when transaction type metadata does not exist', async () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
-    baseEnv.quickBooks.items.revenue = 'Stripe Sales Item';
     const { fetcher, requests } = createFetchMock(
-      {
-        QueryResponse: {
-          Item: [{ Id: '123', Name: 'Stripe Sales Item' }],
-        },
-      },
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-4', DisplayName: 'Donor Example' } },
+      { QueryResponse: {} },
+      { Item: { Id: '321', Name: 'New Donation' } },
       { SalesReceipt: { Id: 'sr-3' } },
       { JournalEntry: { Id: 'fee-je-3' } },
     );
@@ -378,24 +542,50 @@ describe('postChargeToQbo', () => {
       fee: 300,
       memo: 'Item lookup memo',
       date: new Date('2024-06-01'),
+      stripe: buildStripeContext({}, {
+        metadata: { transactionType: 'New Donation' },
+      }),
       options: { fetcher, accessToken: 'token' },
     });
 
     expect(result).toEqual({ qboId: 'sr-3', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(3);
-    expect(requests[0].url).toContain('/query?query=');
-    expect(requests[0].init?.method).toBe('GET');
+    expect(fetcher).toHaveBeenCalledTimes(7);
 
-    const salesReceiptBody = JSON.parse((requests[1].init?.body ?? '{}') as string);
+    const itemLookupRequest = requests.find((request, index) => {
+      if (!request.url.includes('/query?query=')) {
+        return false;
+      }
+      return index > 1;
+    });
+    expect(itemLookupRequest?.url).toContain('/query?query=');
+
+    const itemCreateRequest = requests.find((request) => request.url.includes('/item'));
+    expect(itemCreateRequest?.init?.method).toBe('POST');
+    const itemCreateBody = JSON.parse((itemCreateRequest?.init?.body ?? '{}') as string);
+    expect(itemCreateBody).toMatchObject({
+      Name: 'New Donation',
+      Type: 'Service',
+      IncomeAccountRef: { value: 'QBO_ACCOUNT_REVENUE' },
+    });
+
+    const salesReceiptRequest = requests.find((request) =>
+      request.url.includes('salesreceipt'),
+    );
+    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
     expect(salesReceiptBody.Line[0].SalesItemLineDetail.ItemRef).toMatchObject({
-      value: '123',
-      name: 'Stripe Sales Item',
+      value: '321',
+      name: 'New Donation',
     });
   });
 
   it('throws a helpful error when QuickBooks cannot resolve the configured account name', async () => {
     baseEnv.quickBooks.accounts.stripeClearing = 'Stripe Clearing';
-    const { fetcher } = createFetchMock({ QueryResponse: { Account: [] } });
+    const { fetcher } = createFetchMock(
+      { QueryResponse: {} },
+      { QueryResponse: {} },
+      { Customer: { Id: 'cust-err', DisplayName: 'Donor Example' } },
+      { QueryResponse: { Account: [] } },
+    );
     const { postChargeToQbo } = await importQboSvc();
 
     await expect(
@@ -404,6 +594,7 @@ describe('postChargeToQbo', () => {
         fee: 0,
         memo: 'Missing ID',
         date: new Date('2024-04-01'),
+        stripe: buildStripeContext(),
         options: { fetcher, accessToken: 'token' },
       }),
     ).rejects.toThrow(/could not be found/i);

--- a/__tests__/qboSvc.test.ts
+++ b/__tests__/qboSvc.test.ts
@@ -162,6 +162,17 @@ const createStripeCharge = (overrides: Partial<Stripe.Charge> = {}): Stripe.Char
   return { ...base, ...overrides } as Stripe.Charge;
 };
 
+const createStripeCustomer = (overrides: Partial<Stripe.Customer> = {}): Stripe.Customer => {
+  const base: Partial<Stripe.Customer> = {
+    id: 'cus_test',
+    name: 'Donor Example',
+    email: 'donor@example.com',
+    phone: '555-0100',
+  };
+
+  return { ...base, ...overrides } as Stripe.Customer;
+};
+
 const createCheckoutSession = (
   overrides: Partial<Stripe.Checkout.Session> = {},
 ): Stripe.Checkout.Session => {
@@ -200,10 +211,11 @@ const createCheckoutSession = (
 const buildStripeContext = (
   chargeOverrides: Partial<Stripe.Charge> = {},
   checkoutOverrides: Partial<Stripe.Checkout.Session> = {},
+  customer?: Stripe.Customer | null,
 ) => ({
   charge: createStripeCharge(chargeOverrides),
   paymentIntent: null,
-  customer: null,
+  customer: customer ?? null,
   checkoutSession: createCheckoutSession(checkoutOverrides),
 });
 
@@ -401,6 +413,97 @@ describe('postChargeToQbo', () => {
       name: 'Donor Example',
     });
     expect(salesReceiptBody.BillEmail).toEqual({ Address: 'donor@example.com' });
+  });
+
+  it('prefers the Stripe customer name over billing details when refreshing QuickBooks customers', async () => {
+    baseEnv.accounting.postingStrategy = 'sales-receipt';
+    const { fetcher, requests } = createFetchMock(
+      {
+        QueryResponse: {
+          Customer: [
+            {
+              Id: 'cust-2',
+              DisplayName: 'Legacy Name',
+              PrimaryEmailAddr: { Address: 'member@example.com' },
+            },
+          ],
+        },
+      },
+      {
+        Customer: {
+          Id: 'cust-2',
+          DisplayName: 'Legacy Name',
+          SyncToken: '3',
+          PrimaryEmailAddr: { Address: 'member@example.com' },
+        },
+      },
+      {
+        Customer: {
+          Id: 'cust-2',
+          DisplayName: 'Member Stripe',
+          SyncToken: '4',
+          PrimaryEmailAddr: { Address: 'member@example.com' },
+        },
+      },
+      {
+        QueryResponse: {
+          Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
+        },
+      },
+      { SalesReceipt: { Id: 'sr-4' } },
+    );
+
+    const { postChargeToQbo } = await importQboSvc();
+
+    const stripeCustomer = createStripeCustomer({
+      id: 'cus_member',
+      name: 'Member Stripe',
+      email: 'member@example.com',
+      phone: '555-4242',
+    });
+
+    const result = await postChargeToQbo({
+      gross: 12_000,
+      fee: 0,
+      memo: 'Charge memo',
+      date: new Date('2024-07-01'),
+      stripe: buildStripeContext(
+        {
+          billing_details: {
+            name: 'Card Holder Name',
+            email: 'member@example.com',
+            phone: '555-0000',
+            address: {
+              line1: '321 Legacy Ln',
+              city: 'History',
+              state: 'CA',
+              postal_code: '90001',
+              country: 'US',
+            },
+          },
+        },
+        {},
+        stripeCustomer,
+      ),
+      options: { fetcher, accessToken: 'token' },
+    });
+
+    expect(result).toEqual({ qboId: 'sr-4', type: 'sales-receipt' });
+    expect(fetcher).toHaveBeenCalledTimes(5);
+
+    const [, , customerUpdate, , salesReceiptPost] = requests;
+    const updateBody = JSON.parse((customerUpdate.init?.body ?? '{}') as string);
+    expect(updateBody).toMatchObject({
+      DisplayName: 'Member Stripe',
+      PrimaryEmailAddr: { Address: 'member@example.com' },
+      sparse: true,
+    });
+
+    const salesReceiptBody = JSON.parse((salesReceiptPost.init?.body ?? '{}') as string);
+    expect(salesReceiptBody.CustomerRef).toMatchObject({
+      value: 'cust-2',
+      name: 'Member Stripe',
+    });
   });
 
   it('retries sales receipt with looked up item id when QuickBooks rejects provided item reference', async () => {

--- a/__tests__/stripeWebhook.test.ts
+++ b/__tests__/stripeWebhook.test.ts
@@ -257,6 +257,11 @@ describe('stripeWebhook', () => {
         }),
       }),
     );
+    const chargePostingArgs = accounting.postChargeToQbo.mock.calls[0]?.[0];
+    expect(chargePostingArgs?.date).toBeInstanceOf(Date);
+    expect(chargePostingArgs?.date?.toISOString()).toBe(
+      new Date(1_700_000_000_000).toISOString(),
+    );
     expect(salesforce.markPostedToQbo).toHaveBeenCalledWith('sf_1', {
       id: '123',
       type: 'journal-entry',

--- a/__tests__/stripeWebhook.test.ts
+++ b/__tests__/stripeWebhook.test.ts
@@ -179,6 +179,13 @@ describe('stripeWebhook', () => {
       charges: {
         retrieve: vi.fn(),
       },
+      customers: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: 'cus_123',
+          name: 'Donor Example',
+          email: 'donor@example.com',
+        }),
+      },
       checkout: {
         sessions: {
           list: vi.fn().mockResolvedValue({
@@ -239,7 +246,16 @@ describe('stripeWebhook', () => {
       { overrideId: 'sf_existing' },
     );
     expect(accounting.postChargeToQbo).toHaveBeenCalledWith(
-      expect.objectContaining({ gross: 1_000, fee: 100 }),
+      expect.objectContaining({
+        gross: 1_000,
+        fee: 100,
+        stripe: expect.objectContaining({
+          charge: expect.objectContaining({ id: 'ch_test' }),
+          paymentIntent: expect.objectContaining({ id: 'pi_test' }),
+          customer: expect.objectContaining({ id: 'cus_123' }),
+          checkoutSession: expect.objectContaining({ id: 'cs_test' }),
+        }),
+      }),
     );
     expect(salesforce.markPostedToQbo).toHaveBeenCalledWith('sf_1', {
       id: '123',

--- a/docs/END_TO_END_TESTING.md
+++ b/docs/END_TO_END_TESTING.md
@@ -50,12 +50,13 @@ that mirror those tenants.
 | `QBO_REFRESH_TOKEN` | Refresh token paired with the access token. |
 | `QBO_REALM_ID` | QuickBooks company id. |
 | `QBO_ENV` | `sandbox` or `production`. |
-| `QBO_ITEM_REVENUE` | QuickBooks product/service item ID used for sales receipts. |
 | `AZURE_TABLES_CONNECTION_STRING` | Backing store for webhook idempotency keys. |
 
 > ⚠️ **Important:** The script refuses to run if any of the variables above are
 > missing. Refresh the QuickBooks access token immediately before running the
-> test to avoid 401 responses during verification.
+> test to avoid 401 responses during verification. Ensure the Stripe Checkout
+> Session used during testing supplies a `transactionType` metadata value so the
+> integration can derive (or create) the corresponding QuickBooks item.
 
 ## 3. Install Project Dependencies
 

--- a/local.settings.json.example
+++ b/local.settings.json.example
@@ -31,7 +31,6 @@
     "QBO_ACCOUNT_STRIPE_CLEARING": "Stripe Clearing|123",
     "QBO_ACCOUNT_OPERATING_BANK": "Operating Bank|456",
     "QBO_ACCOUNT_REVENUE": "Revenue|789",
-    "QBO_ITEM_REVENUE": "Stripe Sales Item|987",
     "QBO_ACCOUNT_FEES": "Stripe Fees|321",
     "ACCOUNTING_POSTING_STRATEGY": "je-transfer",
     "ACCOUNTING_SYNC_ENABLED": "false",

--- a/local.settings.json.template
+++ b/local.settings.json.template
@@ -35,7 +35,6 @@
     "QBO_ACCOUNT_STRIPE_CLEARING": "Stripe Clearing|123",
     "QBO_ACCOUNT_OPERATING_BANK": "Operating Bank|456",
     "QBO_ACCOUNT_REVENUE": "Revenue|789",
-    "QBO_ITEM_REVENUE": "Stripe Sales Item|987",
     "QBO_ACCOUNT_FEES": "Stripe Fees|321",
     "ACCOUNTING_POSTING_STRATEGY": "je-transfer",
     "ACCOUNTING_SYNC_ENABLED": "false",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -196,11 +196,6 @@ function loadEnv(): EnvConfig {
           defaultValue: 'Dispute Losses',
         }) ?? 'Dispute Losses',
     },
-    items: {
-      revenue: resolveEnv('QBO_ITEM_REVENUE', {
-        fallbackNames: ['ACCOUNTING_REVENUE_ITEM'],
-      }),
-    },
   };
 
   const quickBooksSchema = z.object({
@@ -217,11 +212,6 @@ function loadEnv(): EnvConfig {
       refunds: z.string().min(1),
       disputeLosses: z.string().min(1),
     }),
-    items: z
-      .object({
-        revenue: z.string().min(1).optional(),
-      })
-      .optional(),
   });
 
   const quickBooks = quickBooksSchema.parse(quickBooksRaw);
@@ -258,13 +248,6 @@ function loadEnv(): EnvConfig {
     }
   }
 
-  if (postingStrategy.success && postingStrategy.data === 'sales-receipt') {
-    const revenueItem = quickBooks.items?.revenue?.trim();
-    if (!revenueItem) {
-      missing.push('QBO_ITEM_REVENUE');
-    }
-  }
-
   const appInsightsInstrumentationKey = resolveEnv('APPINSIGHTS_INSTRUMENTATIONKEY', {
     fallbackNames: ['APPINSIGHTS_INSTRUMENTATION_KEY'],
   });
@@ -298,7 +281,6 @@ function loadEnv(): EnvConfig {
       clientSecret: quickBooks.clientSecret,
       refreshToken: quickBooks.refreshToken,
       accounts: quickBooks.accounts,
-      items: quickBooks.items,
     },
     accounting: {
       postingStrategy: (postingStrategy.success

--- a/src/handlers/stripeTrueUp.ts
+++ b/src/handlers/stripeTrueUp.ts
@@ -421,7 +421,9 @@ const processPayments = async (
           fee: Math.abs(balanceTransaction.fee ?? 0),
           memo: `Stripe charge ${charge.id}`,
           date: timestampToDate(
-            balanceTransaction.available_on ?? balanceTransaction.created ?? null,
+            balanceTransaction.created ??
+              balanceTransaction.available_on ??
+              null,
           ),
           stripe: {
             charge: charge as Stripe.Charge,
@@ -539,7 +541,9 @@ const processRefunds = async (
           amount: Math.abs(balanceTransaction.amount ?? 0),
           memo: `Stripe refund ${refund.id}`,
           date: timestampToDate(
-            balanceTransaction.available_on ?? balanceTransaction.created ?? null,
+            balanceTransaction.created ??
+              balanceTransaction.available_on ??
+              null,
           ),
         });
         summary.qboPosts += 1;
@@ -628,7 +632,11 @@ const processPayouts = async (
         const posting = await dependencies.accounting.postPayoutToQbo({
           amount: Math.abs(payout.amount ?? 0),
           memo: `Stripe payout ${payout.id}`,
-          date: timestampToDate(payout.arrival_date ?? payout.created ?? null),
+          date: timestampToDate(
+            payout.created ??
+              payout.arrival_date ??
+              null,
+          ),
         });
         summary.qboPosts += 1;
 

--- a/src/handlers/stripeTrueUp.ts
+++ b/src/handlers/stripeTrueUp.ts
@@ -307,6 +307,46 @@ const ensureStripeBalanceTransaction = (
   return value;
 };
 
+const extractStripeId = (value: unknown): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'object' && value !== null && 'id' in (value as Record<string, unknown>)) {
+    const idValue = (value as Record<string, unknown>).id;
+    return typeof idValue === 'string' ? idValue : null;
+  }
+
+  return null;
+};
+
+const resolveCustomerForCharge = async (
+  stripe: Stripe,
+  charge: Stripe.Charge,
+  logger: (...args: unknown[]) => void,
+): Promise<(Stripe.Customer | Stripe.DeletedCustomer) | null> => {
+  const customerId = extractStripeId(charge.customer);
+  if (!customerId) {
+    return null;
+  }
+
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    return customer as Stripe.Customer | Stripe.DeletedCustomer;
+  } catch (error) {
+    logger('[StripeTrueUp] Failed to retrieve Stripe customer', {
+      chargeId: charge.id,
+      customerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};
+
 const processPayments = async (
   context: HttpContext,
   stripe: Stripe,
@@ -370,6 +410,12 @@ const processPayments = async (
         );
         summary.salesforceUpdates += 1;
 
+        const stripeCustomer = await resolveCustomerForCharge(
+          stripe,
+          charge as Stripe.Charge,
+          context.log,
+        );
+
         const posting = await dependencies.accounting.postChargeToQbo({
           gross: Math.abs(balanceTransaction.amount ?? 0),
           fee: Math.abs(balanceTransaction.fee ?? 0),
@@ -377,6 +423,11 @@ const processPayments = async (
           date: timestampToDate(
             balanceTransaction.available_on ?? balanceTransaction.created ?? null,
           ),
+          stripe: {
+            charge: charge as Stripe.Charge,
+            paymentIntent: null,
+            customer: stripeCustomer,
+          },
         });
         summary.qboPosts += 1;
 

--- a/src/handlers/stripeWebhook.ts
+++ b/src/handlers/stripeWebhook.ts
@@ -345,6 +345,32 @@ const resolveBalanceTransaction = async (
   return null;
 };
 
+const resolveStripeCustomer = async (
+  stripe: Stripe,
+  charge: Stripe.Charge | null,
+  paymentIntent: Stripe.PaymentIntent | null,
+  logger: (...args: unknown[]) => void,
+): Promise<(Stripe.Customer | Stripe.DeletedCustomer) | null> => {
+  const customerId =
+    normalizeStripeId(charge?.customer) ||
+    normalizeStripeId(paymentIntent?.customer);
+
+  if (!customerId) {
+    return null;
+  }
+
+  try {
+    const customer = await stripe.customers.retrieve(customerId);
+    return customer as Stripe.Customer | Stripe.DeletedCustomer;
+  } catch (error) {
+    logger('[StripeWebhook] Failed to retrieve Stripe customer', {
+      customerId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+};
+
 const findCheckoutSessionForPaymentIntent = async (
   stripe: Stripe,
   paymentIntentId: string | null | undefined,
@@ -504,6 +530,13 @@ const handlePaymentIntentSucceeded = async (
   await deps.idempotencyStore.withLock(
     `bt_${balanceTransactionId}`,
     async () => {
+      const stripeCustomer = await resolveStripeCustomer(
+        stripe,
+        charge,
+        paymentIntent,
+        context.log,
+      );
+
       const posting = await deps.accounting.postChargeToQbo({
         gross: Math.abs(balanceTransaction.amount ?? 0),
         fee: Math.abs(balanceTransaction.fee ?? 0),
@@ -511,6 +544,12 @@ const handlePaymentIntentSucceeded = async (
         date: timestampToDate(
           balanceTransaction.available_on ?? balanceTransaction.created ?? null,
         ),
+        stripe: {
+          charge: charge ?? undefined,
+          paymentIntent,
+          customer: stripeCustomer,
+          checkoutSession: checkoutSession ?? undefined,
+        },
       });
 
       await markPosted(salesforce, upsertResult, posting);

--- a/src/handlers/stripeWebhook.ts
+++ b/src/handlers/stripeWebhook.ts
@@ -542,7 +542,7 @@ const handlePaymentIntentSucceeded = async (
         fee: Math.abs(balanceTransaction.fee ?? 0),
         memo: `Stripe charge ${charge?.id || paymentIntent.id}`,
         date: timestampToDate(
-          balanceTransaction.available_on ?? balanceTransaction.created ?? null,
+          balanceTransaction.created ?? balanceTransaction.available_on ?? null,
         ),
         stripe: {
           charge: charge ?? undefined,
@@ -641,7 +641,7 @@ const handleChargeRefunded = async (
         amount,
         memo: `Stripe refund ${refund.id} (charge ${charge.id})`,
         date: timestampToDate(
-          balanceTransaction.available_on ?? balanceTransaction.created ?? null,
+          balanceTransaction.created ?? balanceTransaction.available_on ?? null,
         ),
       });
 
@@ -776,8 +776,8 @@ const handleDisputeClosed = async (
       feeAmount: feeAmountCents,
       memo: `Stripe dispute ${dispute.id} (charge ${chargeId || '-'})`,
       date: timestampToDate(
-        primaryBalanceTransaction?.available_on ??
-          primaryBalanceTransaction?.created ??
+        primaryBalanceTransaction?.created ??
+          primaryBalanceTransaction?.available_on ??
           dispute.created ??
           null,
       ),

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'node:buffer';
 
+import type Stripe from 'stripe';
+
 import env from '../config/env';
 
 const QBO_BASE_URL: Record<'sandbox' | 'production', string> = {
@@ -45,6 +47,21 @@ type ItemRefWithMetadata = QuickBooksReference & {
   [ITEM_LOOKUP_METADATA]?: ItemRefLookupMetadata;
 };
 
+interface QuickBooksEmailAddress {
+  Address: string;
+}
+
+interface QuickBooksPhysicalAddress {
+  Line1?: string;
+  Line2?: string;
+  Line3?: string;
+  Line4?: string;
+  City?: string;
+  CountrySubDivisionCode?: string;
+  PostalCode?: string;
+  Country?: string;
+}
+
 interface QuickBooksSalesItemLineDetail {
   ItemRef: QuickBooksReference;
   ItemAccountRef?: QuickBooksReference;
@@ -63,6 +80,10 @@ export interface QuickBooksSalesReceipt {
   TxnDate: string;
   PrivateNote?: string;
   DepositToAccountRef: QuickBooksReference;
+  CustomerRef?: QuickBooksReference;
+  BillEmail?: QuickBooksEmailAddress;
+  BillAddr?: QuickBooksPhysicalAddress;
+  ShipAddr?: QuickBooksPhysicalAddress;
   Line: QuickBooksSalesReceiptLine[];
 }
 
@@ -121,8 +142,42 @@ interface BuildSalesReceiptInput {
   memo?: string;
   date: string | Date;
   revenueAccountName?: string;
-  revenueItemName?: string;
+  revenueItemName: string;
   depositAccountName?: string;
+  customer?: SalesReceiptCustomerDetails | null;
+}
+
+type StripeCustomerContext = {
+  charge?: Stripe.Charge | null;
+  paymentIntent?: Stripe.PaymentIntent | null;
+  customer?: (Stripe.Customer | Stripe.DeletedCustomer) | null;
+  checkoutSession?: Stripe.Checkout.Session | null;
+};
+
+interface SalesReceiptCustomerDetails {
+  ref: QuickBooksReference;
+  email?: string | null;
+  billingAddress?: QuickBooksPhysicalAddress | null;
+  shippingAddress?: QuickBooksPhysicalAddress | null;
+}
+
+interface EnsureCustomerInput {
+  displayName: string;
+  email?: string | null;
+  givenName?: string | null;
+  familyName?: string | null;
+  phone?: string | null;
+  billingAddress?: QuickBooksPhysicalAddress | null;
+  shippingAddress?: QuickBooksPhysicalAddress | null;
+  stripeCustomerId?: string | null;
+  chargeId?: string | null;
+}
+
+interface EnsureCustomerResult {
+  ref: QuickBooksReference;
+  email?: string | null;
+  billingAddress?: QuickBooksPhysicalAddress | null;
+  shippingAddress?: QuickBooksPhysicalAddress | null;
 }
 
 interface BuildFeesJournalEntryInput {
@@ -154,6 +209,7 @@ export interface PostChargeToQboInput {
   fee: number;
   memo?: string;
   date: string | Date;
+  stripe?: StripeCustomerContext;
   options?: PostOptions;
 }
 
@@ -189,6 +245,254 @@ const centsToDollars = (value: number): number => {
   return Math.round(value) / 100;
 };
 
+const toTrimmed = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const normalizeEmail = (value: unknown): string | null => {
+  const trimmed = toTrimmed(value);
+  return trimmed ? trimmed.toLowerCase() : null;
+};
+
+const truncate = (value: string | null | undefined, length: number): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.length > length ? trimmed.slice(0, length) : trimmed;
+};
+
+const mapStripeAddress = (
+  address: Stripe.Address | null | undefined,
+): QuickBooksPhysicalAddress | null => {
+  if (!address) {
+    return null;
+  }
+
+  const extract = (key: keyof Stripe.Address): string | null => {
+    const candidate = (address as Stripe.Address)[key];
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      return trimmed.length > 0 ? trimmed : null;
+    }
+    return null;
+  };
+
+  const mapped: QuickBooksPhysicalAddress = {};
+
+  const line1 = extract('line1');
+  const line2 = extract('line2');
+  const city = extract('city');
+  const state = extract('state');
+  const postalCode = extract('postal_code');
+  const country = extract('country');
+
+  if (line1) {
+    mapped.Line1 = truncate(line1, 500) ?? undefined;
+  }
+  if (line2) {
+    mapped.Line2 = truncate(line2, 500) ?? undefined;
+  }
+  if (city) {
+    mapped.City = truncate(city, 255) ?? undefined;
+  }
+  if (state) {
+    mapped.CountrySubDivisionCode = truncate(state, 255) ?? undefined;
+  }
+  if (postalCode) {
+    mapped.PostalCode = truncate(postalCode, 30) ?? undefined;
+  }
+  if (country) {
+    mapped.Country = truncate(country, 255) ?? undefined;
+  }
+
+  return Object.keys(mapped).length > 0 ? mapped : null;
+};
+
+const sanitizeAddress = (
+  address: QuickBooksPhysicalAddress | null | undefined,
+): QuickBooksPhysicalAddress | undefined => {
+  if (!address) {
+    return undefined;
+  }
+
+  const sanitized: QuickBooksPhysicalAddress = {};
+
+  if (address.Line1) {
+    sanitized.Line1 = truncate(address.Line1, 500) ?? undefined;
+  }
+  if (address.Line2) {
+    sanitized.Line2 = truncate(address.Line2, 500) ?? undefined;
+  }
+  if (address.Line3) {
+    sanitized.Line3 = truncate(address.Line3, 500) ?? undefined;
+  }
+  if (address.Line4) {
+    sanitized.Line4 = truncate(address.Line4, 500) ?? undefined;
+  }
+  if (address.City) {
+    sanitized.City = truncate(address.City, 255) ?? undefined;
+  }
+  if (address.CountrySubDivisionCode) {
+    sanitized.CountrySubDivisionCode = truncate(address.CountrySubDivisionCode, 255) ?? undefined;
+  }
+  if (address.PostalCode) {
+    sanitized.PostalCode = truncate(address.PostalCode, 30) ?? undefined;
+  }
+  if (address.Country) {
+    sanitized.Country = truncate(address.Country, 255) ?? undefined;
+  }
+
+  return Object.keys(sanitized).length > 0 ? sanitized : undefined;
+};
+
+const splitName = (
+  name: string | null | undefined,
+): { givenName?: string | null; familyName?: string | null } => {
+  const trimmed = toTrimmed(name);
+  if (!trimmed) {
+    return {};
+  }
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 0) {
+    return {};
+  }
+
+  if (parts.length === 1) {
+    return { givenName: truncate(parts[0], 100) };
+  }
+
+  const givenName = parts.shift() ?? '';
+  const familyName = parts.join(' ');
+
+  return {
+    givenName: truncate(givenName, 100),
+    familyName: truncate(familyName, 100),
+  };
+};
+
+const isDeletedCustomer = (
+  customer: (Stripe.Customer | Stripe.DeletedCustomer) | null | undefined,
+): customer is Stripe.DeletedCustomer => {
+  return Boolean(customer && 'deleted' in customer && customer.deleted);
+};
+
+const deriveSalesReceiptCustomer = (
+  source: StripeCustomerContext,
+): EnsureCustomerInput => {
+  const activeCustomer =
+    source.customer && !isDeletedCustomer(source.customer)
+      ? (source.customer as Stripe.Customer)
+      : null;
+
+  const billingDetails = source.charge?.billing_details ?? null;
+  const chargeShipping = source.charge?.shipping ?? null;
+  const paymentShipping = source.paymentIntent?.shipping ?? null;
+  const checkoutDetails = source.checkoutSession?.customer_details ?? null;
+
+  const stripeCustomerId =
+    toTrimmed(
+      (typeof source.charge?.customer === 'string'
+        ? source.charge.customer
+        : source.charge?.customer && 'id' in source.charge.customer
+        ? (source.charge.customer as { id?: string }).id
+        : undefined) ||
+        (typeof source.paymentIntent?.customer === 'string'
+          ? source.paymentIntent.customer
+          : source.paymentIntent?.customer && 'id' in source.paymentIntent.customer
+          ? (source.paymentIntent.customer as { id?: string }).id
+          : undefined) ||
+        (activeCustomer?.id ?? null) ||
+        (typeof source.checkoutSession?.customer === 'string'
+          ? source.checkoutSession.customer
+          : source.checkoutSession?.customer && 'id' in source.checkoutSession.customer
+          ? (source.checkoutSession.customer as { id?: string }).id
+          : undefined),
+    ) ?? null;
+
+  const preferredName =
+    toTrimmed(billingDetails?.name) ||
+    toTrimmed(paymentShipping?.name) ||
+    toTrimmed(chargeShipping?.name) ||
+    toTrimmed(activeCustomer?.name) ||
+    toTrimmed(checkoutDetails?.name);
+
+  const email =
+    normalizeEmail(billingDetails?.email) ||
+    normalizeEmail(source.paymentIntent?.receipt_email) ||
+    normalizeEmail(checkoutDetails?.email) ||
+    normalizeEmail(activeCustomer?.email) ||
+    normalizeEmail(source.checkoutSession?.customer_email);
+
+  const phone =
+    toTrimmed(billingDetails?.phone) ||
+    toTrimmed(paymentShipping?.phone) ||
+    toTrimmed(chargeShipping?.phone) ||
+    toTrimmed(activeCustomer?.phone) ||
+    toTrimmed(activeCustomer?.shipping?.phone) ||
+    toTrimmed(checkoutDetails?.phone);
+
+  const billingAddress =
+    mapStripeAddress(billingDetails?.address) ||
+    mapStripeAddress(activeCustomer?.address) ||
+    mapStripeAddress(checkoutDetails?.address);
+
+  const shippingAddress =
+    mapStripeAddress(paymentShipping?.address) ||
+    mapStripeAddress(chargeShipping?.address) ||
+    mapStripeAddress(activeCustomer?.shipping?.address) ||
+    mapStripeAddress(checkoutDetails?.address);
+
+  const fallbackName =
+    preferredName ||
+    email ||
+    (stripeCustomerId ? `Stripe Customer ${stripeCustomerId}` : null) ||
+    (source.charge?.id ? `Stripe Charge ${source.charge.id}` : null) ||
+    (source.paymentIntent?.id ? `Stripe Payment ${source.paymentIntent.id}` : null) ||
+    'Stripe Customer';
+
+  const { givenName, familyName } = splitName(preferredName ?? fallbackName);
+
+  return {
+    displayName: truncate(fallbackName, 99) ?? 'Stripe Customer',
+    email,
+    givenName,
+    familyName,
+    phone,
+    billingAddress,
+    shippingAddress,
+    stripeCustomerId,
+    chargeId: source.charge?.id ?? null,
+  };
+};
+
+const getCheckoutTransactionType = (
+  session: Stripe.Checkout.Session | null | undefined,
+): string | null => {
+  if (!session) {
+    return null;
+  }
+
+  const metadata = session.metadata as Record<string, unknown> | null | undefined;
+  if (!metadata || typeof metadata !== 'object') {
+    return null;
+  }
+
+  const value = metadata.transactionType;
+  return typeof value === 'string' ? toTrimmed(value) : null;
+};
+
 const normalizeDate = (value: string | Date): string => {
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) {
@@ -222,6 +526,349 @@ const ensureReferenceValue = <T extends QuickBooksReference>(
   }
 
   return { ...ref, ...normalized } as T;
+};
+
+const queryQuickBooks = async <T = unknown>(
+  query: string,
+  context: QuickBooksRequestContext,
+): Promise<T[]> => {
+  const url = buildQboQueryUrl(query);
+  const response = await context.request(url, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+    throw new Error(
+      `QuickBooks query failed (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const queryResponse =
+    data && typeof data === 'object'
+      ? ((data as Record<string, unknown>).QueryResponse as Record<string, unknown> | undefined)
+      : undefined;
+
+  if (!queryResponse) {
+    return [];
+  }
+
+  const values = Object.values(queryResponse).find((value) =>
+    Array.isArray(value) || (value && typeof value === 'object'),
+  );
+
+  if (!values) {
+    return [];
+  }
+
+  if (Array.isArray(values)) {
+    return values as T[];
+  }
+
+  return [values as T];
+};
+
+const findCustomerByEmail = async (
+  email: string,
+  context: QuickBooksRequestContext,
+) => {
+  const query = `select Id, DisplayName, PrimaryEmailAddr from Customer where PrimaryEmailAddr = '${escapeQueryValue(
+    email,
+  )}'`;
+  const customers = await queryQuickBooks<Record<string, unknown>>(query, context);
+
+  return (
+    customers.find((customer) => {
+      const addr = customer?.PrimaryEmailAddr as { Address?: string } | undefined;
+      const value = addr?.Address;
+      return typeof value === 'string' && value.trim().toLowerCase() === email.toLowerCase();
+    }) ?? null
+  );
+};
+
+const findCustomerByDisplayName = async (
+  displayName: string,
+  context: QuickBooksRequestContext,
+) => {
+  const query = `select Id, DisplayName from Customer where DisplayName = '${escapeQueryValue(displayName)}'`;
+  const customers = await queryQuickBooks<Record<string, unknown>>(query, context);
+
+  return (
+    customers.find((customer) => {
+      const name = customer?.DisplayName;
+      return typeof name === 'string' && name.trim().toLowerCase() === displayName.toLowerCase();
+    }) ?? null
+  );
+};
+
+const ensureSalesReceiptCustomer = async (
+  input: EnsureCustomerInput,
+  context: QuickBooksRequestContext,
+): Promise<EnsureCustomerResult | null> => {
+  const displayName = truncate(input.displayName, 99) ?? 'Stripe Customer';
+  const email = input.email ? normalizeEmail(input.email) : null;
+  const givenName = truncate(input.givenName ?? null, 100);
+  const familyName = truncate(input.familyName ?? null, 100);
+  const phone = truncate(input.phone ?? null, 30);
+  const billingAddress = sanitizeAddress(input.billingAddress);
+  const shippingAddress = sanitizeAddress(input.shippingAddress);
+
+  let existing: Record<string, unknown> | null = null;
+
+  if (email) {
+    try {
+      existing = await findCustomerByEmail(email, context);
+    } catch (error) {
+      throw new Error(
+        `Failed to look up QuickBooks customer by email "${email}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  if (!existing) {
+    try {
+      existing = await findCustomerByDisplayName(displayName, context);
+    } catch (error) {
+      throw new Error(
+        `Failed to look up QuickBooks customer "${displayName}": ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  if (existing) {
+    const id = existing.Id;
+    if (typeof id === 'string' || typeof id === 'number') {
+      const value = typeof id === 'number' ? id.toString() : id.trim();
+      if (value) {
+        return {
+          ref: {
+            value,
+            name:
+              typeof existing.DisplayName === 'string'
+                ? existing.DisplayName
+                : displayName,
+          },
+          email,
+          billingAddress,
+          shippingAddress,
+        };
+      }
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    DisplayName: displayName,
+  };
+
+  if (email) {
+    payload.PrimaryEmailAddr = { Address: email } satisfies QuickBooksEmailAddress;
+  }
+  if (givenName) {
+    payload.GivenName = givenName;
+  }
+  if (familyName) {
+    payload.FamilyName = familyName;
+  }
+  if (phone) {
+    payload.PrimaryPhone = { FreeFormNumber: phone };
+  }
+  if (billingAddress) {
+    payload.BillAddr = billingAddress;
+  }
+  if (shippingAddress) {
+    payload.ShipAddr = shippingAddress;
+  }
+
+  const note = input.stripeCustomerId
+    ? `Stripe Customer ID: ${input.stripeCustomerId}`
+    : input.chargeId
+    ? `Stripe Charge ID: ${input.chargeId}`
+    : null;
+  if (note) {
+    payload.Notes = truncate(note, 500);
+  }
+
+  const url = buildQboUrl('customer');
+  const response = await context.request(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+
+    if (
+      response.status === 400 &&
+      errorText &&
+      /Duplicate Name Exists Error/i.test(errorText)
+    ) {
+      const duplicate = await findCustomerByDisplayName(displayName, context);
+      if (duplicate) {
+        const id = duplicate.Id;
+        if (typeof id === 'string' || typeof id === 'number') {
+          const value = typeof id === 'number' ? id.toString() : id.trim();
+          if (value) {
+            return {
+              ref: {
+                value,
+                name:
+                  typeof duplicate.DisplayName === 'string'
+                    ? duplicate.DisplayName
+                    : displayName,
+              },
+              email,
+              billingAddress,
+              shippingAddress,
+            };
+          }
+        }
+      }
+    }
+
+    throw new Error(
+      `Failed to create QuickBooks customer "${displayName}" (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const customer =
+    data && typeof data === 'object'
+      ? ((data as Record<string, unknown>).Customer as Record<string, unknown> | undefined)
+      : undefined;
+
+  const idValue = customer?.Id;
+  const resolvedDisplayName =
+    typeof customer?.DisplayName === 'string'
+      ? customer.DisplayName
+      : displayName;
+
+  if (typeof idValue === 'string' && idValue.trim()) {
+    return {
+      ref: { value: idValue.trim(), name: resolvedDisplayName },
+      email,
+      billingAddress,
+      shippingAddress,
+    };
+  }
+
+  if (typeof idValue === 'number' && Number.isFinite(idValue)) {
+    return {
+      ref: { value: idValue.toString(), name: resolvedDisplayName },
+      email,
+      billingAddress,
+      shippingAddress,
+    };
+  }
+
+  throw new Error('QuickBooks customer creation response did not include an identifier.');
+};
+
+const ensureSalesReceiptItem = async (
+  itemName: string,
+  context: QuickBooksRequestContext,
+): Promise<QuickBooksReference> => {
+  const trimmedName = toTrimmed(itemName);
+  if (!trimmedName) {
+    throw new Error('Stripe Checkout Session metadata.transactionType must be provided.');
+  }
+
+  const truncatedName = truncate(trimmedName, 100) ?? trimmedName;
+
+  const existing = await findItemReferenceByName(truncatedName, context);
+  if (existing) {
+    return existing;
+  }
+
+  const revenueAccountRef = createAccountRef(env.quickBooks.accounts.revenue);
+  await resolveAccountReferences([revenueAccountRef], context);
+
+  const payload: Record<string, unknown> = {
+    Name: truncatedName,
+    Type: 'Service',
+    IncomeAccountRef: { value: revenueAccountRef.value },
+  };
+
+  const url = buildQboUrl('item');
+  const response = await context.request(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const cacheKey = buildItemCacheKey(truncatedName);
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+
+    if (
+      response.status === 400 &&
+      errorText &&
+      /Duplicate Name Exists Error/i.test(errorText)
+    ) {
+      const duplicate = await findItemReferenceByName(truncatedName, context);
+      if (duplicate) {
+        return duplicate;
+      }
+    }
+
+    throw new Error(
+      `Failed to create QuickBooks item "${truncatedName}" (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const item =
+    data && typeof data === 'object'
+      ? ((data as Record<string, unknown>).Item as Record<string, unknown> | undefined)
+      : undefined;
+
+  const idValue = item?.Id;
+  const resolvedName =
+    typeof item?.Name === 'string' && item.Name.trim()
+      ? item.Name.trim()
+      : truncatedName;
+
+  if (typeof idValue === 'string' && idValue.trim()) {
+    const id = idValue.trim();
+    itemLookupCache.set(cacheKey, id);
+    return { value: id, name: resolvedName };
+  }
+
+  if (typeof idValue === 'number' && Number.isFinite(idValue)) {
+    const id = idValue.toString();
+    itemLookupCache.set(cacheKey, id);
+    return { value: id, name: resolvedName };
+  }
+
+  const created = await findItemReferenceByName(truncatedName, context);
+  if (created) {
+    return created;
+  }
+
+  throw new Error(
+    `QuickBooks item creation response did not include an identifier for "${truncatedName}".`,
+  );
 };
 
 const parseDelimitedReference = (
@@ -364,8 +1011,9 @@ export const buildSalesReceipt = ({
   memo,
   date,
   revenueAccountName = env.quickBooks.accounts.revenue,
-  revenueItemName = env.quickBooks.items?.revenue,
+  revenueItemName,
   depositAccountName = env.quickBooks.accounts.stripeClearing,
+  customer = null,
 }: BuildSalesReceiptInput): QuickBooksSalesReceipt => {
   const amount = ensurePositiveAmount(amountCents, 'Sales receipt amount');
   if (amount === 0) {
@@ -379,7 +1027,7 @@ export const buildSalesReceipt = ({
     );
   }
 
-  return {
+  const receipt: QuickBooksSalesReceipt = {
     DocNumber: docNumber,
     TxnDate: normalizeDate(date),
     PrivateNote: memo,
@@ -396,6 +1044,30 @@ export const buildSalesReceipt = ({
       },
     ],
   };
+
+  if (customer?.ref?.value) {
+    receipt.CustomerRef = {
+      value: customer.ref.value,
+      name: customer.ref.name,
+    };
+  }
+
+  const customerEmail = normalizeEmail(customer?.email ?? null);
+  if (customerEmail) {
+    receipt.BillEmail = { Address: customerEmail };
+  }
+
+  const billingAddress = sanitizeAddress(customer?.billingAddress);
+  if (billingAddress) {
+    receipt.BillAddr = billingAddress;
+  }
+
+  const shippingAddress = sanitizeAddress(customer?.shippingAddress);
+  if (shippingAddress) {
+    receipt.ShipAddr = shippingAddress;
+  }
+
+  return receipt;
 };
 
 const createJournalEntryLine = (
@@ -893,17 +1565,26 @@ const isItemLookupRequired = (ref: ItemRefWithMetadata): boolean => {
   return Boolean(metadata && metadata.resolved === false);
 };
 
-const resolveItemId = async (
+const buildItemCacheKey = (name: string): string => {
+  return `${env.quickBooks.environment}:${env.quickBooks.realmId ?? ''}:item:${name.trim().toLowerCase()}`;
+};
+
+const findItemReferenceByName = async (
   name: string,
   context: QuickBooksRequestContext,
-): Promise<string> => {
-  const cacheKey = `${env.quickBooks.environment}:${env.quickBooks.realmId ?? ''}:item:${name.toLowerCase()}`;
-  const cached = itemLookupCache.get(cacheKey);
-  if (cached) {
-    return cached;
+): Promise<QuickBooksReference | null> => {
+  const normalizedName = name.trim();
+  if (!normalizedName) {
+    return null;
   }
 
-  const query = `select Id, Name from Item where Name = '${escapeQueryValue(name)}'`;
+  const cacheKey = buildItemCacheKey(normalizedName);
+  const cached = itemLookupCache.get(cacheKey);
+  if (cached) {
+    return { value: cached, name: normalizedName };
+  }
+
+  const query = `select Id, Name from Item where Name = '${escapeQueryValue(normalizedName)}'`;
   const url = buildQboQueryUrl(query);
   const response = await context.request(url, {
     method: 'GET',
@@ -915,7 +1596,7 @@ const resolveItemId = async (
   if (!response.ok) {
     const errorText = await response.text().catch(() => undefined);
     throw new Error(
-      `Failed to resolve QuickBooks item "${name}" (status ${response.status}): ${
+      `Failed to look up QuickBooks item "${normalizedName}" (status ${response.status}): ${
         errorText ?? response.statusText
       }`,
     );
@@ -941,20 +1622,17 @@ const resolveItemId = async (
     if (typeof itemName !== 'string') {
       return false;
     }
-    return itemName.trim().toLowerCase() === name.trim().toLowerCase();
+    return itemName.trim().toLowerCase() === normalizedName.toLowerCase();
   }) ?? itemList[0];
 
   if (!match || typeof match !== 'object') {
-    throw new Error(
-      `QuickBooks item "${name}" could not be found. ` +
-        'Provide the item ID in configuration or ensure the item exists in QuickBooks.',
-    );
+    return null;
   }
 
   const idValue = (match as Record<string, unknown>).Id;
   if (typeof idValue !== 'string' && typeof idValue !== 'number') {
     throw new Error(
-      `QuickBooks item "${name}" does not provide a usable ID. ` +
+      `QuickBooks item "${normalizedName}" does not provide a usable ID. ` +
         'Update the configuration to include the item ID.',
     );
   }
@@ -962,12 +1640,32 @@ const resolveItemId = async (
   const id = typeof idValue === 'number' ? idValue.toString() : idValue.trim();
   if (!id) {
     throw new Error(
-      `QuickBooks item "${name}" returned an empty ID. Update the configuration to include the item ID.`,
+      `QuickBooks item "${normalizedName}" returned an empty ID. Update the configuration to include the item ID.`,
     );
   }
 
+  const resolvedName =
+    typeof (match as Record<string, unknown>).Name === 'string'
+      ? ((match as Record<string, unknown>).Name as string).trim() || normalizedName
+      : normalizedName;
+
   itemLookupCache.set(cacheKey, id);
-  return id;
+  return { value: id, name: resolvedName };
+};
+
+const resolveItemId = async (
+  name: string,
+  context: QuickBooksRequestContext,
+): Promise<string> => {
+  const reference = await findItemReferenceByName(name, context);
+  if (!reference) {
+    throw new Error(
+      `QuickBooks item "${name}" could not be found. ` +
+        'Provide the item ID in configuration or ensure the item exists in QuickBooks.',
+    );
+  }
+
+  return reference.value;
 };
 
 const resolveItemReferences = async (
@@ -1239,6 +1937,7 @@ export const postChargeToQbo = async ({
   fee,
   memo,
   date,
+  stripe,
   options,
 }: PostChargeToQboInput): Promise<PostChargeToQboResult> => {
   const grossAmount = ensurePositiveAmount(gross, 'Gross amount');
@@ -1249,11 +1948,58 @@ export const postChargeToQbo = async ({
 
   if (strategy === 'sales-receipt') {
     const salesReceiptDocNumber = buildDocNumber('CHG', date, grossAmount);
+    const context = createRequestContext(options);
+    let receiptCustomer: SalesReceiptCustomerDetails | null = null;
+
+    try {
+      const derived = deriveSalesReceiptCustomer({ ...(stripe ?? {}) });
+      const ensured = await ensureSalesReceiptCustomer(derived, context);
+      if (ensured) {
+        receiptCustomer = {
+          ref: ensured.ref,
+          email: ensured.email ?? null,
+          billingAddress: ensured.billingAddress ?? null,
+          shippingAddress: ensured.shippingAddress ?? null,
+        };
+      }
+    } catch (error) {
+      throw new Error(
+        `Failed to ensure QuickBooks customer for sales receipt: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    const transactionTypeName = getCheckoutTransactionType(stripe?.checkoutSession);
+    if (!transactionTypeName) {
+      throw new Error(
+        'Stripe Checkout Session metadata.transactionType is required to determine the QuickBooks item for sales receipts.',
+      );
+    }
+
+    let revenueItemReference: QuickBooksReference;
+    try {
+      revenueItemReference = await ensureSalesReceiptItem(transactionTypeName, context);
+    } catch (error) {
+      throw new Error(
+        `Failed to ensure QuickBooks item "${transactionTypeName}" for sales receipt: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+
+    const revenueItemPayload = JSON.stringify({
+      value: revenueItemReference.value,
+      name: revenueItemReference.name ?? transactionTypeName,
+    });
+
     const salesReceipt = buildSalesReceipt({
       docNumber: salesReceiptDocNumber,
       amountCents: grossAmount,
       memo: normalizedMemo,
       date,
+      revenueItemName: revenueItemPayload,
+      customer: receiptCustomer,
     });
 
     const salesReceiptResult = await postSalesReceipt(salesReceipt, options);

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -163,6 +163,7 @@ interface SalesReceiptCustomerDetails {
 
 interface EnsureCustomerInput {
   displayName: string;
+  preferredDisplayName?: string | null;
   email?: string | null;
   givenName?: string | null;
   familyName?: string | null;
@@ -270,6 +271,12 @@ const truncate = (value: string | null | undefined, length: number): string | nu
   }
 
   return trimmed.length > length ? trimmed.slice(0, length) : trimmed;
+};
+
+const equalsIgnoreCase = (a: string | null | undefined, b: string | null | undefined): boolean => {
+  const left = a?.trim().toLowerCase();
+  const right = b?.trim().toLowerCase();
+  return Boolean(left && right && left === right);
 };
 
 const mapStripeAddress = (
@@ -466,6 +473,7 @@ const deriveSalesReceiptCustomer = (
 
   return {
     displayName: truncate(fallbackName, 99) ?? 'Stripe Customer',
+    preferredDisplayName: truncate(preferredName ?? null, 99),
     email,
     givenName,
     familyName,
@@ -607,6 +615,100 @@ const findCustomerByDisplayName = async (
   );
 };
 
+const fetchQuickBooksCustomer = async (
+  id: string,
+  context: QuickBooksRequestContext,
+): Promise<Record<string, unknown>> => {
+  const trimmedId = id.trim();
+  if (!trimmedId) {
+    throw new Error('QuickBooks customer ID is required to load customer details.');
+  }
+
+  const url = `${buildQboUrl('customer')}/${encodeURIComponent(trimmedId)}`;
+  const response = await context.request(url, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+    throw new Error(
+      `Failed to load QuickBooks customer "${trimmedId}" (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const customer =
+    data && typeof data === 'object'
+      ? ((data as Record<string, unknown>).Customer as Record<string, unknown> | undefined)
+      : undefined;
+
+  if (!customer) {
+    throw new Error('QuickBooks customer response did not include a Customer record.');
+  }
+
+  return customer;
+};
+
+const updateQuickBooksCustomer = async (
+  id: string,
+  updates: Record<string, unknown>,
+  context: QuickBooksRequestContext,
+): Promise<Record<string, unknown>> => {
+  const customer = await fetchQuickBooksCustomer(id, context);
+  const syncTokenRaw = customer.SyncToken;
+  const syncToken =
+    typeof syncTokenRaw === 'number'
+      ? syncTokenRaw.toString()
+      : typeof syncTokenRaw === 'string'
+      ? syncTokenRaw.trim()
+      : null;
+
+  if (!syncToken) {
+    throw new Error('QuickBooks customer record did not include a SyncToken.');
+  }
+
+  const payload: Record<string, unknown> = {
+    ...updates,
+    Id: customer.Id,
+    SyncToken: syncToken,
+    sparse: true,
+  };
+
+  const url = `${buildQboUrl('customer')}?operation=update`;
+  const response = await context.request(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => undefined);
+    throw new Error(
+      `Failed to update QuickBooks customer "${id}" (status ${response.status}): ${
+        errorText ?? response.statusText
+      }`,
+    );
+  }
+
+  const data = (await response.json().catch(() => undefined)) ?? {};
+  const updated =
+    data && typeof data === 'object'
+      ? ((data as Record<string, unknown>).Customer as Record<string, unknown> | undefined)
+      : undefined;
+
+  if (!updated) {
+    throw new Error('QuickBooks customer update response did not include a Customer record.');
+  }
+
+  return updated;
+};
+
 const ensureSalesReceiptCustomer = async (
   input: EnsureCustomerInput,
   context: QuickBooksRequestContext,
@@ -618,6 +720,7 @@ const ensureSalesReceiptCustomer = async (
   const phone = truncate(input.phone ?? null, 30);
   const billingAddress = sanitizeAddress(input.billingAddress);
   const shippingAddress = sanitizeAddress(input.shippingAddress);
+  const preferredDisplayName = truncate(input.preferredDisplayName ?? null, 99);
 
   let existing: Record<string, unknown> | null = null;
 
@@ -650,13 +753,62 @@ const ensureSalesReceiptCustomer = async (
     if (typeof id === 'string' || typeof id === 'number') {
       const value = typeof id === 'number' ? id.toString() : id.trim();
       if (value) {
+        let resolvedDisplayName =
+          typeof existing.DisplayName === 'string'
+            ? existing.DisplayName
+            : displayName;
+
+        if (
+          preferredDisplayName &&
+          !equalsIgnoreCase(resolvedDisplayName, preferredDisplayName)
+        ) {
+          const updatePayload: Record<string, unknown> = {
+            DisplayName: preferredDisplayName,
+          };
+
+          if (givenName) {
+            updatePayload.GivenName = givenName;
+          }
+          if (familyName) {
+            updatePayload.FamilyName = familyName;
+          }
+          if (email) {
+            updatePayload.PrimaryEmailAddr = {
+              Address: email,
+            } satisfies QuickBooksEmailAddress;
+          }
+          if (phone) {
+            updatePayload.PrimaryPhone = { FreeFormNumber: phone };
+          }
+          if (billingAddress) {
+            updatePayload.BillAddr = billingAddress;
+          }
+          if (shippingAddress) {
+            updatePayload.ShipAddr = shippingAddress;
+          }
+
+          try {
+            const updated = await updateQuickBooksCustomer(value, updatePayload, context);
+            const updatedName =
+              typeof updated.DisplayName === 'string'
+                ? updated.DisplayName
+                : preferredDisplayName;
+            if (updatedName) {
+              resolvedDisplayName = updatedName;
+            }
+          } catch (error) {
+            throw new Error(
+              `Failed to update QuickBooks customer "${displayName}" (${value}) with Stripe contact details: ${
+                error instanceof Error ? error.message : String(error)
+              }`,
+            );
+          }
+        }
+
         return {
           ref: {
             value,
-            name:
-              typeof existing.DisplayName === 'string'
-                ? existing.DisplayName
-                : displayName,
+            name: resolvedDisplayName,
           },
           email,
           billingAddress,

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -429,11 +429,11 @@ const deriveSalesReceiptCustomer = (
     ) ?? null;
 
   const preferredName =
-    toTrimmed(billingDetails?.name) ||
+    toTrimmed(activeCustomer?.name) ||
+    toTrimmed(checkoutDetails?.name) ||
     toTrimmed(paymentShipping?.name) ||
     toTrimmed(chargeShipping?.name) ||
-    toTrimmed(activeCustomer?.name) ||
-    toTrimmed(checkoutDetails?.name);
+    toTrimmed(billingDetails?.name);
 
   const email =
     normalizeEmail(billingDetails?.email) ||

--- a/tests/stripeTrueUp.test.js
+++ b/tests/stripeTrueUp.test.js
@@ -26,7 +26,11 @@ async function runDryRunTest() {
 
         setDependencies({
             stripe: {
-                getClient: () => ({}),
+                getClient: () => ({
+                    customers: {
+                        retrieve: async () => ({ id: 'cus_test', name: 'Donor Example' }),
+                    },
+                }),
             },
             fetchers: {
                 payments: async () => [


### PR DESCRIPTION
## Summary
- derive the sales receipt item from Stripe Checkout Session `transactionType` metadata and create the QuickBooks item when it is missing
- drop the `QBO_ITEM_REVENUE` configuration requirement and update local settings plus docs to reflect the metadata-driven item lookup
- refresh sales receipt tests to cover metadata-derived item lookups and automatic item creation

## Testing
- `npm run test:unit` *(fails: vitest binary unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eab2c36b54832cb7ffde61e9e874e6