### PR TITLE
Force paid status for Stripe invoice payment updates

### DIFF
--- a/__tests__/stripeWebhook.test.ts
+++ b/__tests__/stripeWebhook.test.ts
@@ -198,6 +198,9 @@ describe('stripeWebhook', () => {
           }),
         },
       },
+      invoices: {
+        retrieve: vi.fn(),
+      },
     };
 
     const accounting = {
@@ -269,5 +272,338 @@ describe('stripeWebhook', () => {
     expect(store.markProcessed).toHaveBeenCalledWith('evt_evt_test');
     expect(context.res.status).toBe(200);
     expect(JSON.parse(context.res.body)).toMatchObject({ received: true, eventType: 'payment_intent.succeeded' });
+  });
+
+  it('locates pending subscription transactions by subscription id when available', async () => {
+    const store = mockIdempotencyStore();
+    const stripeEvent = createStripeEvent();
+    (stripeEvent.data.object as any).invoice = 'in_test';
+    ((stripeEvent.data.object as any).charges.data[0] as any).invoice = 'in_test';
+
+    const stripeClient = {
+      balanceTransactions: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: 'bt_123',
+          amount: 1_000,
+          fee: 100,
+          net: 900,
+          currency: 'usd',
+          created: 1_700_000_000,
+          available_on: 1_700_000_100,
+          type: 'charge',
+        }),
+      },
+      charges: {
+        retrieve: vi.fn(),
+      },
+      customers: {
+        retrieve: vi.fn().mockResolvedValue({ id: 'cus_123' }),
+      },
+      checkout: {
+        sessions: {
+          list: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+      invoices: {
+        retrieve: vi.fn().mockResolvedValue({ id: 'in_test', subscription: 'sub_123' }),
+      },
+    };
+
+    const accounting = {
+      postChargeToQbo: vi.fn().mockResolvedValue({ qboId: '123', type: 'journal-entry' }),
+      postRefundToQbo: vi.fn(),
+      postDisputeToQbo: vi.fn(),
+    };
+
+    const salesforce = {
+      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'sf_1', success: true }),
+      linkPayoutOnTransactions: vi.fn(),
+      markPostedToQbo: vi.fn().mockResolvedValue(undefined),
+      findTransactionIdByExternalId: vi
+        .fn()
+        .mockImplementation(async (field: string) =>
+          field === 'stripe_subscription_id__c' ? 'sf_subscription' : null,
+        ),
+    };
+
+    const stripe = {
+      verifyEvent: vi.fn(() => stripeEvent),
+      getClient: vi.fn(() => stripeClient),
+    };
+
+    internals?.setDependencies({
+      stripe,
+      idempotencyStore: store,
+      getSalesforceSvc: async () => salesforce,
+      accounting,
+    });
+
+    const { context } = createContext();
+    const req = baseRequest();
+
+    await handler(context, req);
+
+    expect(stripeClient.invoices.retrieve).toHaveBeenCalledWith('in_test');
+    expect(salesforce.findTransactionIdByExternalId).toHaveBeenCalledWith(
+      'stripe_subscription_id__c',
+      'sub_123',
+    );
+    expect(salesforce.upsertTransactionByExternalId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_payment_intent_id__c: 'pi_test',
+        stripe_subscription_id__c: 'sub_123',
+      }),
+      'stripe_payment_intent_id__c',
+      { overrideId: 'sf_subscription' },
+    );
+  });
+
+  it('processes invoice payment events and updates subscription transactions to paid', async () => {
+    const store = mockIdempotencyStore();
+    const invoiceEvent: Stripe.Event = {
+      id: 'evt_invoice',
+      type: 'invoice.payment_succeeded',
+      data: {
+        object: {
+          id: 'in_456',
+          payment_intent: 'pi_invoice',
+          subscription: 'sub_999',
+          customer: 'cus_999',
+        },
+      } as Stripe.Event.Data,
+      livemode: false,
+    };
+
+    const paymentIntent: Partial<Stripe.PaymentIntent> = {
+      id: 'pi_invoice',
+      status: 'succeeded',
+      currency: 'usd',
+      customer: 'cus_999',
+      created: 1_700_000_500,
+      invoice: 'in_456',
+      charges: {
+        data: [
+          {
+            id: 'ch_invoice',
+            status: 'succeeded',
+            amount: 2_000,
+            currency: 'usd',
+            balance_transaction: 'bt_invoice',
+            created: 1_700_000_500,
+            invoice: 'in_456',
+            payment_method_details: {
+              type: 'card',
+              card: {
+                brand: 'visa',
+                last4: '4242',
+              },
+            },
+          } as Stripe.Charge,
+        ],
+      },
+    };
+
+    const stripeClient = {
+      paymentIntents: {
+        retrieve: vi.fn().mockResolvedValue(paymentIntent),
+      },
+      balanceTransactions: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: 'bt_invoice',
+          amount: 2_000,
+          fee: 120,
+          net: 1_880,
+          currency: 'usd',
+          created: 1_700_000_500,
+          available_on: 1_700_000_600,
+          type: 'charge',
+        }),
+      },
+      charges: {
+        retrieve: vi.fn(),
+      },
+      customers: {
+        retrieve: vi.fn().mockResolvedValue({ id: 'cus_999' }),
+      },
+      checkout: {
+        sessions: {
+          list: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+      invoices: {
+        retrieve: vi.fn(),
+      },
+    };
+
+    const accounting = {
+      postChargeToQbo: vi.fn().mockResolvedValue({ qboId: '999', type: 'journal-entry' }),
+      postRefundToQbo: vi.fn(),
+      postDisputeToQbo: vi.fn(),
+    };
+
+    const salesforce = {
+      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'sf_paid', success: true }),
+      linkPayoutOnTransactions: vi.fn(),
+      markPostedToQbo: vi.fn().mockResolvedValue(undefined),
+      findTransactionIdByExternalId: vi
+        .fn()
+        .mockImplementation(async (field: string) =>
+          field === 'stripe_subscription_id__c' ? 'sf_pending_sub' : null,
+        ),
+    };
+
+    const stripe = {
+      verifyEvent: vi.fn(() => invoiceEvent),
+      getClient: vi.fn(() => stripeClient),
+    };
+
+    internals?.setDependencies({
+      stripe,
+      idempotencyStore: store,
+      getSalesforceSvc: async () => salesforce,
+      accounting,
+    });
+
+    const { context } = createContext();
+    const req = baseRequest();
+
+    await handler(context, req);
+
+    expect(stripeClient.paymentIntents.retrieve).toHaveBeenCalledWith('pi_invoice');
+    expect(salesforce.findTransactionIdByExternalId).toHaveBeenCalledWith(
+      'stripe_subscription_id__c',
+      'sub_999',
+    );
+    expect(salesforce.upsertTransactionByExternalId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_payment_intent_id__c: 'pi_invoice',
+        status__c: 'paid',
+        stripe_subscription_id__c: 'sub_999',
+      }),
+      'stripe_payment_intent_id__c',
+      { overrideId: 'sf_pending_sub' },
+    );
+    expect(accounting.postChargeToQbo).toHaveBeenCalled();
+    expect(stripeClient.invoices.retrieve).not.toHaveBeenCalled();
+    expect(store.markProcessed).toHaveBeenCalledWith('evt_evt_invoice');
+    expect(context.res.status).toBe(200);
+  });
+
+  it('forces the transaction status to paid when the invoice indicates payment completion', async () => {
+    const store = mockIdempotencyStore();
+    const invoiceEvent: Stripe.Event = {
+      id: 'evt_invoice_paid',
+      type: 'invoice.paid',
+      data: {
+        object: {
+          id: 'in_paid',
+          payment_intent: 'pi_paid',
+          subscription: 'sub_paid',
+          customer: 'cus_paid',
+          status: 'paid',
+          paid: true,
+        },
+      } as Stripe.Event.Data,
+      livemode: false,
+    };
+
+    const charge: Partial<Stripe.Charge> = {
+      id: 'ch_paid',
+      status: 'pending',
+      amount: 5_000,
+      currency: 'usd',
+      balance_transaction: 'bt_paid',
+      invoice: 'in_paid',
+    };
+
+    const paymentIntent: Partial<Stripe.PaymentIntent> = {
+      id: 'pi_paid',
+      status: 'processing',
+      currency: 'usd',
+      customer: 'cus_paid',
+      created: 1_700_000_700,
+      invoice: 'in_paid',
+      latest_charge: 'ch_paid',
+      charges: { data: [charge as Stripe.Charge] },
+    };
+
+    const stripeClient = {
+      paymentIntents: {
+        retrieve: vi.fn().mockResolvedValue(paymentIntent),
+      },
+      balanceTransactions: {
+        retrieve: vi.fn().mockResolvedValue({
+          id: 'bt_paid',
+          amount: 5_000,
+          fee: 150,
+          net: 4_850,
+          currency: 'usd',
+          created: 1_700_000_700,
+          available_on: 1_700_000_800,
+          type: 'charge',
+        }),
+      },
+      charges: {
+        retrieve: vi.fn().mockResolvedValue(charge),
+      },
+      customers: {
+        retrieve: vi.fn().mockResolvedValue({ id: 'cus_paid' }),
+      },
+      checkout: {
+        sessions: {
+          list: vi.fn().mockResolvedValue({ data: [] }),
+        },
+      },
+      invoices: {
+        retrieve: vi.fn(),
+      },
+    };
+
+    const salesforce = {
+      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'sf_paid', success: true }),
+      linkPayoutOnTransactions: vi.fn(),
+      markPostedToQbo: vi.fn().mockResolvedValue(undefined),
+      findTransactionIdByExternalId: vi
+        .fn()
+        .mockImplementation(async (field: string) =>
+          field === 'stripe_subscription_id__c' ? 'sf_sub' : null,
+        ),
+    };
+
+    const accounting = {
+      postChargeToQbo: vi.fn().mockResolvedValue({ qboId: 'paid', type: 'journal-entry' }),
+      postRefundToQbo: vi.fn(),
+      postDisputeToQbo: vi.fn(),
+    };
+
+    const stripe = {
+      verifyEvent: vi.fn(() => invoiceEvent),
+      getClient: vi.fn(() => stripeClient),
+    };
+
+    internals?.setDependencies({
+      stripe,
+      idempotencyStore: store,
+      getSalesforceSvc: async () => salesforce,
+      accounting,
+    });
+
+    const { context } = createContext();
+    const req = baseRequest();
+
+    await handler(context, req);
+
+    expect(stripeClient.paymentIntents.retrieve).toHaveBeenCalledWith('pi_paid');
+    expect(salesforce.upsertTransactionByExternalId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripe_payment_intent_id__c: 'pi_paid',
+        status__c: 'paid',
+        stripe_subscription_id__c: 'sub_paid',
+      }),
+      'stripe_payment_intent_id__c',
+      { overrideId: 'sf_sub' },
+    );
+    expect(accounting.postChargeToQbo).toHaveBeenCalled();
+    expect(store.markProcessed).toHaveBeenCalledWith('evt_evt_invoice_paid');
   });
 });

