### PR TITLE
Handle duplicate Salesforce external IDs when processing refunds

### DIFF
--- a/__tests__/salesforceSvc.test.ts
+++ b/__tests__/salesforceSvc.test.ts
@@ -104,7 +104,7 @@ describe('createSalesforceSvc', () => {
     );
 
     expect(query).toHaveBeenCalledWith(
-      "SELECT Id, Transaction_Type__c FROM Transaction__c WHERE Stripe_Checkout_Session_Id__c = 'cs_test_123' ORDER BY LastModifiedDate DESC LIMIT 10",
+      "SELECT Id FROM Transaction__c WHERE Stripe_Checkout_Session_Id__c = 'cs_test_123' LIMIT 1",
     );
     expect(result).toBe('sf_1');
   });
@@ -175,12 +175,7 @@ describe('createSalesforceSvc', () => {
       ])
       .mockResolvedValueOnce([{ success: true, id: 'a1', errors: [] }]);
 
-    query.mockResolvedValue({
-      records: [
-        { Id: 'a1', Transaction_Type__c: 'charge' },
-        { Id: 'a2', Transaction_Type__c: 'refund' },
-      ],
-    });
+    query.mockResolvedValue({ records: [{ Id: 'a1' }] });
 
     const service: SalesforceSvc = createSalesforceSvc({
       connection: { upsert, query, sobject } as unknown as Connection,
@@ -191,7 +186,7 @@ describe('createSalesforceSvc', () => {
     const result = await service.upsertTransactionByExternalId(dto, 'stripe_charge_id__c');
 
     expect(query).toHaveBeenCalledWith(
-      "SELECT Id, Transaction_Type__c FROM Transaction__c WHERE Stripe_Charge_Id__c = 'ch_123' ORDER BY LastModifiedDate DESC LIMIT 10",
+      "SELECT Id FROM Transaction__c WHERE Stripe_Charge_Id__c = 'ch_123' LIMIT 1",
     );
 
     expect(upsert).toHaveBeenCalledTimes(2);
@@ -205,22 +200,4 @@ describe('createSalesforceSvc', () => {
     expect(result).toEqual({ success: true, id: 'a1', errors: [] });
   });
 
-  it('prefers charge transactions when resolving duplicate lookups', async () => {
-    const { upsert, query, sobject } = createMockConnection();
-    upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);
-    query.mockResolvedValue({
-      records: [
-        { Id: 'refund1', Transaction_Type__c: 'refund' },
-        { Id: 'charge1', Transaction_Type__c: 'charge' },
-      ],
-    });
-
-    const service: SalesforceSvc = createSalesforceSvc({
-      connection: { upsert, query, sobject } as unknown as Connection,
-    });
-
-    const result = await service.findTransactionIdByExternalId('stripe_charge_id__c', 'ch_456');
-
-    expect(result).toBe('charge1');
-  });
 });

--- a/__tests__/salesforceSvc.test.ts
+++ b/__tests__/salesforceSvc.test.ts
@@ -10,17 +10,15 @@ import type { TransactionUpsertDTO } from '../src/domain/transactions';
 
 type MockConnection = {
   upsert: ReturnType<typeof vi.fn>;
+  query: ReturnType<typeof vi.fn>;
   sobject: ReturnType<typeof vi.fn>;
 };
 
-const createMockConnection = (): MockConnection & { queryBuilder: any } => {
+const createMockConnection = (): MockConnection => {
   const upsert = vi.fn();
-  const queryBuilder: any = {};
-  queryBuilder.find = vi.fn().mockImplementation(() => queryBuilder);
-  queryBuilder.limit = vi.fn().mockImplementation(() => queryBuilder);
-  queryBuilder.execute = vi.fn().mockResolvedValue([]);
-  const sobject = vi.fn().mockReturnValue(queryBuilder);
-  return { upsert, sobject, queryBuilder };
+  const query = vi.fn().mockResolvedValue({ records: [] });
+  const sobject = vi.fn();
+  return { upsert, query, sobject };
 };
 
 describe('createSalesforceSvc', () => {
@@ -62,11 +60,11 @@ describe('createSalesforceSvc', () => {
   });
 
   it('maps DTO fields to Salesforce API names when upserting', async () => {
-    const { upsert, sobject } = createMockConnection();
+    const { upsert, sobject, query } = createMockConnection();
     upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);
 
     const service: SalesforceSvc = createSalesforceSvc({
-      connection: { upsert, sobject } as unknown as Connection,
+      connection: { upsert, sobject, query } as unknown as Connection,
     });
 
     const dto = buildDto();
@@ -92,12 +90,12 @@ describe('createSalesforceSvc', () => {
   });
 
   it('uses Salesforce API names when looking up transactions by external id', async () => {
-    const { upsert, sobject, queryBuilder } = createMockConnection();
+    const { upsert, sobject, query } = createMockConnection();
     upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);
-    queryBuilder.execute.mockResolvedValue([{ Id: 'sf_1' }]);
+    query.mockResolvedValue({ records: [{ Id: 'sf_1' }] });
 
     const service: SalesforceSvc = createSalesforceSvc({
-      connection: { upsert, sobject } as unknown as Connection,
+      connection: { upsert, sobject, query } as unknown as Connection,
     });
 
     const result = await service.findTransactionIdByExternalId(
@@ -105,22 +103,18 @@ describe('createSalesforceSvc', () => {
       'cs_test_123',
     );
 
-    expect(queryBuilder.find).toHaveBeenCalledWith(
-      {
-        [TRANSACTION_FIELD_API_NAMES.stripe_checkout_session_id__c]: 'cs_test_123',
-      },
-      ['Id'],
+    expect(query).toHaveBeenCalledWith(
+      "SELECT Id, Transaction_Type__c FROM Transaction__c WHERE Stripe_Checkout_Session_Id__c = 'cs_test_123' ORDER BY LastModifiedDate DESC LIMIT 10",
     );
-    expect(queryBuilder.limit).toHaveBeenCalledWith(1);
     expect(result).toBe('sf_1');
   });
 
   it('normalizes payout linkage upserts to Salesforce API names', async () => {
-    const { upsert, sobject } = createMockConnection();
+    const { upsert, sobject, query } = createMockConnection();
     upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);
 
     const service: SalesforceSvc = createSalesforceSvc({
-      connection: { upsert, sobject } as unknown as Connection,
+      connection: { upsert, sobject, query } as unknown as Connection,
     });
 
     await service.linkPayoutOnTransactions('po_123', ['bt_1']);
@@ -139,11 +133,11 @@ describe('createSalesforceSvc', () => {
   });
 
   it('leaves existing Salesforce lookups untouched when metadata omits them', async () => {
-    const { upsert, sobject } = createMockConnection();
+    const { upsert, sobject, query } = createMockConnection();
     upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);
 
     const service: SalesforceSvc = createSalesforceSvc({
-      connection: { upsert, sobject } as unknown as Connection,
+      connection: { upsert, sobject, query } as unknown as Connection,
     });
 
     const dto = buildDto();
@@ -163,5 +157,70 @@ describe('createSalesforceSvc', () => {
     expect(records[0]).not.toHaveProperty('Fund__c');
     expect(records[0]).not.toHaveProperty('Designation__c');
     expect(records[0]).not.toHaveProperty('Restriction__c');
+  });
+
+  it('falls back to updating by Id when duplicate external ids are detected', async () => {
+    const { upsert, query, sobject } = createMockConnection();
+    upsert
+      .mockResolvedValueOnce([
+        {
+          success: false,
+          id: null,
+          errors: [
+            {
+              message: 'Stripe Charge ID: more than one record found for external id field: [a1, a2]',
+            },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([{ success: true, id: 'a1', errors: [] }]);
+
+    query.mockResolvedValue({
+      records: [
+        { Id: 'a1', Transaction_Type__c: 'charge' },
+        { Id: 'a2', Transaction_Type__c: 'refund' },
+      ],
+    });
+
+    const service: SalesforceSvc = createSalesforceSvc({
+      connection: { upsert, query, sobject } as unknown as Connection,
+    });
+
+    const dto = buildDto();
+
+    const result = await service.upsertTransactionByExternalId(dto, 'stripe_charge_id__c');
+
+    expect(query).toHaveBeenCalledWith(
+      "SELECT Id, Transaction_Type__c FROM Transaction__c WHERE Stripe_Charge_Id__c = 'ch_123' ORDER BY LastModifiedDate DESC LIMIT 10",
+    );
+
+    expect(upsert).toHaveBeenCalledTimes(2);
+    const [, firstCallRecords, firstExternalIdField] = upsert.mock.calls[0];
+    expect(firstExternalIdField).toBe(TRANSACTION_FIELD_API_NAMES.stripe_charge_id__c);
+    expect(firstCallRecords[0]).not.toHaveProperty('Id');
+
+    const [, secondCallRecords, secondExternalIdField] = upsert.mock.calls[1];
+    expect(secondExternalIdField).toBe('Id');
+    expect(secondCallRecords[0]).toMatchObject({ Id: 'a1' });
+    expect(result).toEqual({ success: true, id: 'a1', errors: [] });
+  });
+
+  it('prefers charge transactions when resolving duplicate lookups', async () => {
+    const { upsert, query, sobject } = createMockConnection();
+    upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);
+    query.mockResolvedValue({
+      records: [
+        { Id: 'refund1', Transaction_Type__c: 'refund' },
+        { Id: 'charge1', Transaction_Type__c: 'charge' },
+      ],
+    });
+
+    const service: SalesforceSvc = createSalesforceSvc({
+      connection: { upsert, query, sobject } as unknown as Connection,
+    });
+
+    const result = await service.findTransactionIdByExternalId('stripe_charge_id__c', 'ch_456');
+
+    expect(result).toBe('charge1');
   });
 });

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -91,10 +91,7 @@ type TransactionRecordInput = Partial<TransactionUpsertDTO> & {
 
 type TransactionRecord = Record<string, TransactionFieldValue>;
 
-type TransactionLookupRecord = {
-  Id?: string;
-  Transaction_Type__c?: string | null;
-};
+type TransactionLookupRecord = { Id?: string };
 
 const TRANSACTION_OBJECT = 'Transaction__c';
 
@@ -166,63 +163,22 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     return [];
   };
 
-  const pickPreferredTransactionId = (
-    records: TransactionLookupRecord[],
-    desiredType?: string | null,
-  ): string | null => {
-    if (!records || records.length === 0) {
-      return null;
-    }
-
-    const normalizedDesired =
-      typeof desiredType === 'string' ? desiredType.trim().toLowerCase() : null;
-
-    if (normalizedDesired) {
-      const matching = records.find((record) => {
-        const recordType =
-          typeof record.Transaction_Type__c === 'string'
-            ? record.Transaction_Type__c.trim().toLowerCase()
-            : null;
-        return recordType === normalizedDesired && typeof record.Id === 'string' && record.Id.trim();
-      });
-
-      if (matching && typeof matching.Id === 'string') {
-        return matching.Id;
-      }
-    }
-
-    const chargeRecord = records.find((record) => {
-      const recordType =
-        typeof record.Transaction_Type__c === 'string'
-          ? record.Transaction_Type__c.trim().toLowerCase()
-          : null;
-      return recordType === 'charge' && typeof record.Id === 'string' && record.Id.trim();
-    });
-
-    if (chargeRecord && typeof chargeRecord.Id === 'string') {
-      return chargeRecord.Id;
-    }
-
-    const firstWithId = records.find(
-      (record) => typeof record.Id === 'string' && record.Id.trim().length > 0,
-    );
-
-    return firstWithId?.Id ?? null;
-  };
-
   const resolveExistingTransactionId = async (
     field: TransactionExternalIdField,
     value: string,
-    transactionType?: string | null,
   ): Promise<string | null> => {
     const apiField = resolveExternalIdField(field);
     const escapedValue = escapeForSoqlLiteral(value);
-    const soql = `SELECT Id, Transaction_Type__c FROM ${TRANSACTION_OBJECT} WHERE ${apiField} = '${escapedValue}' ORDER BY LastModifiedDate DESC LIMIT 10`;
+    const soql = `SELECT Id FROM ${TRANSACTION_OBJECT} WHERE ${apiField} = '${escapedValue}' LIMIT 1`;
 
     const result = await connection.query<TransactionLookupRecord>(soql);
     const records = toLookupRecords(result);
 
-    return pickPreferredTransactionId(records, transactionType ?? null);
+    const recordWithId = records.find(
+      (record): record is { Id: string } => typeof record.Id === 'string' && record.Id.trim().length > 0,
+    );
+
+    return recordWithId?.Id ?? null;
   };
 
   const upsertTransactionByExternalId = async (
@@ -259,11 +215,7 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
       );
 
       if (duplicateError) {
-        const fallbackId = await resolveExistingTransactionId(
-          key,
-          normalizedExternalId,
-          dto.transaction_type__c ?? null,
-        );
+        const fallbackId = await resolveExistingTransactionId(key, normalizedExternalId);
 
         if (fallbackId) {
           const fallbackRecords = [
@@ -370,7 +322,6 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     return resolveExistingTransactionId(
       normalizedKey as TransactionExternalIdField,
       normalizedValue,
-      null,
     );
   };
 

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -91,6 +91,11 @@ type TransactionRecordInput = Partial<TransactionUpsertDTO> & {
 
 type TransactionRecord = Record<string, TransactionFieldValue>;
 
+type TransactionLookupRecord = {
+  Id?: string;
+  Transaction_Type__c?: string | null;
+};
+
 const TRANSACTION_OBJECT = 'Transaction__c';
 
 const resolveFieldApiName = (field: keyof TransactionRecordInput): string => {
@@ -140,6 +145,86 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
   const resolveExternalIdField = (field: TransactionExternalIdField): string =>
     TRANSACTION_FIELD_API_NAMES[field] ?? field;
 
+  const escapeForSoqlLiteral = (value: string): string =>
+    value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+  const toLookupRecords = (
+    result: unknown,
+  ): TransactionLookupRecord[] => {
+    if (Array.isArray(result)) {
+      return result as TransactionLookupRecord[];
+    }
+
+    if (
+      result &&
+      typeof result === 'object' &&
+      Array.isArray((result as { records?: unknown[] }).records)
+    ) {
+      return (result as { records: TransactionLookupRecord[] }).records;
+    }
+
+    return [];
+  };
+
+  const pickPreferredTransactionId = (
+    records: TransactionLookupRecord[],
+    desiredType?: string | null,
+  ): string | null => {
+    if (!records || records.length === 0) {
+      return null;
+    }
+
+    const normalizedDesired =
+      typeof desiredType === 'string' ? desiredType.trim().toLowerCase() : null;
+
+    if (normalizedDesired) {
+      const matching = records.find((record) => {
+        const recordType =
+          typeof record.Transaction_Type__c === 'string'
+            ? record.Transaction_Type__c.trim().toLowerCase()
+            : null;
+        return recordType === normalizedDesired && typeof record.Id === 'string' && record.Id.trim();
+      });
+
+      if (matching && typeof matching.Id === 'string') {
+        return matching.Id;
+      }
+    }
+
+    const chargeRecord = records.find((record) => {
+      const recordType =
+        typeof record.Transaction_Type__c === 'string'
+          ? record.Transaction_Type__c.trim().toLowerCase()
+          : null;
+      return recordType === 'charge' && typeof record.Id === 'string' && record.Id.trim();
+    });
+
+    if (chargeRecord && typeof chargeRecord.Id === 'string') {
+      return chargeRecord.Id;
+    }
+
+    const firstWithId = records.find(
+      (record) => typeof record.Id === 'string' && record.Id.trim().length > 0,
+    );
+
+    return firstWithId?.Id ?? null;
+  };
+
+  const resolveExistingTransactionId = async (
+    field: TransactionExternalIdField,
+    value: string,
+    transactionType?: string | null,
+  ): Promise<string | null> => {
+    const apiField = resolveExternalIdField(field);
+    const escapedValue = escapeForSoqlLiteral(value);
+    const soql = `SELECT Id, Transaction_Type__c FROM ${TRANSACTION_OBJECT} WHERE ${apiField} = '${escapedValue}' ORDER BY LastModifiedDate DESC LIMIT 10`;
+
+    const result = await connection.query<TransactionLookupRecord>(soql);
+    const records = toLookupRecords(result);
+
+    return pickPreferredTransactionId(records, transactionType ?? null);
+  };
+
   const upsertTransactionByExternalId = async (
     dto: TransactionUpsertDTO,
     key: TransactionExternalIdField,
@@ -167,6 +252,45 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
       }),
     );
     if (!result.success) {
+      const duplicateError = result.errors.find(
+        (error) =>
+          typeof error?.message === 'string' &&
+          error.message.includes('more than one record found for external id field'),
+      );
+
+      if (duplicateError) {
+        const fallbackId = await resolveExistingTransactionId(
+          key,
+          normalizedExternalId,
+          dto.transaction_type__c ?? null,
+        );
+
+        if (fallbackId) {
+          const fallbackRecords = [
+            sanitizeTransactionRecord({
+              ...dto,
+              [key]: normalizedExternalId,
+              Id: fallbackId,
+            }),
+          ];
+
+          const [fallbackResult] = toArray(
+            await connection.upsert(TRANSACTION_OBJECT, fallbackRecords, 'Id', {
+              allOrNone: true,
+            }),
+          );
+
+          if (!fallbackResult.success) {
+            const fallbackMessage =
+              collectErrorMessages([fallbackResult]) ||
+              `Failed to upsert transaction with ${key}=${normalizedExternalId}.`;
+            throw new Error(fallbackMessage);
+          }
+
+          return fallbackResult;
+        }
+      }
+
       const message =
         collectErrorMessages([result]) || `Failed to upsert transaction with ${key}=${normalizedExternalId}.`;
       throw new Error(message);
@@ -243,21 +367,11 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
   ): Promise<string | null> => {
     const normalizedKey = ensureNonEmpty(key, 'External ID field');
     const normalizedValue = ensureNonEmpty(value, 'External ID value');
-
-    const apiField = resolveExternalIdField(normalizedKey as TransactionExternalIdField);
-
-    const records = (await (connection as any)
-      .sobject(TRANSACTION_OBJECT)
-      .find({ [apiField]: normalizedValue }, ['Id'])
-      .limit(1)
-      .execute()) as Array<{ Id?: string }>;
-
-    if (!records || records.length === 0) {
-      return null;
-    }
-
-    const [{ Id }] = records;
-    return typeof Id === 'string' && Id.trim().length > 0 ? Id : null;
+    return resolveExistingTransactionId(
+      normalizedKey as TransactionExternalIdField,
+      normalizedValue,
+      null,
+    );
   };
 
   return {


### PR DESCRIPTION
## Summary
- add duplicate external ID handling in the Salesforce service by querying for existing records and retrying the upsert by Id
- update the Salesforce lookup helper to query via SOQL and prefer charge records when duplicates exist
- expand the Salesforce service unit tests to cover the new duplicate handling behaviour

## Testing
- npx vitest run __tests__/salesforceSvc.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68ed9fd150c8832c86b10f9161cdf98f