### PR TITLE
Handle Stripe refunds by updating charge transactions and QBO adjustments

### DIFF
--- a/__tests__/stripeRefundsHandler.test.ts
+++ b/__tests__/stripeRefundsHandler.test.ts
@@ -119,6 +119,12 @@ const setup = ({
         return transaction;
       }),
     },
+    refunds: {
+      list: vi.fn().mockResolvedValue({
+        data: Array.isArray(charge.refunds?.data) ? charge.refunds.data : [],
+        has_more: false,
+      }),
+    },
   } as unknown as Stripe;
 
   const upsertResult = { id: 'sf_txn_1' };
@@ -141,6 +147,7 @@ const setup = ({
       .fn()
       .mockResolvedValue({ qboId: 'RR-1', type: 'refund-receipt' }),
     markRefundFailed: vi.fn().mockResolvedValue(undefined),
+    appendSalesReceiptAdjustments: vi.fn().mockResolvedValue(undefined),
   };
 
   const deps: StripeWebhookDependencies = {
@@ -213,6 +220,7 @@ describe('handleRefundEvent', () => {
         qbo_sales_receipt_number: 'CHG-20240101-1000',
         qbo_sales_receipt_lines: lineMetadata,
       },
+      amount_refunded: 1_000,
     });
 
     const paymentIntent = createPaymentIntent({ metadata: {} });
@@ -235,10 +243,27 @@ describe('handleRefundEvent', () => {
       600,
       400,
     ]);
+    expect(salesforce.upsertTransactionByExternalId).toHaveBeenCalledTimes(2);
+    const [refundCall, chargeCall] = salesforce.upsertTransactionByExternalId.mock.calls;
+    expect(refundCall[1]).toBe('stripe_refund_id__c');
+    expect(chargeCall[1]).toBe('stripe_charge_id__c');
+    expect(chargeCall[2]).toEqual({ overrideId: 'sf_charge_1' });
+    expect(chargeCall[0].amount_net__c).toBe(0);
+    expect(chargeCall[0].status__c).toBe('refunded');
     expect(salesforce.markPostedToQbo).toHaveBeenCalledWith('sf_txn_1', {
       qboId: 'RR-1',
       type: 'refund-receipt',
     });
+    expect(refundAdapter.appendSalesReceiptAdjustments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        docNumber: 'CHG-20240101-1000',
+        lines: [
+          expect.objectContaining({ amountCents: -600 }),
+          expect.objectContaining({ amountCents: -400 }),
+        ],
+        stripeRefundId: 're_123',
+      }),
+    );
   });
 
   it('prorates refund lines for partial refunds', async () => {
@@ -260,6 +285,7 @@ describe('handleRefundEvent', () => {
         qbo_sales_receipt_number: 'CHG-20240101-1000',
         qbo_sales_receipt_lines: lineMetadata,
       },
+      amount_refunded: 500,
     });
 
     const refund = createRefund({ amount: 500 });
@@ -275,6 +301,20 @@ describe('handleRefundEvent', () => {
       300,
       200,
     ]);
+    const chargeCall = salesforce.upsertTransactionByExternalId.mock.calls.find(
+      (call) => call[1] === 'stripe_charge_id__c',
+    );
+    expect(chargeCall).toBeDefined();
+    expect(chargeCall?.[0].amount_net__c).toBe(5);
+    expect(chargeCall?.[0].status__c).toBe('paid');
+    expect(refundAdapter.appendSalesReceiptAdjustments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lines: [
+          expect.objectContaining({ amountCents: -300 }),
+          expect.objectContaining({ amountCents: -200 }),
+        ],
+      }),
+    );
   });
 
   it('updates refund receipt when refund amount changes', async () => {
@@ -293,6 +333,7 @@ describe('handleRefundEvent', () => {
     const firstRefund = createRefund({ id: 're_partial', amount: 400 });
     const secondRefund = createRefund({ id: 're_partial', amount: 700 });
 
+    charge.amount_refunded = 400;
     const firstSetup = setup({ charge, refund: firstRefund });
     const { deps, refundAdapter } = firstSetup;
     const { context } = createContext();
@@ -307,7 +348,9 @@ describe('handleRefundEvent', () => {
     ).toEqual([240, 160]);
 
     refundAdapter.upsertRefundReceipt.mockClear();
+    refundAdapter.appendSalesReceiptAdjustments.mockClear();
 
+    charge.amount_refunded = 700;
     const secondSetup = setup({ charge, refund: secondRefund });
     await handleRefundEvent(context, secondSetup.event, secondSetup.deps);
 
@@ -317,6 +360,7 @@ describe('handleRefundEvent', () => {
         (line: RefundReceiptLineInput) => line.amountCents,
       ),
     ).toEqual([420, 280]);
+    expect(refundAdapter.appendSalesReceiptAdjustments).toHaveBeenCalledTimes(1);
   });
 
   it('skips refund receipt creation for failed refunds', async () => {
@@ -332,6 +376,7 @@ describe('handleRefundEvent', () => {
     expect(refundAdapter.markRefundFailed).toHaveBeenCalledWith(
       expect.objectContaining({ stripeRefundId: refund.id }),
     );
+    expect(refundAdapter.appendSalesReceiptAdjustments).not.toHaveBeenCalled();
     expect(salesforce.upsertTransactionByExternalId).toHaveBeenCalledWith(
       expect.objectContaining({ status__c: 'failed' }),
       'stripe_refund_id__c',
@@ -350,10 +395,14 @@ describe('handleRefundEvent', () => {
     await handleRefundEvent(context, event, deps);
 
     expect(salesforce.upsertTransactionByExternalId).toHaveBeenCalled();
-    const [transaction] = salesforce.upsertTransactionByExternalId.mock.calls[0];
-    expect(transaction.amount_gross__c).toBe(-25);
-    expect(transaction.amount_net__c).toBe(-25);
-    expect(transaction.amount_fee__c).toBe(0);
+    const refundCall = salesforce.upsertTransactionByExternalId.mock.calls.find(
+      (call) => call[1] === 'stripe_refund_id__c',
+    );
+    expect(refundCall).toBeDefined();
+    const transaction = refundCall?.[0];
+    expect(transaction?.amount_gross__c).toBe(-25);
+    expect(transaction?.amount_net__c).toBe(-25);
+    expect(transaction?.amount_fee__c).toBe(0);
   });
 });
 

--- a/src/stripe/handlers/refunds.ts
+++ b/src/stripe/handlers/refunds.ts
@@ -92,22 +92,25 @@ const summarizeBalanceTransaction = (
 
 const buildSalesReceiptAdjustments = (
   lines: RefundReceiptLineInput[],
-): SalesReceiptAdjustmentLineInput[] =>
-  lines
-    .map((line) => {
-      const amount = Math.round(Math.abs(line.amountCents ?? 0));
-      if (amount === 0) {
-        return null;
-      }
+): SalesReceiptAdjustmentLineInput[] => {
+  const adjustments: SalesReceiptAdjustmentLineInput[] = [];
 
-      return {
-        amountCents: -amount,
-        description: line.description ?? null,
-        itemRef: line.itemRef ? { ...line.itemRef } : null,
-        taxCodeRef: line.taxCodeRef ? { ...line.taxCodeRef } : null,
-      } satisfies SalesReceiptAdjustmentLineInput;
-    })
-    .filter((line): line is SalesReceiptAdjustmentLineInput => Boolean(line));
+  for (const line of lines) {
+    const amount = Math.round(Math.abs(line.amountCents ?? 0));
+    if (amount === 0) {
+      continue;
+    }
+
+    adjustments.push({
+      amountCents: -amount,
+      description: line.description ?? null,
+      itemRef: line.itemRef ? { ...line.itemRef } : null,
+      taxCodeRef: line.taxCodeRef ? { ...line.taxCodeRef } : null,
+    });
+  }
+
+  return adjustments;
+};
 
 const collectRefundContexts = async (
   stripe: Stripe,

--- a/src/stripe/handlers/refunds.ts
+++ b/src/stripe/handlers/refunds.ts
@@ -2,9 +2,11 @@ import Stripe from 'stripe';
 
 import env from '../../config/env';
 import type {
+  AppendSalesReceiptAdjustmentsInput,
   HttpContext,
   RefundReceiptAccountingAdapter,
   RefundReceiptLineInput,
+  SalesReceiptAdjustmentLineInput,
   StripeQuickBooksDocument,
   StripeWebhookDependencies,
   UpsertRefundReceiptInput,
@@ -19,6 +21,7 @@ import {
 } from '../utils';
 import { ensureStripeClient } from './common';
 import type { TransactionUpsertDTO } from '../../domain/transactions';
+import type { SalesforceSvc } from '../../services/salesforceSvc';
 
 type Nullable<T> = T | null | undefined;
 
@@ -48,6 +51,350 @@ interface StripeContext {
   charge: Stripe.Charge | null;
   paymentIntent: Stripe.PaymentIntent | null;
 }
+
+interface RefundBalanceTransactionContext {
+  refund: Stripe.Refund;
+  balanceTransaction: Stripe.BalanceTransaction | null;
+}
+
+const toSafeInteger = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) ? value : 0;
+
+const summarizeBalanceTransaction = (
+  balanceTransaction: Stripe.BalanceTransaction | null,
+): { gross: number; fee: number; net: number; currency: string | null } => {
+  if (!balanceTransaction) {
+    return { gross: 0, fee: 0, net: 0, currency: null };
+  }
+
+  const gross = toSafeInteger(balanceTransaction.amount);
+  const fee =
+    typeof balanceTransaction.fee === 'number' && Number.isFinite(balanceTransaction.fee)
+      ? balanceTransaction.fee
+      : Array.isArray(balanceTransaction.fee_details)
+      ? balanceTransaction.fee_details.reduce(
+          (sum, detail) => sum + toSafeInteger(detail?.amount),
+          0,
+        )
+      : 0;
+  const net =
+    typeof balanceTransaction.net === 'number' && Number.isFinite(balanceTransaction.net)
+      ? balanceTransaction.net
+      : gross - fee;
+
+  return {
+    gross,
+    fee,
+    net,
+    currency: balanceTransaction.currency ?? null,
+  };
+};
+
+const buildSalesReceiptAdjustments = (
+  lines: RefundReceiptLineInput[],
+): SalesReceiptAdjustmentLineInput[] =>
+  lines
+    .map((line) => {
+      const amount = Math.round(Math.abs(line.amountCents ?? 0));
+      if (amount === 0) {
+        return null;
+      }
+
+      return {
+        amountCents: -amount,
+        description: line.description ?? null,
+        itemRef: line.itemRef ? { ...line.itemRef } : null,
+        taxCodeRef: line.taxCodeRef ? { ...line.taxCodeRef } : null,
+      } satisfies SalesReceiptAdjustmentLineInput;
+    })
+    .filter((line): line is SalesReceiptAdjustmentLineInput => Boolean(line));
+
+const collectRefundContexts = async (
+  stripe: Stripe,
+  context: HttpContext,
+  charge: Stripe.Charge,
+  refund: Stripe.Refund,
+  knownBalanceTransaction: Stripe.BalanceTransaction | null,
+): Promise<RefundBalanceTransactionContext[]> => {
+  const refundsById = new Map<string, Stripe.Refund>();
+  const addRefund = (entry: Stripe.Refund | null | undefined) => {
+    const id = normalizeStripeId(entry?.id);
+    if (id && entry && !refundsById.has(id)) {
+      refundsById.set(id, entry);
+    }
+  };
+
+  if (Array.isArray(charge.refunds?.data)) {
+    for (const entry of charge.refunds.data) {
+      addRefund(entry);
+    }
+  }
+
+  addRefund(refund);
+
+  if (
+    charge.refunds?.has_more &&
+    stripe.refunds &&
+    typeof stripe.refunds.list === 'function'
+  ) {
+    let startingAfter =
+      charge.refunds.data && charge.refunds.data.length > 0
+        ? charge.refunds.data[charge.refunds.data.length - 1]?.id ?? null
+        : null;
+
+    while (true) {
+      try {
+        const page = await stripe.refunds.list({
+          charge: charge.id,
+          limit: 100,
+          starting_after: startingAfter ?? undefined,
+        });
+        if (Array.isArray(page.data)) {
+          for (const entry of page.data) {
+            addRefund(entry as Stripe.Refund);
+          }
+        }
+        if (!page.has_more || !page.data || page.data.length === 0) {
+          break;
+        }
+        startingAfter = page.data[page.data.length - 1]?.id ?? null;
+        if (!startingAfter) {
+          break;
+        }
+      } catch (error) {
+        context.log('[StripeWebhook] Failed to paginate refunds for charge', {
+          chargeId: charge.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        break;
+      }
+    }
+  }
+
+  const known = new Map<string, Stripe.BalanceTransaction>();
+  if (knownBalanceTransaction?.id) {
+    known.set(knownBalanceTransaction.id, knownBalanceTransaction);
+  }
+
+  const contexts: RefundBalanceTransactionContext[] = [];
+  for (const refundEntry of refundsById.values()) {
+    const status = refundEntry.status ?? 'succeeded';
+    if (status === 'failed' || status === 'canceled') {
+      continue;
+    }
+
+    const balanceTransactionId = normalizeStripeId(refundEntry.balance_transaction);
+    if (balanceTransactionId && known.has(balanceTransactionId)) {
+      contexts.push({
+        refund: refundEntry,
+        balanceTransaction: known.get(balanceTransactionId) ?? null,
+      });
+      continue;
+    }
+
+    if (!balanceTransactionId) {
+      contexts.push({ refund: refundEntry, balanceTransaction: null });
+      continue;
+    }
+
+    try {
+      const transaction = (await stripe.balanceTransactions.retrieve(
+        balanceTransactionId,
+      )) as Stripe.BalanceTransaction;
+      known.set(balanceTransactionId, transaction);
+      contexts.push({ refund: refundEntry, balanceTransaction: transaction });
+    } catch (error) {
+      context.log('[StripeWebhook] Failed to retrieve balance transaction for refund', {
+        refundId: refundEntry.id,
+        balanceTransactionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      contexts.push({ refund: refundEntry, balanceTransaction: null });
+    }
+  }
+
+  return contexts;
+};
+
+const computeChargeTotalsWithRefunds = async (
+  stripe: Stripe,
+  context: HttpContext,
+  stripeContext: StripeContext,
+  refund: Stripe.Refund,
+  refundBalanceTransaction: Stripe.BalanceTransaction | null,
+): Promise<
+  | {
+      totals: { gross: number; fee: number; net: number; currency: string | null };
+      chargeBalanceTransaction: Stripe.BalanceTransaction | null;
+    }
+  | null
+> => {
+  const charge = stripeContext.charge;
+  if (!charge) {
+    return null;
+  }
+
+  const chargeBalanceTransaction = await resolveBalanceTransaction(
+    stripe,
+    charge,
+    stripeContext.paymentIntent,
+  );
+
+  let baseSummary = summarizeBalanceTransaction(chargeBalanceTransaction);
+  if (baseSummary.gross === 0 && baseSummary.net === 0) {
+    const fallbackGross = toSafeInteger(charge.amount);
+    if (fallbackGross !== 0) {
+      baseSummary = {
+        gross: fallbackGross,
+        fee: 0,
+        net: fallbackGross,
+        currency: charge.currency ?? baseSummary.currency,
+      };
+    }
+  }
+
+  if (!baseSummary.currency && charge.currency) {
+    baseSummary = { ...baseSummary, currency: charge.currency };
+  }
+
+  const refundContexts = await collectRefundContexts(
+    stripe,
+    context,
+    charge,
+    refund,
+    refundBalanceTransaction,
+  );
+
+  const totals = { ...baseSummary };
+
+  for (const { refund: refundEntry, balanceTransaction } of refundContexts) {
+    let summary = summarizeBalanceTransaction(balanceTransaction);
+    if (summary.gross === 0 && summary.net === 0) {
+      const fallbackGross = -Math.abs(toSafeInteger(refundEntry.amount));
+      if (fallbackGross !== 0) {
+        summary = {
+          gross: fallbackGross,
+          fee: 0,
+          net: fallbackGross,
+          currency: summary.currency ?? refundEntry.currency ?? null,
+        };
+      }
+    }
+
+    totals.gross += summary.gross;
+    totals.fee += summary.fee;
+    totals.net += summary.net;
+
+    if (!totals.currency && summary.currency) {
+      totals.currency = summary.currency;
+    }
+  }
+
+  if (!totals.currency) {
+    totals.currency = charge.currency ?? null;
+  }
+
+  return { totals, chargeBalanceTransaction };
+};
+
+const updateChargeTransaction = async (
+  context: HttpContext,
+  stripe: Stripe,
+  refund: Stripe.Refund,
+  stripeContext: StripeContext,
+  refundBalanceTransaction: Stripe.BalanceTransaction | null,
+  salesforce: SalesforceSvc,
+  parentId: string | null,
+): Promise<void> => {
+  const charge = stripeContext.charge;
+  const chargeId = normalizeStripeId(charge?.id);
+
+  if (!charge || !chargeId) {
+    return;
+  }
+
+  const summary = await computeChargeTotalsWithRefunds(
+    stripe,
+    context,
+    stripeContext,
+    refund,
+    refundBalanceTransaction,
+  );
+
+  if (!summary) {
+    return;
+  }
+
+  const { totals, chargeBalanceTransaction } = summary;
+
+  const amountCharged = Math.abs(toSafeInteger(charge.amount));
+  const amountRefunded = Math.abs(toSafeInteger(charge.amount_refunded));
+  const fullyRefunded = amountCharged > 0 && amountRefunded >= amountCharged;
+
+  const paymentIntentId =
+    normalizeStripeId(charge.payment_intent) ||
+    normalizeStripeId(stripeContext.paymentIntent?.id);
+
+  const customerId =
+    normalizeStripeId(charge.customer) ||
+    normalizeStripeId(stripeContext.paymentIntent?.customer);
+
+  const transaction: TransactionUpsertDTO = {
+    transaction_type__c: 'charge',
+    status__c: fullyRefunded ? 'refunded' : 'paid',
+    stripe_charge_id__c: chargeId,
+    stripe_payment_intent_id__c: paymentIntentId,
+    stripe_balance_transaction_id__c: chargeBalanceTransaction?.id ?? null,
+    stripe_customer_id__c: customerId,
+    amount_gross__c: centsToMajorUnits(totals.gross),
+    amount_fee__c: centsToMajorUnits(totals.fee),
+    amount_net__c: centsToMajorUnits(totals.net),
+    currency_iso_code__c: totals.currency ? totals.currency.toUpperCase() : null,
+    received_at__c: timestampToIsoString(charge.created ?? null),
+    payment_brand__c: charge.payment_method_details?.card?.brand ?? null,
+    payment_last4__c: charge.payment_method_details?.card?.last4 ?? null,
+  };
+
+  await salesforce.upsertTransactionByExternalId(
+    transaction,
+    'stripe_charge_id__c',
+    parentId ? { overrideId: parentId } : undefined,
+  );
+};
+
+const appendAdjustmentsIfAvailable = async (
+  adapter: RefundReceiptAccountingAdapter,
+  salesReceipt: SalesReceiptContext,
+  refundInput: UpsertRefundReceiptInput,
+  stripeContext: StripeContext,
+  refund: Stripe.Refund,
+  event: Stripe.Event,
+): Promise<void> => {
+  if (typeof adapter.appendSalesReceiptAdjustments !== 'function') {
+    return;
+  }
+
+  if (!salesReceipt.docNumber) {
+    return;
+  }
+
+  const adjustments = buildSalesReceiptAdjustments(refundInput.lines);
+  if (adjustments.length === 0) {
+    return;
+  }
+
+  const payload: AppendSalesReceiptAdjustmentsInput = {
+    docNumber: salesReceipt.docNumber,
+    lines: adjustments,
+    memo: refundInput.memo,
+    stripeRefundId: refund.id,
+    stripeEventId: event.id,
+    charge: stripeContext.charge,
+    paymentIntent: stripeContext.paymentIntent,
+  };
+
+  await adapter.appendSalesReceiptAdjustments(payload);
+};
 
 const parseAmountToCents = (value: unknown): number | null => {
   if (typeof value === 'number' && Number.isFinite(value)) {
@@ -356,7 +703,7 @@ const normalizeDocumentReference = (
 };
 
 const markRefundPosted = async (
-  deps: StripeWebhookDependencies,
+  salesforce: SalesforceSvc,
   upsertResult: unknown,
   doc: StripeQuickBooksDocument | { qboId: string; type: string } | null | void,
 ): Promise<void> => {
@@ -365,7 +712,6 @@ const markRefundPosted = async (
     return;
   }
 
-  const salesforce = await deps.getSalesforceSvc();
   const recordId =
     upsertResult &&
     typeof upsertResult === 'object' &&
@@ -480,13 +826,11 @@ const buildRefundTransaction = (
 
 const upsertSalesforceTransaction = async (
   context: HttpContext,
-  deps: StripeWebhookDependencies,
   refund: Stripe.Refund,
   stripeContext: StripeContext,
   balanceTransaction: Stripe.BalanceTransaction | null,
+  salesforce: SalesforceSvc,
 ): Promise<{ upsertResult: unknown; parentId: string | null }> => {
-  const salesforce = await deps.getSalesforceSvc();
-
   let parentId: string | null = null;
   if (stripeContext.charge?.id) {
     try {
@@ -529,6 +873,7 @@ const processRefund = async (
   chargeHint?: Stripe.Charge | null,
 ): Promise<void> => {
   const stripe = ensureStripeClient(deps, event);
+  const salesforce = await deps.getSalesforceSvc();
   const stripeContext = await loadStripeContext(
     context,
     event,
@@ -543,12 +888,12 @@ const processRefund = async (
     refund,
   );
 
-  const { upsertResult } = await upsertSalesforceTransaction(
+  const { upsertResult, parentId } = await upsertSalesforceTransaction(
     context,
-    deps,
     refund,
     stripeContext,
     balanceTransaction,
+    salesforce,
   );
 
   if (refund.status === 'failed') {
@@ -564,6 +909,16 @@ const processRefund = async (
     }
     return;
   }
+
+  await updateChargeTransaction(
+    context,
+    stripe,
+    refund,
+    stripeContext,
+    balanceTransaction,
+    salesforce,
+    parentId,
+  );
 
   if (!env.accounting.syncEnabled) {
     return;
@@ -601,7 +956,19 @@ const processRefund = async (
     `stripe_evt_${event.id}`,
     async () => {
       const result = await adapter.upsertRefundReceipt(refundInput);
-      await markRefundPosted(deps, upsertResult, result as StripeQuickBooksDocument | { qboId: string; type: string } | null | void);
+      await markRefundPosted(
+        salesforce,
+        upsertResult,
+        result as StripeQuickBooksDocument | { qboId: string; type: string } | null | void,
+      );
+      await appendAdjustmentsIfAvailable(
+        adapter,
+        salesReceiptContext,
+        refundInput,
+        stripeContext,
+        refund,
+        event,
+      );
     },
   );
 };

--- a/src/stripe/types.ts
+++ b/src/stripe/types.ts
@@ -27,6 +27,21 @@ export interface RefundReceiptLineInput {
   taxCodeRef?: { value: string; name?: string | null } | null;
 }
 
+export interface SalesReceiptAdjustmentLineInput
+  extends RefundReceiptLineInput {
+  amountCents: number;
+}
+
+export interface AppendSalesReceiptAdjustmentsInput {
+  docNumber: string;
+  lines: SalesReceiptAdjustmentLineInput[];
+  memo: string;
+  stripeRefundId: string;
+  stripeEventId: string;
+  charge: Stripe.Charge | null;
+  paymentIntent: Stripe.PaymentIntent | null;
+}
+
 export interface UpsertRefundReceiptInput {
   stripeEventId: string;
   stripeRefundId: string;
@@ -66,6 +81,9 @@ export interface RefundReceiptAccountingAdapter {
     paymentIntent: Stripe.PaymentIntent | null;
     reason?: string | null;
   }) => Promise<void>;
+  appendSalesReceiptAdjustments?: (
+    input: AppendSalesReceiptAdjustmentsInput,
+  ) => Promise<void>;
 }
 
 export type PayoutDepositLineType = 'charge' | 'fee' | 'refund' | 'adjustment';


### PR DESCRIPTION
## Summary
- recompute charge transaction totals when refunds arrive and persist the updated charge record in Salesforce
- collect refund balance transactions so QuickBooks adjustments can be derived and appended to the originating sales receipt
- extend the refund handler tests to cover charge updates and the new adjustment payloads, along with the accounting adapter contract

## Testing
- `npm run test:unit -- __tests__/stripeRefundsHandler.test.ts` *(fails: vitest executable missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ec59253e2c832cb6aff29474761122