--- a/src/handlers/stripeWebhook.ts
+++ b/src/handlers/stripeWebhook.ts
@@ -450,15 +450,23 @@ const markPosted = async (
   }
 };
 
-const handlePaymentIntentSucceeded = async (
-  context: HttpContext,
-  event: Stripe.Event,
-  deps: Dependencies,
-): Promise<void> => {
-  const paymentIntent = event.data.object as Stripe.PaymentIntent;
-  const stripe = deps.stripe.getClient(Boolean(event.livemode));
-  const salesforce = await deps.getSalesforceSvc();
+interface ProcessPaymentIntentOptions {
+  context: HttpContext;
+  paymentIntent: Stripe.PaymentIntent;
+  stripe: Stripe;
+  salesforce: SalesforceSvc;
+  deps: Dependencies;
+  invoice?: Stripe.Invoice | null;
+}
 
+const processSuccessfulPaymentIntent = async ({
+  context,
+  paymentIntent,
+  stripe,
+  salesforce,
+  deps,
+  invoice,
+}: ProcessPaymentIntentOptions): Promise<void> => {
   const charge = await resolveCharge(stripe, paymentIntent);
   const balanceTransaction = await resolveBalanceTransaction(
     stripe,
@@ -484,6 +492,47 @@ const handlePaymentIntentSucceeded = async (
     balanceTransaction: balanceTransaction ?? undefined,
   });
 
+  const invoiceId =
+    normalizeStripeId(paymentIntent.invoice) ||
+    normalizeStripeId(charge?.invoice) ||
+    normalizeStripeId(invoice?.id);
+
+  let resolvedInvoice: Stripe.Invoice | null = invoice ?? null;
+
+  let subscriptionId =
+    transaction.stripe_subscription_id__c ||
+    normalizeStripeId(checkoutSession?.subscription) ||
+    normalizeStripeId(invoice?.subscription);
+
+  if (!subscriptionId && invoiceId && !invoice) {
+    try {
+      const loadedInvoice = await stripe.invoices.retrieve(invoiceId);
+      resolvedInvoice = loadedInvoice as Stripe.Invoice;
+      subscriptionId = normalizeStripeId(loadedInvoice?.subscription);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unknown error retrieving invoice for payment intent';
+      context.log('[StripeWebhook] Failed to retrieve invoice for payment intent', {
+        paymentIntentId: paymentIntent.id,
+        invoiceId,
+        error: message,
+      });
+    }
+  }
+
+  if (subscriptionId && !transaction.stripe_subscription_id__c) {
+    transaction.stripe_subscription_id__c = subscriptionId;
+  }
+
+  if (
+    resolvedInvoice &&
+    (resolvedInvoice.status === 'paid' || resolvedInvoice.paid === true)
+  ) {
+    transaction.status__c = 'paid';
+  }
+
   let overrideId: string | null = null;
 
   if (checkoutSession) {
@@ -503,6 +552,24 @@ const handlePaymentIntentSucceeded = async (
           : 'Unknown error locating transaction by checkout session ID';
       context.log('[StripeWebhook] Failed to locate transaction by checkout session ID', {
         sessionId: checkoutSession.id,
+        error: message,
+      });
+    }
+  }
+
+  if (!overrideId && subscriptionId) {
+    try {
+      overrideId = await salesforce.findTransactionIdByExternalId(
+        'stripe_subscription_id__c',
+        subscriptionId,
+      );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unknown error locating transaction by subscription ID';
+      context.log('[StripeWebhook] Failed to locate transaction by subscription ID', {
+        subscriptionId,
         error: message,
       });
     }
@@ -555,6 +622,68 @@ const handlePaymentIntentSucceeded = async (
       await markPosted(salesforce, upsertResult, posting);
     },
   );
+};
+
+const handlePaymentIntentSucceeded = async (
+  context: HttpContext,
+  event: Stripe.Event,
+  deps: Dependencies,
+): Promise<void> => {
+  const paymentIntent = event.data.object as Stripe.PaymentIntent;
+  const stripe = deps.stripe.getClient(Boolean(event.livemode));
+  const salesforce = await deps.getSalesforceSvc();
+
+  await processSuccessfulPaymentIntent({
+    context,
+    paymentIntent,
+    stripe,
+    salesforce,
+    deps,
+  });
+};
+
+const handleInvoicePaymentSucceeded = async (
+  context: HttpContext,
+  event: Stripe.Event,
+  deps: Dependencies,
+): Promise<void> => {
+  const invoice = event.data.object as Stripe.Invoice;
+  const paymentIntentId = normalizeStripeId(invoice.payment_intent);
+
+  if (!paymentIntentId) {
+    context.log('[StripeWebhook] Invoice payment event missing payment intent', {
+      invoiceId: invoice.id,
+    });
+    return;
+  }
+
+  const stripe = deps.stripe.getClient(Boolean(event.livemode));
+  const salesforce = await deps.getSalesforceSvc();
+
+  let paymentIntent: Stripe.PaymentIntent;
+  try {
+    paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Unknown error retrieving payment intent for invoice';
+    context.log('[StripeWebhook] Failed to retrieve payment intent for invoice', {
+      invoiceId: invoice.id,
+      paymentIntentId,
+      error: message,
+    });
+    return;
+  }
+
+  await processSuccessfulPaymentIntent({
+    context,
+    paymentIntent,
+    stripe,
+    salesforce,
+    deps,
+    invoice,
+  });
 };
 
 const getLatestRefund = (charge: Stripe.Charge): Stripe.Refund | null => {
@@ -804,6 +933,10 @@ const processEvent = async (
       return;
     case 'charge.dispute.closed':
       await handleDisputeClosed(context, event, deps);
+      return;
+    case 'invoice.paid':
+    case 'invoice.payment_succeeded':
+      await handleInvoicePaymentSucceeded(context, event, deps);
       return;
     default:
       context.log('[StripeWebhook] Ignoring unsupported event type', {

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -48,7 +48,8 @@ export type TransactionExternalIdField =
   | 'stripe_dispute_id__c'
   | 'stripe_balance_transaction_id__c'
   | 'stripe_checkout_session_id__c'
-  | 'stripe_charge_id__c';
+  | 'stripe_charge_id__c'
+  | 'stripe_subscription_id__c';
 
 export interface QuickBooksDocumentReference {
   type: string;


### PR DESCRIPTION
## Summary
- ensure Stripe invoice updates override the transaction status to paid whenever the invoice itself is marked paid
- reuse retrieved invoice details for subscription resolution while keeping existing overrides intact
- extend the Stripe webhook unit tests to cover the paid invoice status override scenario

## Testing
- npm run build
- npx vitest run __tests__/stripeWebhook.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68eafc3809e0832c9c772bd08d145424