### PR TITLE
Handle subscription transactions in Stripe webhook

### DIFF
--- a/__tests__/stripeWebhook.test.ts
+++ b/__tests__/stripeWebhook.test.ts
@@ -198,6 +198,9 @@ describe('stripeWebhook', () => {
           }),
         },
       },
+      invoices: {
+        retrieve: vi.fn(),
+      },
     };
 
     const accounting = {
@@ -269,5 +272,89 @@ describe('stripeWebhook', () => {
     expect(store.markProcessed).toHaveBeenCalledWith('evt_evt_test');
     expect(context.res.status).toBe(200);
     expect(JSON.parse(context.res.body)).toMatchObject({ received: true, eventType: 'payment_intent.succeeded' });
+  });
+
+  it('locates pending subscription transactions by subscription id when available', async () => {
+    const store = mockIdempotencyStore();
+    const stripeEvent = createStripeEvent();
+    (stripeEvent.data.object as any).invoice = 'in_test';
+    ((stripeEvent.data.object as any).charges.data[0] as any).invoice = 'in_test';
+
+    const stripeClient = {
+      balanceTransactions: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: 'bt_123',
+          amount: 1_000,
+          fee: 100,
+          net: 900,
+          currency: 'usd',
+          created: 1_700_000_000,
+          available_on: 1_700_000_100,
+          type: 'charge',
+        }),
+      },
+      charges: {
+        retrieve: vi.fn(),
+      },
+      customers: {
+        retrieve: vi.fn().mockResolvedValue({ id: 'cus_123' }),
+      },
+      checkout: {
+        sessions: {
+          list: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+      invoices: {
+        retrieve: vi.fn().mockResolvedValue({ id: 'in_test', subscription: 'sub_123' }),
+      },
+    };
+
+    const accounting = {
+      postChargeToQbo: vi.fn().mockResolvedValue({ qboId: '123', type: 'journal-entry' }),
+      postRefundToQbo: vi.fn(),
+      postDisputeToQbo: vi.fn(),
+    };
+
+    const salesforce = {
+      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'sf_1', success: true }),
+      linkPayoutOnTransactions: vi.fn(),
+      markPostedToQbo: vi.fn().mockResolvedValue(undefined),
+      findTransactionIdByExternalId: vi
+        .fn()
+        .mockImplementation(async (field: string) =>
+          field === 'stripe_subscription_id__c' ? 'sf_subscription' : null,
+        ),
+    };
+
+    const stripe = {
+      verifyEvent: vi.fn(() => stripeEvent),
+      getClient: vi.fn(() => stripeClient),
+    };
+
+    internals?.setDependencies({
+      stripe,
+      idempotencyStore: store,
+      getSalesforceSvc: async () => salesforce,
+      accounting,
+    });
+
+    const { context } = createContext();
+    const req = baseRequest();
+
+    await handler(context, req);
+
+    expect(stripeClient.invoices.retrieve).toHaveBeenCalledWith('in_test');
+    expect(salesforce.findTransactionIdByExternalId).toHaveBeenCalledWith(
+      'stripe_subscription_id__c',
+      'sub_123',
+    );
+    expect(salesforce.upsertTransactionByExternalId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_payment_intent_id__c: 'pi_test',
+        stripe_subscription_id__c: 'sub_123',
+      }),
+      'stripe_payment_intent_id__c',
+      { overrideId: 'sf_subscription' },
+    );
   });
 });

--- a/src/handlers/stripeWebhook.ts
+++ b/src/handlers/stripeWebhook.ts
@@ -484,6 +484,33 @@ const handlePaymentIntentSucceeded = async (
     balanceTransaction: balanceTransaction ?? undefined,
   });
 
+  const invoiceId =
+    normalizeStripeId(paymentIntent.invoice) || normalizeStripeId(charge?.invoice);
+
+  let subscriptionId =
+    transaction.stripe_subscription_id__c || normalizeStripeId(checkoutSession?.subscription);
+
+  if (!subscriptionId && invoiceId) {
+    try {
+      const invoice = await stripe.invoices.retrieve(invoiceId);
+      subscriptionId = normalizeStripeId(invoice?.subscription);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unknown error retrieving invoice for payment intent';
+      context.log('[StripeWebhook] Failed to retrieve invoice for payment intent', {
+        paymentIntentId: paymentIntent.id,
+        invoiceId,
+        error: message,
+      });
+    }
+  }
+
+  if (subscriptionId && !transaction.stripe_subscription_id__c) {
+    transaction.stripe_subscription_id__c = subscriptionId;
+  }
+
   let overrideId: string | null = null;
 
   if (checkoutSession) {
@@ -503,6 +530,24 @@ const handlePaymentIntentSucceeded = async (
           : 'Unknown error locating transaction by checkout session ID';
       context.log('[StripeWebhook] Failed to locate transaction by checkout session ID', {
         sessionId: checkoutSession.id,
+        error: message,
+      });
+    }
+  }
+
+  if (!overrideId && subscriptionId) {
+    try {
+      overrideId = await salesforce.findTransactionIdByExternalId(
+        'stripe_subscription_id__c',
+        subscriptionId,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unknown error locating transaction by subscription ID';
+      context.log('[StripeWebhook] Failed to locate transaction by subscription ID', {
+        subscriptionId,
         error: message,
       });
     }

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -48,7 +48,8 @@ export type TransactionExternalIdField =
   | 'stripe_dispute_id__c'
   | 'stripe_balance_transaction_id__c'
   | 'stripe_checkout_session_id__c'
-  | 'stripe_charge_id__c';
+  | 'stripe_charge_id__c'
+  | 'stripe_subscription_id__c';
 
 export interface QuickBooksDocumentReference {
   type: string;


### PR DESCRIPTION
## Summary
- capture Stripe subscription identifiers when handling successful payment intents
- fall back to locating Salesforce transactions by subscription external id before upserting
- add coverage to ensure subscription updates retrieve invoices and update QuickBooks posting flow

## Testing
- npm run build
- npx vitest run __tests__/stripeWebhook.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68eafc3809e0832c9c772bd08d145424