### PR TITLE
Update Salesforce transaction naming to include type

### DIFF
--- a/src/config/contactMatching.ts
+++ b/src/config/contactMatching.ts
@@ -61,6 +61,7 @@ export interface TransactionMetadata {
   amount?: string;
   date?: string;
   id?: string;
+  transactionType?: string;
 }
 
 export function loadConfig(): ContactMatchConfig {
@@ -89,7 +90,7 @@ export function loadConfig(): ContactMatchConfig {
       },
     },
     transaction: {
-      nameTemplate: process.env.TRANSACTION_NAME_TEMPLATE || 'Transaction - {category}',
+      nameTemplate: process.env.TRANSACTION_NAME_TEMPLATE || '{category} - {transactionType}',
       defaultCategory: process.env.TRANSACTION_DEFAULT_CATEGORY || 'Uncategorized',
     },
     review: {
@@ -152,10 +153,16 @@ export function generateTransactionName(
 ): string {
   let name = config.transaction.nameTemplate;
 
-  name = name.replace('{category}', category);
-  name = name.replace('{amount}', metadata.amount || '');
-  name = name.replace('{date}', metadata.date || '');
-  name = name.replace('{id}', metadata.id || '');
+  const transactionType = metadata.transactionType || 'Payment';
+  const amount = metadata.amount || '';
+  const date = metadata.date || '';
+  const id = metadata.id || '';
+
+  name = name.replace(/\{category\}/g, category);
+  name = name.replace(/\{transactionType\}/g, transactionType);
+  name = name.replace(/\{amount\}/g, amount);
+  name = name.replace(/\{date\}/g, date);
+  name = name.replace(/\{id\}/g, id);
 
   return name;
 }

--- a/src/handlers/processTransaction.js
+++ b/src/handlers/processTransaction.js
@@ -600,10 +600,14 @@ const createPendingTransaction = async (context, session, contactId, transaction
             transactionRecord.Attribution__c = transactionData.attribution;
         }
 
+        const transactionTypeName =
+            transactionData.transactionType || transactionData.metadata?.transactionType || 'Payment';
+
         const name = generateTransactionName(normalizedCategory, matchingConfig, {
             amount: amount !== null ? `$${amount.toFixed(2)}` : undefined,
             date: new Date().toLocaleDateString(),
-            id: session.id
+            id: session.id,
+            transactionType: transactionTypeName
         });
 
         if (name) {

--- a/src/services/salesforce/salesforceCrm.js
+++ b/src/services/salesforce/salesforceCrm.js
@@ -385,13 +385,14 @@ class SalesforceCrmService extends BaseCrmService {
 
         const {
             amount,
-            currency = 'USD', 
+            currency = 'USD',
             paymentMethod = 'Credit Card',
             transactionId,
             status = 'Completed',
             description,
             frequency,
             category,
+            transactionType,
             name, // New field for proper transaction naming
             sessionId // New field for checkout session ID
         } = transactionData;
@@ -400,7 +401,10 @@ class SalesforceCrmService extends BaseCrmService {
         // If it fails, fall back to creating an Opportunity
         try {
             const transactionRecord = {
-                Name: name || description || `Transaction - ${category || 'Uncategorized'}`, // Add Name field
+                Name:
+                    name ||
+                    description ||
+                    `${category || 'Uncategorized'} - ${transactionType || 'Payment'}`, // Add Name field
                 Contact__c: contactId, // Assuming custom lookup field
                 Amount__c: amount / 100, // Convert cents to dollars
                 Currency__c: currency,
@@ -479,11 +483,12 @@ class SalesforceCrmService extends BaseCrmService {
      */
     async createOpportunityAsTransaction(contactId, transactionData) {
         const { 
-            amount, 
+            amount,
             transactionId,
             description,
             frequency,
             category,
+            transactionType,
             name, // New field for proper transaction naming
             sessionId, // New field for checkout session ID
             status = 'Completed'
@@ -507,7 +512,10 @@ class SalesforceCrmService extends BaseCrmService {
         }
 
         const opportunityRecord = {
-            Name: name || description || `Transaction - ${category || 'Uncategorized'}`, // Use new naming format
+            Name:
+                name ||
+                description ||
+                `${category || 'Uncategorized'} - ${transactionType || 'Payment'}`, // Use new naming format
             ContactId: contactId,
             Amount: amount / 100, // Convert cents to dollars
             StageName: stageName,

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -168,19 +168,19 @@ function runIntegrationTests() {
     test('Transaction name generation', () => {
         const config = loadConfig();
         const name = generateTransactionName('General Giving', config);
-        assertEqual(name, 'Transaction - General Giving');
+        assertEqual(name, 'General Giving - Payment');
     });
     
     test('Transaction name generation - General Donation', () => {
         const config = loadConfig();
-        const name = generateTransactionName('General Donation', config);
-        assertEqual(name, 'Transaction - General Donation');
+        const name = generateTransactionName('General Donation', config, { transactionType: 'Giving' });
+        assertEqual(name, 'General Donation - Giving');
     });
     
     test('Transaction name generation - Example Category', () => {
         const config = loadConfig();
-        const name = generateTransactionName('Example Category', config);
-        assertEqual(name, 'Transaction - Example Category');
+        const name = generateTransactionName('Example Category', config, { transactionType: 'Support' });
+        assertEqual(name, 'Example Category - Support');
     });
     
     // Test full integration flow - high confidence match
@@ -297,7 +297,7 @@ function runIntegrationTests() {
         
         const transaction = await mockCrm.createTransaction('0031234567890001', transactionData);
         
-        assertEqual(transaction.Name, 'Transaction - Youth Ministry');
+        assertEqual(transaction.Name, 'Youth Ministry - Payment');
         assertEqual(transaction.Category__c, 'Youth Ministry');
         assertEqual(transaction.Amount__c, 75.00);
     });


### PR DESCRIPTION
## Summary
- update the default transaction name template to use both category and transaction type
- ensure Salesforce pending transactions and fallbacks populate the new naming convention
- adjust integration tests to cover the new format

## Testing
- npm run build
- node tests/integration.test.js

------
https://chatgpt.com/codex/tasks/task_e_68eadf64ba68832ca8d69ced760f3927