### PR TITLE
Add single-record Salesforce↔QuickBooks sync, backfill QBO<->SF IDs, and account support in Stripe true‑up

### DIFF
--- a/__tests__/qboCustomersSync.test.ts
+++ b/__tests__/qboCustomersSync.test.ts
@@ -8,8 +8,8 @@ describe('qboCustomersSync', () => {
   let handler: any;
   let internals: any;
 
-  beforeEach(() => {
-    const loaded = require('../dist/handlers/qboCustomersSync');
+  beforeEach(async () => {
+    const loaded = await import(`../src/handlers/qboCustomersSync?t=${Date.now()}`);
     handler = loaded.default || loaded;
     internals = handler.__internals;
   });
@@ -53,10 +53,7 @@ describe('qboCustomersSync', () => {
       .mockResolvedValueOnce([]);
 
     const query = vi.fn(async (soql: string) => {
-      if (
-        soql.includes("Email = 'ada@example.com'") ||
-        soql.includes("FirstName = 'Ada'")
-      ) {
+      if (soql.includes("Email = 'ada@example.com'") || soql.includes("FirstName = 'Ada'")) {
         return {
           records: [
             {
@@ -101,9 +98,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn();
     const update = vi.fn();
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -138,6 +137,7 @@ describe('qboCustomersSync', () => {
 
     expect(create).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
   });
 
   it('does not overwrite existing Salesforce fields unless overwrite=true', async () => {
@@ -164,10 +164,7 @@ describe('qboCustomersSync', () => {
       .mockResolvedValueOnce([]);
 
     const query = vi.fn(async (soql: string) => {
-      if (
-        soql.includes("Email = 'ada@example.com'") ||
-        soql.includes("FirstName = 'Ada'")
-      ) {
+      if (soql.includes("Email = 'ada@example.com'") || soql.includes("FirstName = 'Ada'")) {
         return {
           records: [
             {
@@ -195,9 +192,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn().mockResolvedValue({ success: true, id: '003_new' });
     const update = vi.fn().mockResolvedValue({ success: true, id: '003_existing' });
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -242,6 +241,7 @@ describe('qboCustomersSync', () => {
         Phone: '555-0002',
       })
     );
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('c2', '003_new');
   });
 
   it('supports create-only mode to skip updates on existing contacts', async () => {
@@ -289,9 +289,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn().mockResolvedValue({ success: true, id: '003_new' });
     const update = vi.fn().mockResolvedValue({ success: true, id: '003_existing' });
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -318,6 +320,7 @@ describe('qboCustomersSync', () => {
 
     expect(create).toHaveBeenCalledTimes(1);
     expect(update).not.toHaveBeenCalled();
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('c2', '003_new');
   });
 
   it('uses Contact record type id when available during create', async () => {
@@ -348,9 +351,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn().mockResolvedValue({ success: true, id: '003_new_rt' });
     const update = vi.fn();
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -376,5 +381,314 @@ describe('qboCustomersSync', () => {
         Email: 'record.type@example.com',
       })
     );
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('c100', '003_new_rt');
+  });
+
+  it('prefers a populated QuickBooks Salesforce ID by validating Contact before Account', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cSFContact',
+          DisplayName: 'QBO Contact',
+          CustomField: [
+            { DefinitionId: '1', Name: 'Salesforce ID', StringValue: '003ValidContact' },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003ValidContact'")) {
+        return { records: [{ Id: '003ValidContact', FirstName: 'Valid', LastName: 'Contact' }] };
+      }
+
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+    const update = vi.fn().mockResolvedValue({ success: true, id: '003FromQboField' });
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'GET', url: 'http://localhost', query: { dryRun: 'true' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.counts.alreadyExistInSalesforce).toBe(1);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cSFContact',
+      salesforceId: '003ValidContact',
+      salesforceObject: 'Contact',
+      matchPath: 'quickbooks_salesforce_id',
+    });
+    expect(query).not.toHaveBeenCalledWith(expect.stringContaining('FROM Account WHERE Id ='));
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Account when QuickBooks Salesforce ID is not a Contact', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cSFAccount',
+          DisplayName: 'QBO Account',
+          CustomField: [
+            { DefinitionId: '1', Name: 'Salesforce ID', StringValue: '001ValidAccount' },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '001ValidAccount'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Account WHERE Id = '001ValidAccount'")) {
+        return { records: [{ Id: '001ValidAccount', Name: 'Acme Org' }] };
+      }
+
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+    const update = vi.fn().mockResolvedValue({ success: true, id: '003FromQboField' });
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'GET', url: 'http://localhost', query: { dryRun: 'true' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cSFAccount',
+      salesforceId: '001ValidAccount',
+      salesforceObject: 'Account',
+      matchPath: 'quickbooks_salesforce_id',
+    });
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
+  });
+
+  it('backfills QuickBooks Salesforce ID when Contact is matched by QuickBooks_ID__c', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cQboLookup',
+          DisplayName: 'Lookup Contact',
+          GivenName: 'Lookup',
+          FamilyName: 'Contact',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Contact WHERE QuickBooks_ID__c = 'cQboLookup'")) {
+        return {
+          records: [
+            {
+              Id: '003FromQboField',
+              FirstName: 'Lookup',
+              LastName: 'Contact',
+              QuickBooks_ID__c: 'cQboLookup',
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Account WHERE QuickBooks_ID__c = 'cQboLookup'")) {
+        return { records: [] };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({
+          create: vi.fn(),
+          update: vi.fn().mockResolvedValue({ success: true, id: '003FromQboField' }),
+        }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'POST', url: 'http://localhost', query: { dryRun: 'false' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cQboLookup',
+      salesforceId: '003FromQboField',
+      salesforceObject: 'Contact',
+      matchPath: 'salesforce_quickbooks_id',
+    });
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('cQboLookup', '003FromQboField');
+  });
+
+  it('checks Account by QuickBooks_ID__c only after no Contact match exists', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([{ Id: 'cAccountLookup', DisplayName: 'Lookup Account' }])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Contact WHERE QuickBooks_ID__c = 'cAccountLookup'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Account WHERE QuickBooks_ID__c = 'cAccountLookup'")) {
+        return {
+          records: [
+            { Id: '001FromQboField', Name: 'Matched Account', QuickBooks_ID__c: 'cAccountLookup' },
+          ],
+        };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update: vi.fn() }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'POST', url: 'http://localhost', query: { dryRun: 'false' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cAccountLookup',
+      salesforceId: '001FromQboField',
+      salesforceObject: 'Account',
+      matchPath: 'salesforce_quickbooks_id',
+    });
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('cAccountLookup', '001FromQboField');
+  });
+
+  it('uses fallback matching when no deterministic ID match exists', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cFallback',
+          DisplayName: 'Fallback Match',
+          GivenName: 'Fallback',
+          FamilyName: 'Match',
+          PrimaryEmailAddr: { Address: 'fallback@example.com' },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Contact WHERE QuickBooks_ID__c = 'cFallback'")) {
+        throw new Error("No such column 'QuickBooks_ID__c' on entity 'Contact'");
+      }
+
+      if (soql.includes("FROM Account WHERE QuickBooks_ID__c = 'cFallback'")) {
+        throw new Error("No such column 'QuickBooks_ID__c' on entity 'Account'");
+      }
+
+      if (soql.includes("Email = 'fallback@example.com'")) {
+        return {
+          records: [
+            {
+              Id: '003Fallback',
+              FirstName: 'Fallback',
+              LastName: 'Match',
+              Email: 'fallback@example.com',
+              Description: 'Legacy record',
+            },
+          ],
+        };
+      }
+
+      return { records: [] };
+    });
+
+    const update = vi.fn().mockResolvedValue({ success: true, id: '003Fallback' });
+    const updateQboCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'POST', url: 'http://localhost', query: { dryRun: 'false' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cFallback',
+      salesforceId: '003Fallback',
+      matchPath: 'fallback_match',
+      salesforceObject: 'Contact',
+    });
+    expect(update).toHaveBeenCalled();
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -1,0 +1,451 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { createContext, normalizeResponse } = require('./testUtils');
+
+describe('salesforceRecordQboSync', () => {
+  let handler: any;
+  let internals: any;
+
+  beforeEach(async () => {
+    const loaded = await import(`../src/handlers/salesforceRecordQboSync?t=${Date.now()}`);
+    handler = loaded.default || loaded;
+    internals = handler.__internals;
+  });
+
+  afterEach(() => {
+    internals?.resetDependencies?.();
+    vi.restoreAllMocks();
+  });
+
+  const createConnection = (
+    queryImpl: (soql: string) => Promise<{ records: any[] } | any[]>,
+    updateImpl: (
+      objectName: string,
+      payload: Record<string, unknown>
+    ) => Promise<any> = async () => ({
+      success: true,
+      id: 'updated',
+    })
+  ) => ({
+    query: vi.fn(queryImpl),
+    sobject: vi.fn((objectName: string) => ({
+      update: vi.fn((payload: Record<string, unknown>) => updateImpl(objectName, payload)),
+    })),
+  });
+
+  it('dry-runs a Contact record resolved via Salesforce QuickBooks_ID__c without duplicating synced transactions', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003CONTACT'")) {
+        return {
+          records: [
+            { Id: '003CONTACT', FirstName: 'Ada', LastName: 'Lovelace', QuickBooks_ID__c: '200' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003CONTACT'")) {
+        return {
+          records: [
+            {
+              Id: 'a01Txn',
+              Transaction_Type__c: 'refund',
+              QBO_Doc_Id__c: '900',
+              QBO_Doc_Type__c: 'journal-entry',
+              Posted_to_QBO__c: true,
+            },
+          ],
+        };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '200'")) {
+        return [
+          {
+            Id: '200',
+            DisplayName: 'Ada Lovelace',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONTACT' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM JournalEntry WHERE Id = '900'")) {
+        return [{ Id: '900', DocNumber: 'REF-1' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '200'")) {
+        return [];
+      }
+
+      throw new Error(`Unexpected QBO query: ${query}`);
+    });
+
+    const markPostedToQbo = vi.fn();
+    const postRefundToQbo = vi.fn();
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo }) as any,
+      qboQuery,
+      postRefundToQbo,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003CONTACT&dryRun=true',
+          query: new URLSearchParams({ salesforceId: '003CONTACT', dryRun: 'true' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Contact');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('200');
+    expect(body.summary.transactionCounts.salesforce.refund).toBe(1);
+    expect(body.summary.transactionCounts.quickbooks.refund).toBe(1);
+    expect(body.summary.plannedCreates).toEqual([]);
+    expect(postRefundToQbo).not.toHaveBeenCalled();
+    expect(markPostedToQbo).not.toHaveBeenCalled();
+  });
+
+  it('resolves an Account via QuickBooks custom field and backfills Salesforce QuickBooks_ID__c', async () => {
+    const updateCalls: Array<{ objectName: string; payload: Record<string, unknown> }> = [];
+    const connection = createConnection(
+      async (soql: string) => {
+        if (soql.includes("FROM Contact WHERE Id = '001ACCOUNT'")) {
+          return { records: [] };
+        }
+
+        if (soql.includes("FROM Account WHERE Id = '001ACCOUNT'")) {
+          return { records: [{ Id: '001ACCOUNT', Name: 'Acme Org', QuickBooks_ID__c: null }] };
+        }
+
+        if (soql.includes("FROM Transaction__c WHERE Account__c = '001ACCOUNT'")) {
+          return { records: [] };
+        }
+
+        return { records: [] };
+      },
+      async (objectName: string, payload: Record<string, unknown>) => {
+        updateCalls.push({ objectName, payload });
+        return { success: true, id: String(payload.Id ?? 'updated') };
+      }
+    );
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [
+          {
+            Id: '345',
+            DisplayName: 'Acme Org',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '001ACCOUNT' }],
+          },
+        ];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '345'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=001ACCOUNT&dryRun=false',
+          query: new URLSearchParams({ salesforceId: '001ACCOUNT', dryRun: 'false' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Account');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('345');
+    expect(body.summary.plannedBackfills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'backfill_salesforce_quickbooks_id',
+          qboCustomerId: '345',
+          salesforceId: '001ACCOUNT',
+        }),
+      ])
+    );
+    expect(updateCalls).toEqual([
+      {
+        objectName: 'Account',
+        payload: { Id: '001ACCOUNT', QuickBooks_ID__c: '345' },
+      },
+    ]);
+  });
+
+  it('backfills QuickBooks Salesforce ID when the linked customer is missing it', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003BACKFILL'")) {
+        return {
+          records: [
+            { Id: '003BACKFILL', FirstName: 'Grace', LastName: 'Hopper', QuickBooks_ID__c: '456' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003BACKFILL'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '456'")) {
+        return [
+          {
+            Id: '456',
+            DisplayName: 'Grace Hopper',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '456'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const updateQuickBooksCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      updateQuickBooksCustomerSalesforceId,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003BACKFILL&dryRun=false',
+          query: new URLSearchParams({ salesforceId: '003BACKFILL', dryRun: 'false' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.plannedBackfills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'backfill_qbo_salesforce_id',
+          qboCustomerId: '456',
+          salesforceId: '003BACKFILL',
+        }),
+      ])
+    );
+    expect(updateQuickBooksCustomerSalesforceId).toHaveBeenCalledWith('456', '003BACKFILL');
+  });
+
+  it('creates a QuickBooks document for a supported Salesforce-only refund transaction', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003REFUND'")) {
+        return {
+          records: [
+            { Id: '003REFUND', FirstName: 'Linus', LastName: 'Pauling', QuickBooks_ID__c: '777' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003REFUND'")) {
+        return {
+          records: [
+            {
+              Id: 'a01Refund',
+              Name: 'Refund Transaction',
+              Transaction_Type__c: 'refund',
+              Amount_Gross__c: -25,
+              Memo__c: 'Refund Transaction',
+              Received_At__c: '2025-01-01T00:00:00.000Z',
+              Posted_to_QBO__c: false,
+              QBO_Doc_Id__c: null,
+              QBO_Doc_Type__c: null,
+            },
+          ],
+        };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '777'")) {
+        return [
+          {
+            Id: '777',
+            DisplayName: 'Linus Pauling',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003REFUND' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '777'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const postRefundToQbo = vi.fn().mockResolvedValue({ qboId: 'JE-1', type: 'journal-entry' });
+    const markPostedToQbo = vi.fn();
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo }) as any,
+      qboQuery,
+      postRefundToQbo,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003REFUND&dryRun=false',
+          query: new URLSearchParams({ salesforceId: '003REFUND', dryRun: 'false' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.plannedCreates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'create_qbo_document',
+          salesforceTransactionId: 'a01Refund',
+          transactionType: 'refund',
+        }),
+      ])
+    );
+    expect(postRefundToQbo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 2500,
+        memo: 'Refund Transaction',
+      })
+    );
+    expect(markPostedToQbo).toHaveBeenCalledWith('a01Refund', {
+      id: 'JE-1',
+      type: 'journal-entry',
+    });
+  });
+
+  it('flags conflicts instead of guessing when Salesforce and QuickBooks links disagree', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003CONFLICT'")) {
+        return {
+          records: [
+            {
+              Id: '003CONFLICT',
+              FirstName: 'Katherine',
+              LastName: 'Johnson',
+              QuickBooks_ID__c: '100',
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003CONFLICT'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '100'")) {
+        return [
+          {
+            Id: '100',
+            DisplayName: 'Customer A',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONFLICT' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [
+          {
+            Id: '200',
+            DisplayName: 'Customer B',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONFLICT' }],
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003CONFLICT&dryRun=true',
+          query: new URLSearchParams({ salesforceId: '003CONFLICT', dryRun: 'true' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(409);
+    expect(body.summary.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'cross_system_link_conflict',
+        }),
+      ])
+    );
+  });
+});

--- a/__tests__/stripeTrueUp.test.ts
+++ b/__tests__/stripeTrueUp.test.ts
@@ -42,9 +42,7 @@ describe('stripeTrueUp contact helper', () => {
     const result = await findOrCreateContactInSalesforce({} as any, customer, null, noopLog);
 
     expect(result).toEqual({ id: '003abc' });
-    expect(createMock).toHaveBeenCalledWith(
-      expect.objectContaining({ RecordTypeId: 'rt-999' })
-    );
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ RecordTypeId: 'rt-999' }));
     // should have performed two queries
     expect(connection.query).toHaveBeenCalledTimes(2);
   });
@@ -163,7 +161,11 @@ describe('stripeTrueUp handler overrides', () => {
     });
 
     const { context } = createContext();
-    const req = createQueryRequest({ from: '2026-01-01T00:00:00Z', type: 'payments', bypassQbo: 'true' });
+    const req = createQueryRequest({
+      from: '2026-01-01T00:00:00Z',
+      type: 'payments',
+      bypassQbo: 'true',
+    });
 
     const response = await (stripeTrueUpHandler as any)(req, context);
     const body = JSON.parse(response.body);
@@ -181,7 +183,9 @@ describe('stripeTrueUp handler overrides', () => {
     const internals = (stripeTrueUpHandler as any).__internals;
     const store = createIdempotencyStore();
     const salesforce = {
-      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'a01_existing', success: true }),
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_existing', success: true }),
       linkPayoutOnTransactions: vi.fn(),
       markPostedToQbo: vi.fn(),
       findTransactionIdByExternalId: vi.fn().mockResolvedValue('a01_existing'),
@@ -383,7 +387,9 @@ describe('stripeTrueUp handler overrides', () => {
     const internals = (stripeTrueUpHandler as any).__internals;
     const store = createIdempotencyStore();
     const salesforce = {
-      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'a01_txn_meta', success: true }),
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_txn_meta', success: true }),
       linkPayoutOnTransactions: vi.fn(),
       markPostedToQbo: vi.fn(),
       findTransactionIdByExternalId: vi.fn().mockResolvedValue(null),
@@ -477,11 +483,15 @@ describe('stripeTrueUp handler overrides', () => {
     const internals = (stripeTrueUpHandler as any).__internals;
     const store = createIdempotencyStore();
     const salesforce = {
-      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'a01_txn_cmeta', success: true }),
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_txn_cmeta', success: true }),
       linkPayoutOnTransactions: vi.fn(),
       markPostedToQbo: vi.fn(),
       findTransactionIdByExternalId: vi.fn().mockResolvedValue(null),
-      upsertCustomerByStripeId: vi.fn().mockResolvedValue({ id: '003_created_again', success: true }),
+      upsertCustomerByStripeId: vi
+        .fn()
+        .mockResolvedValue({ id: '003_created_again', success: true }),
       findContactIdById: vi.fn().mockResolvedValue('003FromCustomerMetaAAA'),
     };
 
@@ -564,6 +574,101 @@ describe('stripeTrueUp handler overrides', () => {
       'stripe_charge_id__c',
       undefined
     );
+
+    internals.resetDependencies();
+  });
+
+  it('checks Account after no Contact match for Stripe salesforce_id metadata', async () => {
+    const internals = (stripeTrueUpHandler as any).__internals;
+    const store = createIdempotencyStore();
+    const salesforce = {
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_txn_account', success: true }),
+      linkPayoutOnTransactions: vi.fn(),
+      markPostedToQbo: vi.fn(),
+      findTransactionIdByExternalId: vi.fn().mockResolvedValue(null),
+      upsertCustomerByStripeId: vi.fn(),
+      findContactIdById: vi.fn().mockResolvedValue(null),
+      findAccountIdById: vi.fn().mockResolvedValue('001StripeAccountAAA'),
+    };
+
+    const stripe = {
+      customers: {
+        retrieve: vi.fn(),
+      },
+      invoices: {
+        retrieve: vi.fn(),
+      },
+      paymentIntents: {
+        retrieve: vi.fn(),
+      },
+      subscriptions: {
+        retrieve: vi.fn(),
+      },
+      products: {
+        retrieve: vi.fn(),
+      },
+      prices: {
+        retrieve: vi.fn(),
+      },
+    };
+
+    internals.setDependencies({
+      stripe: { getClient: vi.fn().mockReturnValue(stripe) },
+      fetchers: {
+        payments: vi.fn().mockResolvedValue([
+          {
+            id: 'ch_account_meta',
+            status: 'succeeded',
+            customer: null,
+            currency: 'usd',
+            created: 1_700_000_000,
+            metadata: {
+              salesforce_id: '001StripeAccountAAA',
+            },
+            balance_transaction: {
+              id: 'bt_account_meta',
+              amount: 1500,
+              fee: 45,
+              type: 'charge',
+              currency: 'usd',
+              created: 1_700_000_000,
+            },
+          },
+        ]),
+      },
+      idempotencyStore: store,
+      getSalesforceSvc: async () => salesforce as any,
+      accounting: {
+        postChargeToQbo: vi.fn(),
+      },
+    });
+
+    const { context } = createContext();
+    const req = createQueryRequest({
+      from: '2026-01-01T00:00:00Z',
+      type: 'payments',
+      bypassQbo: 'true',
+    });
+
+    const response = await (stripeTrueUpHandler as any)(req, context);
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.counts.processed).toBe(1);
+    expect(salesforce.findContactIdById).toHaveBeenCalledWith('001StripeAccountAAA');
+    expect(salesforce.findAccountIdById).toHaveBeenCalledWith('001StripeAccountAAA');
+    expect(salesforce.upsertCustomerByStripeId).not.toHaveBeenCalled();
+    const [transactionPayload, externalIdField, upsertOptions] =
+      salesforce.upsertTransactionByExternalId.mock.calls[0];
+    expect(transactionPayload).toMatchObject({
+      stripe_charge_id__c: 'ch_account_meta',
+      account__c: '001StripeAccountAAA',
+    });
+    expect(transactionPayload.contact__c).toBeUndefined();
+    expect(externalIdField).toBe('stripe_charge_id__c');
+    expect(upsertOptions).toBeUndefined();
 
     internals.resetDependencies();
   });

--- a/src/handlers/qboCustomersSync.ts
+++ b/src/handlers/qboCustomersSync.ts
@@ -1,7 +1,7 @@
 import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 
 import { logger } from '../lib/logger';
-import { query as qboQuery } from '../services/qboSvc';
+import { query as qboQuery, updateQuickBooksCustomerSalesforceId } from '../services/qboSvc';
 import { SalesforceService, buildSalesforceConfig } from '../services/salesforceService';
 
 type QboEmailAddress = { Address?: string | null };
@@ -18,6 +18,12 @@ type QboAddress = {
 };
 
 type QboWebAddress = { URI?: string | null };
+type QboCustomField = {
+  DefinitionId?: string | null;
+  Name?: string | null;
+  Type?: string | null;
+  StringValue?: string | null;
+};
 
 type QboCustomer = {
   Id?: string | number | null;
@@ -38,6 +44,7 @@ type QboCustomer = {
   BillAddr?: QboAddress | null;
   ShipAddr?: QboAddress | null;
   WebAddr?: QboWebAddress | null;
+  CustomField?: QboCustomField[] | null;
   Active?: boolean | null;
 };
 
@@ -64,6 +71,13 @@ type SalesforceContact = {
   OtherPostalCode?: string | null;
   OtherCountry?: string | null;
   Description?: string | null;
+  QuickBooks_ID__c?: string | null;
+};
+
+type SalesforceAccount = {
+  Id?: string;
+  Name?: string | null;
+  QuickBooks_ID__c?: string | null;
 };
 
 type QueryResult<T> = {
@@ -74,9 +88,7 @@ type SaveResult = { success: boolean; id?: string };
 
 type SalesforceConnectionLike = {
   query: <T = unknown>(soql: string) => Promise<QueryResult<T> | T[]>;
-  sobject: (
-    name: string
-  ) => {
+  sobject: (name: string) => {
     create: (record: Record<string, unknown>) => Promise<SaveResult | SaveResult[]>;
     update: (record: Record<string, unknown>) => Promise<SaveResult | SaveResult[]>;
   };
@@ -89,6 +101,7 @@ type SyncDependencies = {
     includeInactive: boolean;
   }) => Promise<QboCustomer[]>;
   getSalesforceConnection: () => Promise<SalesforceConnectionLike>;
+  updateQboCustomerSalesforceId: (customerId: string, salesforceId: string) => Promise<void>;
 };
 
 type RecordTypeLookup = {
@@ -125,7 +138,17 @@ type NormalizedQboCustomer = {
 };
 
 type MatchResult =
-  | { status: 'matched'; contact: SalesforceContact }
+  | {
+      status: 'matched';
+      target: 'Contact' | 'Account';
+      record: SalesforceContact | SalesforceAccount;
+      path:
+        | 'quickbooks_salesforce_id'
+        | 'salesforce_quickbooks_id'
+        | 'fallback_match'
+        | 'created_new_salesforce_record';
+      shouldBackfillQuickBooksSalesforceId?: boolean;
+    }
   | { status: 'not-found' }
   | { status: 'duplicate'; reason: string; candidates: SalesforceContact[] };
 
@@ -293,7 +316,14 @@ const normalizeQboCustomer = (customer: QboCustomer): NormalizedQboCustomer | nu
   };
 };
 
-const markerForQboCustomer = (qboCustomerId: string): string => `${QBO_MARKER_PREFIX}${qboCustomerId}]`;
+const getQboSalesforceId = (customer: QboCustomer): string | null => {
+  const customFields = Array.isArray(customer.CustomField) ? customer.CustomField : [];
+  const salesforceField = customFields.find((field) => field?.Name === 'Salesforce ID');
+  return toTrimmed(salesforceField?.StringValue);
+};
+
+const markerForQboCustomer = (qboCustomerId: string): string =>
+  `${QBO_MARKER_PREFIX}${qboCustomerId}]`;
 
 const hasMarker = (description: string | null | undefined, marker: string): boolean => {
   if (!description) {
@@ -320,10 +350,7 @@ const mergeDescriptionWithMarker = (
   return `${base}${separator}${marker}`;
 };
 
-const equalsIgnoreCase = (
-  a: string | null | undefined,
-  b: string | null | undefined
-): boolean => {
+const equalsIgnoreCase = (a: string | null | undefined, b: string | null | undefined): boolean => {
   const left = a?.trim().toLowerCase();
   const right = b?.trim().toLowerCase();
   return Boolean(left && right && left === right);
@@ -463,7 +490,9 @@ const resolveContactRecordTypeId = async (
     "SELECT Id FROM RecordType WHERE SObjectType = 'Contact' AND (Name = 'Contact' OR DeveloperName = 'Contact') AND IsActive = true ORDER BY IsDefaultRecordTypeMapping DESC LIMIT 1";
 
   const result = toRecords(await connection.query<RecordTypeLookup>(soql));
-  const found = result.find((record) => typeof record.Id === 'string' && record.Id.trim().length > 0);
+  const found = result.find(
+    (record) => typeof record.Id === 'string' && record.Id.trim().length > 0
+  );
 
   cachedContactRecordTypeId = found?.Id?.trim() ?? null;
   return cachedContactRecordTypeId;
@@ -515,8 +544,8 @@ const buildUpdatePayload = (
 
   const marker = markerForQboCustomer(customer.id);
   const baseDescription = overwrite
-    ? buildQboDescription(customer) ?? existing.Description ?? null
-    : existing.Description ?? null;
+    ? (buildQboDescription(customer) ?? existing.Description ?? null)
+    : (existing.Description ?? null);
   const nextDescription = mergeDescriptionWithMarker(baseDescription, marker);
 
   if (nextDescription !== (existing.Description ?? null)) {
@@ -528,8 +557,63 @@ const buildUpdatePayload = (
 
 const findSalesforceMatch = async (
   connection: SalesforceConnectionLike,
+  rawCustomer: QboCustomer,
   customer: NormalizedQboCustomer
 ): Promise<MatchResult> => {
+  const quickBooksSalesforceId = getQboSalesforceId(rawCustomer);
+
+  if (quickBooksSalesforceId) {
+    const contact = await findContactBySalesforceId(connection, quickBooksSalesforceId);
+    if (contact) {
+      return {
+        status: 'matched',
+        target: 'Contact',
+        record: contact,
+        path: 'quickbooks_salesforce_id',
+      };
+    }
+
+    const account = await findAccountBySalesforceId(connection, quickBooksSalesforceId);
+    if (account) {
+      return {
+        status: 'matched',
+        target: 'Account',
+        record: account,
+        path: 'quickbooks_salesforce_id',
+      };
+    }
+  } else {
+    const contactByQboId = await findByQuickBooksId<SalesforceContact>(
+      connection,
+      'Contact',
+      customer.id
+    );
+    if (contactByQboId.record) {
+      return {
+        status: 'matched',
+        target: 'Contact',
+        record: contactByQboId.record,
+        path: 'salesforce_quickbooks_id',
+        shouldBackfillQuickBooksSalesforceId: true,
+      };
+    }
+
+    const accountByQboId = await findByQuickBooksId<SalesforceAccount>(
+      connection,
+      'Account',
+      customer.id
+    );
+    if (accountByQboId.record) {
+      return {
+        status: 'matched',
+        target: 'Account',
+        record: accountByQboId.record,
+        path: 'salesforce_quickbooks_id',
+        shouldBackfillQuickBooksSalesforceId: true,
+      };
+    }
+  }
+
   const marker = markerForQboCustomer(customer.id);
 
   const candidates = await executeContactQueryWithFieldFallback(connection, customer);
@@ -550,7 +634,12 @@ const findSalesforceMatch = async (
   }
 
   if (selected.length === 1) {
-    return { status: 'matched', contact: selected[0] };
+    return {
+      status: 'matched',
+      target: 'Contact',
+      record: selected[0],
+      path: 'fallback_match',
+    };
   }
 
   return {
@@ -592,6 +681,83 @@ const parseUnsupportedContactField = (error: unknown): string | null => {
   }
 
   return null;
+};
+
+const parseUnsupportedObjectField = (
+  error: unknown,
+  objectName: 'Contact' | 'Account'
+): string | null => {
+  const message = error instanceof Error ? error.message : String(error);
+  const patterns = [
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on entity '${objectName}'`, 'i'),
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on sobject of type ${objectName}`, 'i'),
+  ];
+
+  for (const pattern of patterns) {
+    const match = message.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+};
+
+const findContactBySalesforceId = async (
+  connection: SalesforceConnectionLike,
+  salesforceId: string
+): Promise<SalesforceContact | null> => {
+  const soql =
+    `SELECT Id, FirstName, LastName, Email FROM Contact ` +
+    `WHERE Id = '${escapeSoqlLiteral(salesforceId)}' LIMIT 1`;
+  const records = toRecords(await connection.query<SalesforceContact>(soql));
+  return (
+    records.find((record) => typeof record.Id === 'string' && record.Id.trim().length > 0) ?? null
+  );
+};
+
+const findAccountBySalesforceId = async (
+  connection: SalesforceConnectionLike,
+  salesforceId: string
+): Promise<SalesforceAccount | null> => {
+  const soql = `SELECT Id, Name FROM Account WHERE Id = '${escapeSoqlLiteral(salesforceId)}' LIMIT 1`;
+  const records = toRecords(await connection.query<SalesforceAccount>(soql));
+  return (
+    records.find((record) => typeof record.Id === 'string' && record.Id.trim().length > 0) ?? null
+  );
+};
+
+const findByQuickBooksId = async <T extends { Id?: string }>(
+  connection: SalesforceConnectionLike,
+  objectName: 'Contact' | 'Account',
+  qboCustomerId: string
+): Promise<{ supported: boolean; record: T | null }> => {
+  const selectFields =
+    objectName === 'Contact'
+      ? 'Id, FirstName, LastName, Email, QuickBooks_ID__c'
+      : 'Id, Name, QuickBooks_ID__c';
+  const soql =
+    `SELECT ${selectFields} FROM ${objectName} ` +
+    `WHERE QuickBooks_ID__c = '${escapeSoqlLiteral(qboCustomerId)}' LIMIT 1`;
+
+  try {
+    const records = toRecords(await connection.query<T>(soql));
+    const record =
+      records.find(
+        (candidate) => typeof candidate.Id === 'string' && candidate.Id.trim().length > 0
+      ) ?? null;
+    return { supported: true, record };
+  } catch (error) {
+    const unsupportedField = parseUnsupportedObjectField(error, objectName);
+    if (unsupportedField?.toLowerCase() === 'quickbooks_id__c') {
+      logger.info('[qboCustomersSync] Salesforce object does not support QuickBooks_ID__c lookup', {
+        objectName,
+      });
+      return { supported: false, record: null };
+    }
+
+    throw error;
+  }
 };
 
 const executeContactQueryWithFieldFallback = async (
@@ -638,7 +804,11 @@ const executeContactQueryWithFieldFallback = async (
       whereClauses.push(`MobilePhone = '${escapeSoqlLiteral(customer.mobilePhone)}'`);
     }
 
-    if (customer.firstName && selectFields.includes('FirstName') && selectFields.includes('LastName')) {
+    if (
+      customer.firstName &&
+      selectFields.includes('FirstName') &&
+      selectFields.includes('LastName')
+    ) {
       whereClauses.push(
         `(FirstName = '${escapeSoqlLiteral(customer.firstName)}' AND LastName = '${escapeSoqlLiteral(
           customer.lastName
@@ -673,9 +843,12 @@ const executeContactQueryWithFieldFallback = async (
       }
 
       const [removedField] = selectFields.splice(index, 1);
-      logger.warn('[qboCustomersSync] Salesforce contact field unsupported; retrying query without field', {
-        removedField,
-      });
+      logger.warn(
+        '[qboCustomersSync] Salesforce contact field unsupported; retrying query without field',
+        {
+          removedField,
+        }
+      );
     }
   }
 
@@ -724,10 +897,13 @@ const executeContactSaveWithFieldFallback = async (
       }
 
       delete workingPayload[unsupportedField];
-      logger.warn('[qboCustomersSync] Salesforce contact field unsupported; retrying save without field', {
-        operation,
-        removedField: unsupportedField,
-      });
+      logger.warn(
+        '[qboCustomersSync] Salesforce contact field unsupported; retrying save without field',
+        {
+          operation,
+          removedField: unsupportedField,
+        }
+      );
     } catch (error) {
       const unsupportedField = parseUnsupportedContactField(error);
       if (!unsupportedField || !(unsupportedField in workingPayload) || unsupportedField === 'Id') {
@@ -735,10 +911,13 @@ const executeContactSaveWithFieldFallback = async (
       }
 
       delete workingPayload[unsupportedField];
-      logger.warn('[qboCustomersSync] Salesforce contact field unsupported; retrying save without field', {
-        operation,
-        removedField: unsupportedField,
-      });
+      logger.warn(
+        '[qboCustomersSync] Salesforce contact field unsupported; retrying save without field',
+        {
+          operation,
+          removedField: unsupportedField,
+        }
+      );
     }
   }
 
@@ -747,7 +926,9 @@ const executeContactSaveWithFieldFallback = async (
 
 const parseUnsupportedCustomerField = (error: unknown): string | null => {
   const message = error instanceof Error ? error.message : String(error);
-  const match = message.match(/Property\s+([A-Za-z0-9_]+)\s+not\s+found\s+for\s+Entity\s+Customer/i);
+  const match = message.match(
+    /Property\s+([A-Za-z0-9_]+)\s+not\s+found\s+for\s+Entity\s+Customer/i
+  );
   if (!match) {
     return null;
   }
@@ -782,6 +963,7 @@ const queryQboCustomersWithFieldFallback = async (
     'BillAddr',
     'ShipAddr',
     'WebAddr',
+    'CustomField',
     'Active',
   ];
 
@@ -800,8 +982,8 @@ const queryQboCustomersWithFieldFallback = async (
         throw error;
       }
 
-      const index = selectFields.findIndex((field) =>
-        field.toLowerCase() === unsupportedField.toLowerCase()
+      const index = selectFields.findIndex(
+        (field) => field.toLowerCase() === unsupportedField.toLowerCase()
       );
 
       if (index === -1) {
@@ -853,6 +1035,9 @@ const createDefaultDependencies = (): SyncDependencies => ({
   getSalesforceConnection: async () => {
     const service = new SalesforceService(buildSalesforceConfig());
     return (await service.authenticate()) as unknown as SalesforceConnectionLike;
+  },
+  updateQboCustomerSalesforceId: async (customerId: string, salesforceId: string) => {
+    await updateQuickBooksCustomerSalesforceId(customerId, salesforceId);
   },
 });
 
@@ -910,9 +1095,12 @@ const syncQboCustomersToSalesforce = async (
       contactRecordTypeId = await resolveContactRecordTypeId(salesforce);
     } catch (error) {
       contactRecordTypeId = null;
-      logger.warn('[qboCustomersSync] Unable to resolve Contact record type; defaulting to org default', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        '[qboCustomersSync] Unable to resolve Contact record type; defaulting to org default',
+        {
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
     }
 
     const startedAt = Date.now();
@@ -985,7 +1173,7 @@ const syncQboCustomersToSalesforce = async (
         }
 
         try {
-          const match = await findSalesforceMatch(salesforce, normalized);
+          const match = await findSalesforceMatch(salesforce, rawCustomer, normalized);
 
           if (match.status === 'duplicate') {
             counts.duplicateConflicts += 1;
@@ -1004,17 +1192,44 @@ const syncQboCustomersToSalesforce = async (
 
           if (match.status === 'matched') {
             counts.alreadyExistInSalesforce += 1;
-            const updatePayload = buildUpdatePayload(match.contact, normalized, overwrite);
-            if (updatePayload) {
+            const updatePayload =
+              match.target === 'Contact'
+                ? buildUpdatePayload(match.record as SalesforceContact, normalized, overwrite)
+                : null;
+            if (updatePayload && match.target === 'Contact') {
               counts.wouldUpdate += 1;
             }
+
+            logger.info('[qboCustomersSync] Matched existing Salesforce record', {
+              qboCustomerId: normalized.id,
+              salesforceId: match.record.Id,
+              salesforceObject: match.target,
+              matchPath: match.path,
+            });
 
             if (samples.matched.length < exampleLimit) {
               samples.matched.push({
                 qboCustomerId: normalized.id,
                 qboDisplayName: normalized.displayName,
-                salesforceContactId: match.contact.Id,
+                salesforceId: match.record.Id,
+                salesforceObject: match.target,
+                matchPath: match.path,
                 wouldUpdate: Boolean(updatePayload),
+              });
+            }
+
+            if (
+              match.path === 'salesforce_quickbooks_id' &&
+              match.shouldBackfillQuickBooksSalesforceId &&
+              !getQboSalesforceId(rawCustomer) &&
+              match.record.Id &&
+              !dryRun
+            ) {
+              await deps.updateQboCustomerSalesforceId(normalized.id, match.record.Id);
+              logger.info('[qboCustomersSync] Backfilled QuickBooks Salesforce ID', {
+                qboCustomerId: normalized.id,
+                salesforceId: match.record.Id,
+                matchPath: 'backfilled_quickbooks_salesforce_id',
               });
             }
 
@@ -1030,7 +1245,9 @@ const syncQboCustomersToSalesforce = async (
                 updatePayload
               );
               if (!saveResult?.success) {
-                throw new Error(`Failed to update Salesforce contact ${String(match.contact.Id ?? '')}`);
+                throw new Error(
+                  `Failed to update Salesforce contact ${String(match.record.Id ?? '')}`
+                );
               }
               counts.updated += 1;
             }
@@ -1066,7 +1283,18 @@ const syncQboCustomersToSalesforce = async (
               createPayload
             );
             if (!saveResult?.success) {
-              throw new Error(`Failed to create Salesforce contact for QBO customer ${normalized.id}`);
+              throw new Error(
+                `Failed to create Salesforce contact for QBO customer ${normalized.id}`
+              );
+            }
+            logger.info('[qboCustomersSync] Created Salesforce record for QuickBooks customer', {
+              qboCustomerId: normalized.id,
+              salesforceId: saveResult.id,
+              salesforceObject: 'Contact',
+              matchPath: 'created_new_salesforce_record',
+            });
+            if (saveResult.id) {
+              await deps.updateQboCustomerSalesforceId(normalized.id, saveResult.id);
             }
             counts.created += 1;
           }

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -1,0 +1,909 @@
+import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+import env from '../config/env';
+import { transactionTypeSchema } from '../domain/transactions';
+import { logger } from '../lib/logger';
+import {
+  postChargeToQbo,
+  postDisputeToQbo,
+  postPayoutToQbo,
+  postRefundToQbo,
+  query as qboQuery,
+  updateQuickBooksCustomerSalesforceId,
+} from '../services/qboSvc';
+import { buildSalesforceConfig, SalesforceService } from '../services/salesforceService';
+import { createSalesforceSvc } from '../services/salesforceSvc';
+
+type SalesforceObjectType = 'Contact' | 'Account';
+type QuickBooksDocType = 'sales-receipt' | 'journal-entry' | 'bank-deposit';
+
+type SalesforceRecord = {
+  Id?: string;
+  FirstName?: string | null;
+  LastName?: string | null;
+  Email?: string | null;
+  Name?: string | null;
+  QuickBooks_ID__c?: string | null;
+};
+
+type QboCustomField = {
+  DefinitionId?: string | null;
+  Name?: string | null;
+  Type?: string | null;
+  StringValue?: string | null;
+};
+
+type QboCustomer = {
+  Id?: string | number | null;
+  DisplayName?: string | null;
+  PrimaryEmailAddr?: { Address?: string | null } | null;
+  Active?: boolean | null;
+  CustomField?: QboCustomField[] | null;
+};
+
+type SalesforceTransaction = {
+  Id?: string;
+  Name?: string | null;
+  Transaction_Type__c?: string | null;
+  Amount_Gross__c?: number | null;
+  Amount_Fee__c?: number | null;
+  Amount_Net__c?: number | null;
+  Memo__c?: string | null;
+  Received_At__c?: string | null;
+  Posted_to_QBO__c?: boolean | null;
+  QBO_Doc_Type__c?: string | null;
+  QBO_Doc_Id__c?: string | null;
+  Stripe_Payout_Id__c?: string | null;
+  Posting_Error__c?: string | null;
+};
+
+type PlannedAction =
+  | {
+      type: 'create_qbo_document';
+      salesforceTransactionId: string;
+      transactionType: string;
+      reason: string;
+    }
+  | {
+      type: 'backfill_qbo_salesforce_id';
+      qboCustomerId: string;
+      salesforceId: string;
+      reason: string;
+    }
+  | {
+      type: 'backfill_salesforce_quickbooks_id';
+      salesforceId: string;
+      qboCustomerId: string;
+      objectType: SalesforceObjectType;
+      fieldName: 'QuickBooks_ID__c';
+      reason: string;
+    }
+  | {
+      type: 'mark_salesforce_posted_to_qbo';
+      salesforceTransactionId: string;
+      qboDocId: string;
+      qboDocType: QuickBooksDocType;
+      reason: string;
+    };
+
+type ConflictItem = {
+  code: string;
+  message: string;
+  salesforceTransactionId?: string;
+  qboDocId?: string;
+};
+
+type HandlerSummary = {
+  resolvedSalesforceObjectType: SalesforceObjectType | null;
+  resolvedSalesforceRecordId: string | null;
+  resolvedQuickBooksCustomerId: string | null;
+  linkingFields: {
+    salesforceQuickBooksField: 'QuickBooks_ID__c';
+    salesforceQuickBooksFieldSupported: boolean;
+    salesforceQuickBooksFieldValue: string | null;
+    quickbooksSalesforceField: 'Salesforce ID';
+    quickbooksSalesforceFieldValue: string | null;
+  };
+  supportedTransactionTypes: string[];
+  transactionCounts: {
+    salesforce: Record<string, number>;
+    quickbooks: Record<string, number>;
+  };
+  plannedCreates: PlannedAction[];
+  plannedUpdates: PlannedAction[];
+  plannedBackfills: PlannedAction[];
+  conflicts: ConflictItem[];
+  manualReviewItems: ConflictItem[];
+};
+
+type Dependencies = {
+  getSalesforceConnection: () => Promise<Awaited<ReturnType<SalesforceService['authenticate']>>>;
+  createSalesforceSvc: (
+    connection: Awaited<ReturnType<SalesforceService['authenticate']>>
+  ) => ReturnType<typeof createSalesforceSvc>;
+  qboQuery: typeof qboQuery;
+  updateQuickBooksCustomerSalesforceId: typeof updateQuickBooksCustomerSalesforceId;
+  postChargeToQbo: typeof postChargeToQbo;
+  postRefundToQbo: typeof postRefundToQbo;
+  postDisputeToQbo: typeof postDisputeToQbo;
+  postPayoutToQbo: typeof postPayoutToQbo;
+};
+
+type ResolvedSalesforceRecord = {
+  objectType: SalesforceObjectType;
+  record: SalesforceRecord;
+  quickBooksFieldSupported: boolean;
+};
+
+const DEFAULT_QBO_PAGE_SIZE = 200;
+let dependencyOverrides: Partial<Dependencies> | null = null;
+
+const toRecords = <T>(result: { records?: T[] } | T[] | null | undefined): T[] => {
+  if (!result) {
+    return [];
+  }
+
+  if (Array.isArray(result)) {
+    return result;
+  }
+
+  return Array.isArray(result.records) ? result.records : [];
+};
+
+const toTrimmed = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const parseBoolean = (value: unknown, defaultValue: boolean): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['false', '0', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+};
+
+const escapeSoqlLiteral = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+const escapeQboLiteral = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+const parseUnsupportedField = (error: unknown, objectName: SalesforceObjectType): string | null => {
+  const message = error instanceof Error ? error.message : String(error);
+  const patterns = [
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on entity '${objectName}'`, 'i'),
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on sobject of type ${objectName}`, 'i'),
+  ];
+
+  for (const pattern of patterns) {
+    const match = message.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+};
+
+const readSalesforceId = async (request: HttpRequest): Promise<string | null> => {
+  const readFromQuery = (): string | null => {
+    if (request.query && typeof request.query.get === 'function') {
+      return toTrimmed(request.query.get('salesforceId'));
+    }
+
+    return toTrimmed(
+      (request.query as unknown as Record<string, unknown> | undefined)?.salesforceId
+    );
+  };
+
+  const fromQuery = readFromQuery();
+  if (fromQuery) {
+    return fromQuery;
+  }
+
+  if (request.method === 'POST') {
+    try {
+      const body = (await request.json()) as Record<string, unknown>;
+      return toTrimmed(body?.salesforceId);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return null;
+};
+
+const getQboSalesforceId = (customer: QboCustomer | null | undefined): string | null => {
+  const customFields = Array.isArray(customer?.CustomField) ? customer.CustomField : [];
+  const field = customFields.find((entry) => entry?.Name === 'Salesforce ID');
+  return toTrimmed(field?.StringValue);
+};
+
+const normalizeQboCustomerId = (value: unknown): string | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return toTrimmed(value);
+};
+
+const fetchSalesforceRecordById = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  objectType: SalesforceObjectType,
+  salesforceId: string
+): Promise<{ record: SalesforceRecord | null; quickBooksFieldSupported: boolean }> => {
+  const baseFields = objectType === 'Contact' ? 'Id, FirstName, LastName, Email' : 'Id, Name';
+  const withQuickBooksField = `${baseFields}, QuickBooks_ID__c`;
+  const escapedId = escapeSoqlLiteral(salesforceId);
+
+  try {
+    const records = toRecords(
+      await connection.query<SalesforceRecord>(
+        `SELECT ${withQuickBooksField} FROM ${objectType} WHERE Id = '${escapedId}' LIMIT 1`
+      )
+    );
+    return {
+      record:
+        records.find((entry) => typeof entry.Id === 'string' && entry.Id.trim().length > 0) ?? null,
+      quickBooksFieldSupported: true,
+    };
+  } catch (error) {
+    const unsupportedField = parseUnsupportedField(error, objectType);
+    if (unsupportedField?.toLowerCase() !== 'quickbooks_id__c') {
+      throw error;
+    }
+
+    const records = toRecords(
+      await connection.query<SalesforceRecord>(
+        `SELECT ${baseFields} FROM ${objectType} WHERE Id = '${escapedId}' LIMIT 1`
+      )
+    );
+    return {
+      record:
+        records.find((entry) => typeof entry.Id === 'string' && entry.Id.trim().length > 0) ?? null,
+      quickBooksFieldSupported: false,
+    };
+  }
+};
+
+const resolveSalesforceRecord = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  salesforceId: string
+): Promise<ResolvedSalesforceRecord | null> => {
+  const contact = await fetchSalesforceRecordById(connection, 'Contact', salesforceId);
+  if (contact.record) {
+    return {
+      objectType: 'Contact',
+      record: contact.record,
+      quickBooksFieldSupported: contact.quickBooksFieldSupported,
+    };
+  }
+
+  const account = await fetchSalesforceRecordById(connection, 'Account', salesforceId);
+  if (account.record) {
+    return {
+      objectType: 'Account',
+      record: account.record,
+      quickBooksFieldSupported: account.quickBooksFieldSupported,
+    };
+  }
+
+  return null;
+};
+
+const queryQboCustomersPage = async (
+  startPosition: number,
+  queryFn: typeof qboQuery
+): Promise<QboCustomer[]> => {
+  const queryText =
+    'SELECT Id, DisplayName, PrimaryEmailAddr, Active, CustomField FROM Customer ' +
+    `STARTPOSITION ${startPosition} MAXRESULTS ${DEFAULT_QBO_PAGE_SIZE}`;
+  const records = await queryFn<QboCustomer[]>(queryText);
+  return Array.isArray(records) ? records : [];
+};
+
+const findQuickBooksCustomerById = async (
+  customerId: string,
+  queryFn: typeof qboQuery
+): Promise<QboCustomer | null> => {
+  const queryText =
+    'SELECT Id, DisplayName, PrimaryEmailAddr, Active, CustomField FROM Customer ' +
+    `WHERE Id = '${escapeQboLiteral(customerId)}' MAXRESULTS 1`;
+  const records = await queryFn<QboCustomer[]>(queryText);
+  const list = Array.isArray(records) ? records : [];
+  return list.find((entry) => normalizeQboCustomerId(entry?.Id) === customerId) ?? null;
+};
+
+const findQuickBooksCustomersBySalesforceId = async (
+  salesforceId: string,
+  queryFn: typeof qboQuery
+): Promise<QboCustomer[]> => {
+  const matches: QboCustomer[] = [];
+  let startPosition = 1;
+
+  while (true) {
+    const page = await queryQboCustomersPage(startPosition, queryFn);
+    if (!page.length) {
+      break;
+    }
+
+    matches.push(
+      ...page.filter(
+        (customer) => getQboSalesforceId(customer)?.toLowerCase() === salesforceId.toLowerCase()
+      )
+    );
+
+    if (page.length < DEFAULT_QBO_PAGE_SIZE) {
+      break;
+    }
+
+    startPosition += page.length;
+  }
+
+  return matches;
+};
+
+const updateSalesforceQuickBooksId = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  objectType: SalesforceObjectType,
+  salesforceId: string,
+  qboCustomerId: string
+): Promise<void> => {
+  const payload = {
+    Id: salesforceId,
+    QuickBooks_ID__c: qboCustomerId,
+  };
+
+  try {
+    const result = await connection.sobject(objectType).update(payload);
+    const saveResult = Array.isArray(result) ? result[0] : result;
+    if (!saveResult?.success) {
+      throw new Error(`Failed to update ${objectType} ${salesforceId} with QuickBooks_ID__c.`);
+    }
+  } catch (error) {
+    const unsupportedField = parseUnsupportedField(error, objectType);
+    if (unsupportedField?.toLowerCase() === 'quickbooks_id__c') {
+      throw new Error(`${objectType}.QuickBooks_ID__c is not supported in this org.`);
+    }
+
+    throw error;
+  }
+};
+
+const loadSalesforceTransactions = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  objectType: SalesforceObjectType,
+  salesforceId: string
+): Promise<SalesforceTransaction[]> => {
+  const relationshipField = objectType === 'Contact' ? 'Contact__c' : 'Account__c';
+  const soql =
+    'SELECT Id, Name, Transaction_Type__c, Amount_Gross__c, Amount_Fee__c, Amount_Net__c, ' +
+    'Memo__c, Received_At__c, Posted_to_QBO__c, QBO_Doc_Type__c, QBO_Doc_Id__c, ' +
+    'Stripe_Payout_Id__c, Posting_Error__c ' +
+    `FROM Transaction__c WHERE ${relationshipField} = '${escapeSoqlLiteral(salesforceId)}' ` +
+    'ORDER BY Received_At__c DESC NULLS LAST';
+  return toRecords(await connection.query<SalesforceTransaction>(soql));
+};
+
+const fetchQuickBooksDocument = async (
+  qboDocType: QuickBooksDocType,
+  qboDocId: string,
+  queryFn: typeof qboQuery
+): Promise<Record<string, unknown> | null> => {
+  const entityName =
+    qboDocType === 'sales-receipt'
+      ? 'SalesReceipt'
+      : qboDocType === 'bank-deposit'
+        ? 'Deposit'
+        : 'JournalEntry';
+  const queryText = `SELECT * FROM ${entityName} WHERE Id = '${escapeQboLiteral(qboDocId)}'`;
+  const records = await queryFn<Record<string, unknown>[]>(queryText);
+  const list = Array.isArray(records) ? records : [];
+  return list.length > 0 ? list[0] : null;
+};
+
+const fetchQuickBooksSalesReceiptsForCustomer = async (
+  customerId: string,
+  queryFn: typeof qboQuery
+): Promise<Record<string, unknown>[]> => {
+  const queryText =
+    'SELECT Id, DocNumber, TxnDate, TotalAmt, CustomerRef FROM SalesReceipt ' +
+    `WHERE CustomerRef = '${escapeQboLiteral(customerId)}'`;
+  const records = await queryFn<Record<string, unknown>[]>(queryText);
+  return Array.isArray(records) ? records : [];
+};
+
+const toCountMap = (types: string[]): Record<string, number> =>
+  Object.fromEntries(types.map((type) => [type, 0]));
+
+const toDate = (value: string | null | undefined): Date => {
+  const parsed = value ? new Date(value) : new Date();
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+};
+
+const toCents = (amount: number | null | undefined): number => {
+  if (typeof amount !== 'number' || Number.isNaN(amount)) {
+    return 0;
+  }
+
+  return Math.round(Math.abs(amount) * 100);
+};
+
+const executeTransactionCreate = async (
+  transaction: SalesforceTransaction,
+  dependencies: Dependencies
+): Promise<{ qboId: string; type: QuickBooksDocType }> => {
+  const transactionType = toTrimmed(transaction.Transaction_Type__c);
+  const memo = toTrimmed(transaction.Memo__c) || toTrimmed(transaction.Name) || undefined;
+  const date = toDate(transaction.Received_At__c);
+
+  switch (transactionType) {
+    case 'refund': {
+      return await dependencies.postRefundToQbo({
+        amount: toCents(transaction.Amount_Gross__c),
+        memo,
+        date,
+      });
+    }
+    case 'dispute': {
+      return await dependencies.postDisputeToQbo({
+        lossAmount: toCents(transaction.Amount_Gross__c),
+        feeAmount: toCents(transaction.Amount_Fee__c),
+        memo,
+        date,
+      });
+    }
+    case 'payout': {
+      return await dependencies.postPayoutToQbo({
+        amount: toCents(transaction.Amount_Gross__c),
+        memo,
+        date,
+        payoutId: toTrimmed(transaction.Stripe_Payout_Id__c) || undefined,
+      });
+    }
+    case 'charge': {
+      if (env.accounting.postingStrategy !== 'je-transfer') {
+        throw new Error(
+          'Charge sync requires existing Stripe checkout metadata when accounting.postingStrategy is sales-receipt.'
+        );
+      }
+
+      return await dependencies.postChargeToQbo({
+        gross: toCents(transaction.Amount_Gross__c),
+        fee: toCents(transaction.Amount_Fee__c),
+        memo,
+        date,
+        stripe: {},
+      });
+    }
+    default:
+      throw new Error(
+        `Unsupported transaction type for QuickBooks sync: ${transactionType ?? 'unknown'}`
+      );
+  }
+};
+
+const buildSummary = (): HandlerSummary => ({
+  resolvedSalesforceObjectType: null,
+  resolvedSalesforceRecordId: null,
+  resolvedQuickBooksCustomerId: null,
+  linkingFields: {
+    salesforceQuickBooksField: 'QuickBooks_ID__c',
+    salesforceQuickBooksFieldSupported: false,
+    salesforceQuickBooksFieldValue: null,
+    quickbooksSalesforceField: 'Salesforce ID',
+    quickbooksSalesforceFieldValue: null,
+  },
+  supportedTransactionTypes: [...transactionTypeSchema.options],
+  transactionCounts: {
+    salesforce: toCountMap([...transactionTypeSchema.options]),
+    quickbooks: toCountMap([...transactionTypeSchema.options]),
+  },
+  plannedCreates: [],
+  plannedUpdates: [],
+  plannedBackfills: [],
+  conflicts: [],
+  manualReviewItems: [],
+});
+
+const createDefaultDependencies = (): Dependencies => ({
+  getSalesforceConnection: async () => {
+    const salesforceService = new SalesforceService(buildSalesforceConfig());
+    return await salesforceService.authenticate();
+  },
+  createSalesforceSvc: (connection) => createSalesforceSvc({ connection }),
+  qboQuery,
+  updateQuickBooksCustomerSalesforceId,
+  postChargeToQbo,
+  postRefundToQbo,
+  postDisputeToQbo,
+  postPayoutToQbo,
+});
+
+const resolveDependencies = (): Dependencies => ({
+  ...createDefaultDependencies(),
+  ...(dependencyOverrides ?? {}),
+});
+
+const salesforceRecordQboSync = async (
+  request: HttpRequest,
+  context: InvocationContext
+): Promise<HttpResponseInit> => {
+  const dryRun = parseBoolean(
+    request.query && typeof request.query.get === 'function'
+      ? request.query.get('dryRun')
+      : (request.query as unknown as Record<string, unknown> | undefined)?.dryRun,
+    true
+  );
+  const salesforceId = await readSalesforceId(request);
+  const summary = buildSummary();
+
+  if (!salesforceId) {
+    return {
+      status: 400,
+      jsonBody: {
+        error: 'bad_request',
+        message: 'salesforceId is required.',
+        dryRun,
+        summary,
+      },
+    };
+  }
+
+  try {
+    const dependencies = resolveDependencies();
+    const connection = await dependencies.getSalesforceConnection();
+    const salesforceSvc = dependencies.createSalesforceSvc(connection);
+
+    const resolvedRecord = await resolveSalesforceRecord(connection, salesforceId);
+    if (!resolvedRecord) {
+      return {
+        status: 404,
+        jsonBody: {
+          error: 'salesforce_record_not_found',
+          message: `No Contact or Account was found for Salesforce ID ${salesforceId}.`,
+          dryRun,
+          summary,
+        },
+      };
+    }
+
+    summary.resolvedSalesforceObjectType = resolvedRecord.objectType;
+    summary.resolvedSalesforceRecordId = resolvedRecord.record.Id ?? salesforceId;
+    summary.linkingFields.salesforceQuickBooksFieldSupported =
+      resolvedRecord.quickBooksFieldSupported;
+    summary.linkingFields.salesforceQuickBooksFieldValue =
+      toTrimmed(resolvedRecord.record.QuickBooks_ID__c) ?? null;
+
+    const salesforceQboId = toTrimmed(resolvedRecord.record.QuickBooks_ID__c);
+    const qboCustomersBySalesforceId = await findQuickBooksCustomersBySalesforceId(
+      salesforceId,
+      dependencies.qboQuery
+    );
+
+    if (qboCustomersBySalesforceId.length > 1) {
+      summary.conflicts.push({
+        code: 'multiple_qbo_customers_for_salesforce_id',
+        message: `Multiple QuickBooks customers reference Salesforce ID ${salesforceId}.`,
+      });
+    }
+
+    let qboCustomer: QboCustomer | null = null;
+
+    if (salesforceQboId) {
+      qboCustomer = await findQuickBooksCustomerById(salesforceQboId, dependencies.qboQuery);
+      if (!qboCustomer) {
+        summary.conflicts.push({
+          code: 'salesforce_quickbooks_id_not_found',
+          message: `Salesforce ${resolvedRecord.objectType} ${salesforceId} references QuickBooks customer ${salesforceQboId}, but that customer was not found.`,
+        });
+      }
+    }
+
+    const qboCustomerFromSalesforceId =
+      qboCustomersBySalesforceId.length === 1 ? qboCustomersBySalesforceId[0] : null;
+    const qboCustomerFromSalesforceIdValue = normalizeQboCustomerId(
+      qboCustomerFromSalesforceId?.Id
+    );
+
+    if (
+      qboCustomer &&
+      qboCustomerFromSalesforceIdValue &&
+      salesforceQboId !== qboCustomerFromSalesforceIdValue
+    ) {
+      summary.conflicts.push({
+        code: 'cross_system_link_conflict',
+        message:
+          `Salesforce ${resolvedRecord.objectType} ${salesforceId} points to QuickBooks customer ${salesforceQboId}, ` +
+          `but QuickBooks custom field "Salesforce ID" points to customer ${qboCustomerFromSalesforceIdValue}.`,
+      });
+    }
+
+    if (!qboCustomer && qboCustomerFromSalesforceId) {
+      qboCustomer = qboCustomerFromSalesforceId;
+      const qboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
+      if (resolvedRecord.quickBooksFieldSupported && qboCustomerId) {
+        summary.plannedBackfills.push({
+          type: 'backfill_salesforce_quickbooks_id',
+          salesforceId,
+          qboCustomerId,
+          objectType: resolvedRecord.objectType,
+          fieldName: 'QuickBooks_ID__c',
+          reason: 'determined_from_quickbooks_salesforce_id',
+        });
+      }
+    }
+
+    if (qboCustomer) {
+      const qboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
+      const qboSalesforceId = getQboSalesforceId(qboCustomer);
+      summary.resolvedQuickBooksCustomerId = qboCustomerId;
+      summary.linkingFields.quickbooksSalesforceFieldValue = qboSalesforceId;
+
+      if (qboSalesforceId && qboSalesforceId !== salesforceId) {
+        summary.conflicts.push({
+          code: 'quickbooks_salesforce_id_conflict',
+          message:
+            `QuickBooks customer ${qboCustomerId} has custom field "Salesforce ID"=${qboSalesforceId}, ` +
+            `which does not match requested Salesforce ID ${salesforceId}.`,
+        });
+      }
+
+      if (!qboSalesforceId && qboCustomerId) {
+        summary.plannedBackfills.push({
+          type: 'backfill_qbo_salesforce_id',
+          qboCustomerId,
+          salesforceId,
+          reason: 'determined_from_salesforce_record',
+        });
+      }
+    }
+
+    if (!qboCustomer) {
+      return {
+        status: 409,
+        jsonBody: {
+          error: 'quickbooks_customer_not_resolved',
+          message: `Unable to deterministically resolve a QuickBooks customer for Salesforce ID ${salesforceId}.`,
+          dryRun,
+          summary,
+        },
+      };
+    }
+
+    if (summary.conflicts.length > 0) {
+      return {
+        status: 409,
+        jsonBody: {
+          error: 'link_conflict',
+          message: 'Conflicting Salesforce/QuickBooks linking data was found.',
+          dryRun,
+          summary,
+        },
+      };
+    }
+
+    const transactions = await loadSalesforceTransactions(
+      connection,
+      resolvedRecord.objectType,
+      salesforceId
+    );
+
+    for (const transaction of transactions) {
+      const transactionType = toTrimmed(transaction.Transaction_Type__c);
+      if (!transactionType || !(summary.transactionCounts.salesforce[transactionType] >= 0)) {
+        continue;
+      }
+
+      summary.transactionCounts.salesforce[transactionType] += 1;
+
+      const qboDocId = toTrimmed(transaction.QBO_Doc_Id__c);
+      const qboDocType = toTrimmed(transaction.QBO_Doc_Type__c) as QuickBooksDocType | null;
+
+      if (qboDocId && qboDocType) {
+        const qboDoc = await fetchQuickBooksDocument(qboDocType, qboDocId, dependencies.qboQuery);
+        if (!qboDoc) {
+          summary.conflicts.push({
+            code: 'linked_qbo_document_missing',
+            message: `QuickBooks document ${qboDocType}:${qboDocId} linked from Salesforce transaction ${transaction.Id} was not found.`,
+            salesforceTransactionId: transaction.Id,
+            qboDocId,
+          });
+          continue;
+        }
+
+        summary.transactionCounts.quickbooks[transactionType] += 1;
+
+        if (transaction.Posted_to_QBO__c !== true && transaction.Id) {
+          summary.plannedUpdates.push({
+            type: 'mark_salesforce_posted_to_qbo',
+            salesforceTransactionId: transaction.Id,
+            qboDocId,
+            qboDocType,
+            reason: 'linked_qbo_document_verified',
+          });
+        }
+
+        continue;
+      }
+
+      if (!transaction.Id) {
+        summary.manualReviewItems.push({
+          code: 'salesforce_transaction_missing_id',
+          message: 'Salesforce transaction record did not include an Id.',
+        });
+        continue;
+      }
+
+      if (transactionType === 'charge' && env.accounting.postingStrategy !== 'je-transfer') {
+        summary.manualReviewItems.push({
+          code: 'charge_sales_receipt_mapping_not_verified',
+          message:
+            `Salesforce transaction ${transaction.Id} is a charge, but the existing QuickBooks ` +
+            'sales-receipt flow depends on Stripe checkout metadata not stored on Transaction__c.',
+          salesforceTransactionId: transaction.Id,
+        });
+        continue;
+      }
+
+      summary.plannedCreates.push({
+        type: 'create_qbo_document',
+        salesforceTransactionId: transaction.Id,
+        transactionType,
+        reason: 'missing_qbo_doc_link',
+      });
+    }
+
+    const qboCustomerId = summary.resolvedQuickBooksCustomerId;
+    if (qboCustomerId) {
+      const salesReceipts = await fetchQuickBooksSalesReceiptsForCustomer(
+        qboCustomerId,
+        dependencies.qboQuery
+      );
+      const linkedQboIds = new Set(
+        transactions.map((transaction) => toTrimmed(transaction.QBO_Doc_Id__c)).filter(Boolean)
+      );
+
+      for (const receipt of salesReceipts) {
+        const receiptId = normalizeQboCustomerId(receipt.Id);
+        if (!receiptId || linkedQboIds.has(receiptId)) {
+          continue;
+        }
+
+        summary.manualReviewItems.push({
+          code: 'quickbooks_only_sales_receipt_unmapped',
+          message:
+            `QuickBooks SalesReceipt ${receiptId} is linked to customer ${qboCustomerId}, but no verified ` +
+            'codebase mapping exists to create Transaction__c records from QuickBooks-only documents.',
+          qboDocId: receiptId,
+        });
+      }
+    }
+
+    if (!dryRun) {
+      for (const action of summary.plannedBackfills) {
+        if (action.type === 'backfill_qbo_salesforce_id') {
+          await dependencies.updateQuickBooksCustomerSalesforceId(
+            action.qboCustomerId,
+            action.salesforceId
+          );
+          context.log('[salesforceRecordQboSync] Backfilled QuickBooks Salesforce ID', action);
+        }
+
+        if (action.type === 'backfill_salesforce_quickbooks_id') {
+          await updateSalesforceQuickBooksId(
+            connection,
+            action.objectType,
+            action.salesforceId,
+            action.qboCustomerId
+          );
+          context.log('[salesforceRecordQboSync] Backfilled Salesforce QuickBooks_ID__c', action);
+        }
+      }
+
+      for (const action of summary.plannedCreates) {
+        if (action.type !== 'create_qbo_document') {
+          continue;
+        }
+
+        const transaction = transactions.find(
+          (entry) => entry.Id === action.salesforceTransactionId
+        );
+        if (!transaction) {
+          continue;
+        }
+
+        const createdDoc = await executeTransactionCreate(transaction, dependencies);
+        await salesforceSvc.markPostedToQbo(action.salesforceTransactionId, {
+          id: createdDoc.qboId,
+          type: createdDoc.type,
+        });
+        context.log(
+          '[salesforceRecordQboSync] Created QuickBooks document from Salesforce transaction',
+          {
+            salesforceTransactionId: action.salesforceTransactionId,
+            qboDocId: createdDoc.qboId,
+            qboDocType: createdDoc.type,
+            transactionType: action.transactionType,
+          }
+        );
+      }
+
+      for (const action of summary.plannedUpdates) {
+        if (action.type !== 'mark_salesforce_posted_to_qbo') {
+          continue;
+        }
+
+        await salesforceSvc.markPostedToQbo(action.salesforceTransactionId, {
+          id: action.qboDocId,
+          type: action.qboDocType,
+        });
+        context.log(
+          '[salesforceRecordQboSync] Marked Salesforce transaction as posted to QBO',
+          action
+        );
+      }
+    }
+
+    return {
+      status: 200,
+      jsonBody: {
+        success: true,
+        dryRun,
+        summary,
+      },
+    };
+  } catch (error) {
+    logger.error('[salesforceRecordQboSync] Unhandled error', {
+      error: error instanceof Error ? error.message : String(error),
+      salesforceId,
+    });
+
+    return {
+      status: 500,
+      jsonBody: {
+        error: 'internal_error',
+        message: 'Failed to sync the Salesforce record with QuickBooks.',
+        details: error instanceof Error ? error.message : String(error),
+        dryRun,
+        summary,
+      },
+    };
+  }
+};
+
+export default salesforceRecordQboSync;
+
+(
+  salesforceRecordQboSync as typeof salesforceRecordQboSync & {
+    __internals?: {
+      setDependencies: (overrides?: Partial<Dependencies> | null) => void;
+      resetDependencies: () => void;
+    };
+  }
+).__internals = {
+  setDependencies(overrides: Partial<Dependencies> | null = null) {
+    dependencyOverrides = overrides;
+  },
+  resetDependencies() {
+    dependencyOverrides = null;
+  },
+};

--- a/src/handlers/stripeTrueUp.ts
+++ b/src/handlers/stripeTrueUp.ts
@@ -35,10 +35,7 @@ import {
 import { SalesforceService, buildSalesforceConfig } from '../services/salesforceService';
 import { mapStripeToTransaction, type TransactionUpsertDTO } from '../domain/transactions';
 import { ensureSalesforceIdOnCustomer } from '../stripe/utils';
-import {
-  loadConfig,
-  normalizeTransactionCategory,
-} from '../config/contactMatching';
+import { loadConfig, normalizeTransactionCategory } from '../config/contactMatching';
 import {
   fetchStripeChargesSince,
   fetchStripeRefundsSince,
@@ -62,7 +59,7 @@ interface FetchServices {
 
 let qboFunctions: any = null;
 const createNoopAccountingServices = (): AccountingServices => ({
-  postChargeToQbo: async () => ({ success: false, error: 'QBO service not available' } as any),
+  postChargeToQbo: async () => ({ success: false, error: 'QBO service not available' }) as any,
   postRefundToQbo: async () => ({ success: false, error: 'QBO service not available' }),
   postPayoutToQbo: async () => ({ success: false, error: 'QBO service not available' }),
 });
@@ -374,19 +371,18 @@ const extractSalesforceIdFromMetadata = (
   );
 };
 
-const isLikelySalesforceContactId = (value: string): boolean => {
-  const trimmed = value.trim();
-  return /^003[a-zA-Z0-9]{12}(?:[a-zA-Z0-9]{3})?$/.test(trimmed);
-};
+type ResolvedSalesforceReference =
+  | { target: 'Contact'; id: string }
+  | { target: 'Account'; id: string };
 
-const resolveContactIdFromMetadata = async (
+const resolveSalesforceReferenceFromMetadata = async (
   salesforce: SalesforceSvc,
   metadata: Record<string, unknown> | null | undefined,
   contextLog: (...args: unknown[]) => void,
   sourceId: string,
   sourceType: 'charge' | 'refund',
   metadataSource: 'customer' | 'charge' = 'charge'
-): Promise<string | null> => {
+): Promise<ResolvedSalesforceReference | null> => {
   const metadataSalesforceId = extractSalesforceIdFromMetadata(metadata);
   if (!metadataSalesforceId) {
     return null;
@@ -402,8 +398,9 @@ const resolveContactIdFromMetadata = async (
           metadataSource,
           contactId: validatedContactId,
           metadataSalesforceId,
+          matchPath: 'stripe_salesforce_id',
         });
-        return validatedContactId;
+        return { target: 'Contact', id: validatedContactId };
       }
 
       contextLog('[StripeTrueUp] Stripe metadata salesforce_id did not match a Contact', {
@@ -412,26 +409,40 @@ const resolveContactIdFromMetadata = async (
         metadataSource,
         metadataSalesforceId,
       });
-      return null;
     }
 
-    if (isLikelySalesforceContactId(metadataSalesforceId)) {
-      contextLog('[StripeTrueUp] Using Stripe metadata salesforce_id as contact fallback', {
+    if (typeof salesforce.findAccountIdById === 'function') {
+      const validatedAccountId = await salesforce.findAccountIdById(metadataSalesforceId);
+      if (validatedAccountId) {
+        contextLog('[StripeTrueUp] Resolved account from Stripe metadata salesforce_id', {
+          sourceType,
+          sourceId,
+          metadataSource,
+          accountId: validatedAccountId,
+          metadataSalesforceId,
+          matchPath: 'stripe_salesforce_id',
+        });
+        return { target: 'Account', id: validatedAccountId };
+      }
+
+      contextLog('[StripeTrueUp] Stripe metadata salesforce_id did not match an Account', {
         sourceType,
         sourceId,
         metadataSource,
         metadataSalesforceId,
       });
-      return metadataSalesforceId;
     }
   } catch (error) {
-    contextLog('[StripeTrueUp] Failed to resolve contact from Stripe metadata salesforce_id', {
-      sourceType,
-      sourceId,
-      metadataSource,
-      metadataSalesforceId,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    contextLog(
+      '[StripeTrueUp] Failed to resolve Salesforce record from Stripe metadata salesforce_id',
+      {
+        sourceType,
+        sourceId,
+        metadataSource,
+        metadataSalesforceId,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
   }
 
   return null;
@@ -800,7 +811,9 @@ const selectBestMatchingContact = (
     return null;
   }
 
-  const stripeIdMatch = candidates.find((contact) => contact.Stripe_Customer_Id__c === stripeCustomer.id);
+  const stripeIdMatch = candidates.find(
+    (contact) => contact.Stripe_Customer_Id__c === stripeCustomer.id
+  );
   if (stripeIdMatch) {
     return stripeIdMatch;
   }
@@ -808,9 +821,11 @@ const selectBestMatchingContact = (
   if (firstName && lastName) {
     const nameMatch = candidates.find((contact) => {
       const firstMatches =
-        typeof contact.FirstName === 'string' && contact.FirstName.toLowerCase() === firstName.toLowerCase();
+        typeof contact.FirstName === 'string' &&
+        contact.FirstName.toLowerCase() === firstName.toLowerCase();
       const lastMatches =
-        typeof contact.LastName === 'string' && contact.LastName.toLowerCase() === lastName.toLowerCase();
+        typeof contact.LastName === 'string' &&
+        contact.LastName.toLowerCase() === lastName.toLowerCase();
       return firstMatches && lastMatches;
     });
 
@@ -887,7 +902,10 @@ const findOrCreateContactInSalesforce = async (
   }
 
   const stripeCustomer = customer as Stripe.Customer;
-  const { customerName, firstName, lastName } = buildContactIdentity(stripeCustomer, transactionName);
+  const { customerName, firstName, lastName } = buildContactIdentity(
+    stripeCustomer,
+    transactionName
+  );
 
   contextLog('[StripeTrueUp] Starting contact find/create process', {
     customerId: stripeCustomer.id,
@@ -1182,8 +1200,7 @@ const processPayments = async (
 
         const customerMetadata =
           stripeCustomer && !stripeCustomer.deleted
-            ? (((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) ||
-              undefined)
+            ? ((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) || undefined
             : undefined;
         const customerMetadataSalesforceId = extractSalesforceIdFromMetadata(customerMetadata);
         const chargeMetadataSalesforceId = extractSalesforceIdFromMetadata(chargeObjectMetadata);
@@ -1216,8 +1233,9 @@ const processPayments = async (
         });
 
         let contactId: string | null = null;
+        let accountId: string | null = null;
         if (metadataSalesforceId && selectedMetadata) {
-          contactId = await resolveContactIdFromMetadata(
+          const resolvedReference = await resolveSalesforceReferenceFromMetadata(
             salesforce,
             selectedMetadata,
             (...args: unknown[]) => context.log(...args),
@@ -1226,9 +1244,15 @@ const processPayments = async (
             metadataSource || 'charge'
           );
 
-          if (!contactId) {
+          if (resolvedReference?.target === 'Contact') {
+            contactId = resolvedReference.id;
+          } else if (resolvedReference?.target === 'Account') {
+            accountId = resolvedReference.id;
+          }
+
+          if (!resolvedReference) {
             context.log(
-              '[StripeTrueUp] Stripe metadata salesforce_id provided but could not be resolved; skipping contact creation fallback',
+              '[StripeTrueUp] Stripe metadata salesforce_id provided but could not be resolved; skipping Salesforce creation fallback',
               {
                 chargeId: charge.id,
                 metadataSalesforceId,
@@ -1237,6 +1261,11 @@ const processPayments = async (
             );
           }
         } else if (stripeCustomer && !stripeCustomer.deleted) {
+          context.log('[StripeTrueUp] Falling back to existing Stripe customer matching flow', {
+            chargeId: charge.id,
+            customerId: stripeCustomer.id,
+            matchPath: 'fallback_match',
+          });
           context.log('[StripeTrueUp] Calling upsertCustomerByStripeId', {
             customerId: stripeCustomer.id,
             customerName: (stripeCustomer as Stripe.Customer).name,
@@ -1257,6 +1286,10 @@ const processPayments = async (
             context.log('[StripeTrueUp] Contact upsert completed', {
               contactId,
               success: !!contactId,
+              matchPath:
+                customerUpsertResult?.created === true
+                  ? 'created_new_salesforce_record'
+                  : 'fallback_match',
             });
 
             if (stripeCustomer && contactId) {
@@ -1371,12 +1404,22 @@ const processPayments = async (
 
         if (contactId) {
           transaction.contact__c = contactId;
+          delete transaction.account__c;
           context.log('[StripeTrueUp] Associated contact with transaction', {
             contactId,
             transactionStripeChargeId: transaction.stripe_charge_id__c,
+            matchPath: 'stripe_salesforce_id',
+          });
+        } else if (accountId) {
+          transaction.account__c = accountId;
+          delete transaction.contact__c;
+          context.log('[StripeTrueUp] Associated account with transaction', {
+            accountId,
+            transactionStripeChargeId: transaction.stripe_charge_id__c,
+            matchPath: 'stripe_salesforce_id',
           });
         } else {
-          context.log('[StripeTrueUp] No contact ID to associate with transaction', {
+          context.log('[StripeTrueUp] No Salesforce record ID to associate with transaction', {
             transactionStripeChargeId: transaction.stripe_charge_id__c,
           });
         }
@@ -1384,7 +1427,9 @@ const processPayments = async (
         context.log('[StripeTrueUp] Upserting transaction to Salesforce', {
           chargeId: charge.id,
           contactId: transaction.contact__c,
+          accountId: transaction.account__c,
           hasContact: !!transaction.contact__c,
+          hasAccount: !!transaction.account__c,
         });
 
         if (
@@ -1590,6 +1635,7 @@ const processRefunds = async (
           (chargeFragment?.metadata as Record<string, unknown> | undefined) || undefined;
 
         let contactId: string | null = null;
+        let accountId: string | null = null;
         let stripeCustomer: Stripe.Customer | Stripe.DeletedCustomer | null = null;
 
         if (chargeFragment && chargeFragment.customer) {
@@ -1602,8 +1648,7 @@ const processRefunds = async (
 
         const customerMetadata =
           stripeCustomer && !stripeCustomer.deleted
-            ? (((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) ||
-              undefined)
+            ? ((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) || undefined
             : undefined;
         const customerMetadataSalesforceId = extractSalesforceIdFromMetadata(customerMetadata);
         const chargeMetadataSalesforceId = extractSalesforceIdFromMetadata(chargeMetadata);
@@ -1626,7 +1671,7 @@ const processRefunds = async (
               : null;
 
         if (metadataSalesforceId && selectedMetadata) {
-          contactId = await resolveContactIdFromMetadata(
+          const resolvedReference = await resolveSalesforceReferenceFromMetadata(
             salesforce,
             selectedMetadata,
             (...args: unknown[]) => context.log(...args),
@@ -1635,9 +1680,15 @@ const processRefunds = async (
             metadataSource || 'charge'
           );
 
-          if (!contactId) {
+          if (resolvedReference?.target === 'Contact') {
+            contactId = resolvedReference.id;
+          } else if (resolvedReference?.target === 'Account') {
+            accountId = resolvedReference.id;
+          }
+
+          if (!resolvedReference) {
             context.log(
-              '[StripeTrueUp] Stripe metadata salesforce_id provided on refund charge but could not be resolved; skipping contact creation fallback',
+              '[StripeTrueUp] Stripe metadata salesforce_id provided on refund charge but could not be resolved; skipping Salesforce creation fallback',
               {
                 refundId: refund.id,
                 chargeId: chargeFragment?.id ?? chargeId,
@@ -1647,6 +1698,15 @@ const processRefunds = async (
             );
           }
         } else if (chargeFragment && chargeFragment.customer) {
+          context.log(
+            '[StripeTrueUp] Falling back to existing Stripe customer matching flow for refund',
+            {
+              refundId: refund.id,
+              chargeId: chargeFragment.id,
+              customerId: extractStripeId(chargeFragment.customer),
+              matchPath: 'fallback_match',
+            }
+          );
           context.log('[StripeTrueUp] Processing refund customer', {
             refundId: refund.id,
             chargeId: chargeFragment.id,
@@ -1686,6 +1746,10 @@ const processRefunds = async (
                 refundId: refund.id,
                 contactId,
                 success: !!contactId,
+                matchPath:
+                  customerUpsertResult?.created === true
+                    ? 'created_new_salesforce_record'
+                    : 'fallback_match',
               });
             } catch (error) {
               context.log('[StripeTrueUp] Failed to upsert contact for refund', {
@@ -1750,20 +1814,35 @@ const processRefunds = async (
 
         if (contactId) {
           transaction.contact__c = contactId;
+          delete transaction.account__c;
           context.log('[StripeTrueUp] Associated contact with refund transaction', {
             contactId,
             refundId: refund.id,
+            matchPath: 'stripe_salesforce_id',
+          });
+        } else if (accountId) {
+          transaction.account__c = accountId;
+          delete transaction.contact__c;
+          context.log('[StripeTrueUp] Associated account with refund transaction', {
+            accountId,
+            refundId: refund.id,
+            matchPath: 'stripe_salesforce_id',
           });
         } else {
-          context.log('[StripeTrueUp] No contact ID to associate with refund transaction', {
-            refundId: refund.id,
-          });
+          context.log(
+            '[StripeTrueUp] No Salesforce record ID to associate with refund transaction',
+            {
+              refundId: refund.id,
+            }
+          );
         }
 
         context.log('[StripeTrueUp] Upserting refund transaction to Salesforce', {
           refundId: refund.id,
           contactId: transaction.contact__c,
+          accountId: transaction.account__c,
           hasContact: !!transaction.contact__c,
+          hasAccount: !!transaction.account__c,
         });
 
         if (
@@ -2100,9 +2179,7 @@ const validateEnvironment = (
       errors.push('QBO_CLIENT_SECRET is not configured (QuickBooks sync will fail)');
     }
     if (!process.env.QBO_REALM_ID && !process.env.QBO_COMPANY_ID) {
-      errors.push(
-        'QBO_REALM_ID or QBO_COMPANY_ID is not configured (QuickBooks sync will fail)'
-      );
+      errors.push('QBO_REALM_ID or QBO_COMPANY_ID is not configured (QuickBooks sync will fail)');
     }
   }
 
@@ -2122,7 +2199,10 @@ const stripeTrueUp = async (req: HttpRequest, context: InvocationContext): Promi
 
     const bypassQboDefault = parseBoolean(process.env.STRIPE_TRUE_UP_BYPASS_QBO, false);
     const bypassQboParam =
-      query.bypassQbo ?? query.skipQbo ?? getHeader(req, 'x-bypass-qbo') ?? getHeader(req, 'x-skip-qbo');
+      query.bypassQbo ??
+      query.skipQbo ??
+      getHeader(req, 'x-bypass-qbo') ??
+      getHeader(req, 'x-skip-qbo');
     const bypassQbo = parseBoolean(bypassQboParam, bypassQboDefault);
 
     const defaultLiveMode = process.env.STRIPE_TRUE_UP_MODE === 'live';
@@ -2223,27 +2303,9 @@ const stripeTrueUp = async (req: HttpRequest, context: InvocationContext): Promi
         limit
       );
     } else if (type === 'refunds') {
-      summary = await processRefunds(
-        context,
-        stripe,
-        from,
-        to,
-        dryRun,
-        resubmit,
-        bypassQbo,
-        limit
-      );
+      summary = await processRefunds(context, stripe, from, to, dryRun, resubmit, bypassQbo, limit);
     } else {
-      summary = await processPayouts(
-        context,
-        stripe,
-        from,
-        to,
-        dryRun,
-        resubmit,
-        bypassQbo,
-        limit
-      );
+      summary = await processPayouts(context, stripe, from, to, dryRun, resubmit, bypassQbo, limit);
     }
 
     if (!dryRun) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,12 @@ const stripeTrueUp = stripeTrueUpModule.default || stripeTrueUpModule;
 const manualQboSyncModule = require('./handlers/manualQboSync');
 const manualQboSync = manualQboSyncModule.default || manualQboSyncModule;
 const salesforcePaymentsSyncModule = require('./handlers/salesforcePaymentsSync');
-const salesforcePaymentsSync =
-  salesforcePaymentsSyncModule.default || salesforcePaymentsSyncModule;
+const salesforcePaymentsSync = salesforcePaymentsSyncModule.default || salesforcePaymentsSyncModule;
 const qboCustomersSyncModule = require('./handlers/qboCustomersSync');
 const qboCustomersSync = qboCustomersSyncModule.default || qboCustomersSyncModule;
+const salesforceRecordQboSyncModule = require('./handlers/salesforceRecordQboSync');
+const salesforceRecordQboSync =
+  salesforceRecordQboSyncModule.default || salesforceRecordQboSyncModule;
 const eventRegistrationModule = require('./handlers/eventRegistration');
 const eventRegistration = eventRegistrationModule.default || eventRegistrationModule;
 const eventCheckInModule = require('./handlers/eventCheckIn');
@@ -190,6 +192,13 @@ const QboCustomersSyncQuerySchema = z
     maxRuntimeMs: PositiveIntLikeSchema.optional(),
     includeInactive: BoolLikeQuerySchema.optional(),
     exampleLimit: PositiveIntLikeSchema.optional(),
+  })
+  .passthrough();
+
+const SalesforceRecordQboSyncQuerySchema = z
+  .object({
+    salesforceId: z.string(),
+    dryRun: BoolLikeQuerySchema.optional(),
   })
   .passthrough();
 
@@ -365,6 +374,32 @@ registerFunction('qboCustomersSync', 'QBO customer sync to Salesforce contacts',
   },
 });
 
+registerFunction(
+  'salesforceRecordQboSync',
+  'Sync QuickBooks and Salesforce for one Salesforce record',
+  {
+    handler: salesforceRecordQboSync,
+    description:
+      'Resolves a Salesforce Contact or Account by Id, links the matching QuickBooks customer, and syncs supported transactions with a dry-run summary.',
+    tags: ['QBO', 'Salesforce'],
+    security: functionAuthSecurity,
+    methods: ['GET', 'POST'],
+    authLevel: 'function',
+    azureFunctionRoutePrefix: 'api',
+    route: 'qbo/salesforce-record-sync',
+    request: {
+      query: SalesforceRecordQboSyncQuerySchema,
+    },
+    responses: {
+      200: { description: 'Single-record sync completed' },
+      400: { description: 'Invalid sync request' },
+      404: { description: 'Salesforce record not found' },
+      409: { description: 'Link conflict or unresolved customer' },
+      500: { description: 'Single-record sync failed' },
+    },
+  }
+);
+
 // define simple event registration schema
 const EventRegistrationSchema = z.object({
   eventId: z.string(),
@@ -412,12 +447,9 @@ const EventCheckInSchema = z
     email: z.string().email().optional(),
     eventId: z.string().optional(),
   })
-  .refine(
-    (data) => !!data.registrationId || (data.email && data.eventId),
-    {
-      message: 'registrationId or both email and eventId must be supplied',
-    }
-  );
+  .refine((data) => !!data.registrationId || (data.email && data.eventId), {
+    message: 'registrationId or both email and eventId must be supplied',
+  });
 
 registerFunction('eventCheckIn', 'Check in an event attendee', {
   handler: eventCheckIn,
@@ -532,6 +564,7 @@ export {
   manualQboSync,
   salesforcePaymentsSync,
   qboCustomersSync,
+  salesforceRecordQboSync,
   eventRegistration,
   eventCheckIn,
 };

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -77,6 +77,13 @@ interface QuickBooksEmailAddress {
   Address: string;
 }
 
+interface QuickBooksCustomField {
+  DefinitionId?: string;
+  Name?: string;
+  Type?: string;
+  StringValue?: string;
+}
+
 interface QuickBooksPhysicalAddress {
   Line1?: string;
   Line2?: string;
@@ -117,7 +124,7 @@ export interface QuickBooksSalesReceipt {
   ShipAddr?: QuickBooksPhysicalAddress;
   ClassRef?: QuickBooksReference;
   Line: QuickBooksSalesReceiptLine[];
-} 
+}
 
 interface QuickBooksJournalEntryLineDetail {
   PostingType: 'Debit' | 'Credit';
@@ -189,7 +196,7 @@ interface BuildSalesReceiptInput {
   lineAmountCents?: number;
   lineServiceDate?: string;
   lineClassRef?: string;
-} 
+}
 
 type StripeCustomerContext = {
   charge?: Stripe.Charge | null;
@@ -857,14 +864,16 @@ const findCustomerByDisplayName = async (
     customers.find((customer) => {
       const name = customer?.DisplayName;
       return (
-        typeof name === 'string' && name.trim().toLowerCase() === normalizedDisplayName.toLowerCase()
+        typeof name === 'string' &&
+        name.trim().toLowerCase() === normalizedDisplayName.toLowerCase()
       );
     }) ?? null;
 
   const reference = extractReferenceFromRecord(existing, 'Id', 'DisplayName');
   if (reference) {
     const recordEmail = (existing?.PrimaryEmailAddr as { Address?: string } | undefined)?.Address;
-    const normalizedEmail = typeof recordEmail === 'string' ? recordEmail.trim().toLowerCase() : null;
+    const normalizedEmail =
+      typeof recordEmail === 'string' ? recordEmail.trim().toLowerCase() : null;
     cacheCustomerReference(reference, normalizedEmail, normalizedDisplayName);
   }
 
@@ -963,6 +972,45 @@ const updateQuickBooksCustomer = async (
   }
 
   return updated;
+};
+
+export const updateQuickBooksCustomerSalesforceId = async (
+  id: string,
+  salesforceId: string,
+  options?: PostOptions
+): Promise<Record<string, unknown>> => {
+  const trimmedSalesforceId = salesforceId.trim();
+  if (!trimmedSalesforceId) {
+    throw new Error('Salesforce ID is required to update the QuickBooks customer.');
+  }
+
+  const context = await createRequestContext(options);
+  const customer = await fetchQuickBooksCustomer(id, context);
+  const customFields = Array.isArray(customer.CustomField)
+    ? (customer.CustomField as QuickBooksCustomField[])
+    : [];
+  const salesforceField = customFields.find((field) => field?.Name === 'Salesforce ID');
+
+  if (!salesforceField?.DefinitionId) {
+    throw new Error(
+      'QuickBooks customer does not expose a "Salesforce ID" custom field definition.'
+    );
+  }
+
+  return updateQuickBooksCustomer(
+    id,
+    {
+      CustomField: [
+        {
+          DefinitionId: salesforceField.DefinitionId,
+          Name: salesforceField.Name,
+          Type: salesforceField.Type,
+          StringValue: trimmedSalesforceId,
+        } satisfies QuickBooksCustomField,
+      ],
+    },
+    context
+  );
 };
 
 const ensureSalesReceiptCustomer = async (
@@ -1757,12 +1805,15 @@ export const buildSalesReceipt = ({
   if (stripeFee > 0) {
     const stripeFeeAmount = -centsToDollars(stripeFee);
     if (!Number.isFinite(stripeFeeAmount)) {
-      throw new Error(`Invalid stripe fee amount calculated for sales receipt: ${stripeFeeAmount} (from ${stripeFee} cents)`);
+      throw new Error(
+        `Invalid stripe fee amount calculated for sales receipt: ${stripeFeeAmount} (from ${stripeFee} cents)`
+      );
     }
 
-    const feeItemAccountRef = typeof feesAccountName === 'string' && feesAccountName.trim()
-      ? createAccountRef(feesAccountName)
-      : undefined;
+    const feeItemAccountRef =
+      typeof feesAccountName === 'string' && feesAccountName.trim()
+        ? createAccountRef(feesAccountName)
+        : undefined;
 
     lines.push({
       Amount: stripeFeeAmount,
@@ -1841,10 +1892,12 @@ export const buildSalesReceipt = ({
       receipt.CustomerMemo = { value: truncated };
     }
   } catch (e) {
-    logger.debug('Failed to build CustomerMemo for sales receipt', { error: e instanceof Error ? e.message : String(e) });
+    logger.debug('Failed to build CustomerMemo for sales receipt', {
+      error: e instanceof Error ? e.message : String(e),
+    });
   }
 
-  return receipt; 
+  return receipt;
 };
 
 const createJournalEntryLine = (
@@ -2122,7 +2175,9 @@ const findAccountRecordByName = async (
     accounts.find((account) => {
       const name = account?.Name;
       return typeof name === 'string' && name.trim().toLowerCase() === normalizedName.toLowerCase();
-    }) ?? accounts[0] ?? null
+    }) ??
+    accounts[0] ??
+    null
   );
 };
 
@@ -3079,9 +3134,13 @@ export const postChargeToQbo = async ({
       feesAccountName: feesAccountRef.value,
       stripeFeeAmountCents: feeAmount,
       stripeChargeId: stripe?.charge?.id ?? null,
-      stripeInvoiceId: typeof stripe?.charge?.invoice === 'string' ? (stripe as any).charge.invoice : null,
+      stripeInvoiceId:
+        typeof stripe?.charge?.invoice === 'string' ? (stripe as any).charge.invoice : null,
       stripeInvoiceNumber: (stripe?.checkoutSession as any)?.invoice?.number ?? null,
-      stripeSubscriptionId: (stripe?.checkoutSession as any)?.subscription ?? (stripe?.paymentIntent as any)?.subscription ?? null,
+      stripeSubscriptionId:
+        (stripe?.checkoutSession as any)?.subscription ??
+        (stripe?.paymentIntent as any)?.subscription ??
+        null,
       customer: receiptCustomer,
       description,
       coverFeesAmountCents,
@@ -3396,7 +3455,11 @@ export const ensureAccount = async (
       const accountId = account.Id;
       const accountResolvedName = account.Name;
       const resolvedId =
-        typeof accountId === 'number' ? accountId.toString() : typeof accountId === 'string' ? accountId.trim() : null;
+        typeof accountId === 'number'
+          ? accountId.toString()
+          : typeof accountId === 'string'
+            ? accountId.trim()
+            : null;
       const resolvedName =
         typeof accountResolvedName === 'string' && accountResolvedName.trim()
           ? accountResolvedName.trim()
@@ -3450,7 +3513,11 @@ export const ensureAccount = async (
 
       // If account type is specified and doesn't match, throw an error
       // Special case: allow "Undeposited Funds" to be used even if type doesn't match
-      if (accountType && account.AccountType !== accountType && accountName !== 'Undeposited Funds') {
+      if (
+        accountType &&
+        account.AccountType !== accountType &&
+        accountName !== 'Undeposited Funds'
+      ) {
         const errorMsg = `Account "${accountName}" exists but is type "${account.AccountType}". For this operation, a "${accountType}" account is required. Please use a different account or create a new one with the correct type.`;
         logger.error('Account type mismatch - operation cannot proceed', {
           accountName,
@@ -3615,8 +3682,13 @@ export const queryReference = async (
     const entity =
       entities.find((candidate) => {
         const candidateName = candidate?.Name;
-        return typeof candidateName === 'string' && candidateName.trim().toLowerCase() === name.trim().toLowerCase();
-      }) ?? entities[0] ?? null;
+        return (
+          typeof candidateName === 'string' &&
+          candidateName.trim().toLowerCase() === name.trim().toLowerCase()
+        );
+      }) ??
+      entities[0] ??
+      null;
 
     const reference = extractReferenceFromRecord(entity, 'Id', 'Name');
     if (reference) {
@@ -3743,5 +3815,6 @@ export default {
   ensureAccount,
   queryReference,
   ensureReference,
+  updateQuickBooksCustomerSalesforceId,
   query,
 };

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -113,6 +113,7 @@ export interface SalesforceSvc {
   ) => Promise<{ id: string; contactId: string | null } | null>;
   upsertCustomerByStripeId: (dto: CustomerUpsertDTO) => Promise<UpsertResult>;
   findContactIdById?: (contactId: string) => Promise<string | null>;
+  findAccountIdById?: (accountId: string) => Promise<string | null>;
 }
 
 type TransactionRecordInput = Partial<TransactionUpsertDTO> & {
@@ -341,9 +342,12 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     const received = dto.received_at__c;
 
     if (
-      typeof contact === 'string' && contact.trim().length > 0 &&
-      typeof amount === 'number' && !Number.isNaN(amount) &&
-      typeof received === 'string' && received.trim().length > 0
+      typeof contact === 'string' &&
+      contact.trim().length > 0 &&
+      typeof amount === 'number' &&
+      !Number.isNaN(amount) &&
+      typeof received === 'string' &&
+      received.trim().length > 0
     ) {
       const escapedContact = escapeForSoqlLiteral(contact.trim());
       const escapedReceived = escapeForSoqlLiteral(received.trim());
@@ -800,6 +804,20 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     return record?.Id ?? null;
   };
 
+  const findAccountIdById = async (accountId: string): Promise<string | null> => {
+    const normalizedId = ensureNonEmpty(accountId, 'Account ID');
+    const escapedId = escapeForSoqlLiteral(normalizedId);
+    const result = await connection.query<{ Id?: string }>(
+      `SELECT Id FROM Account WHERE Id = '${escapedId}' LIMIT 1`
+    );
+    const records = toLookupRecords(result);
+    const record = records.find(
+      (candidate): candidate is { Id: string } =>
+        typeof candidate.Id === 'string' && candidate.Id.trim().length > 0
+    );
+    return record?.Id ?? null;
+  };
+
   return {
     upsertTransactionByExternalId,
     linkPayoutOnTransactions,
@@ -808,6 +826,7 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     findTransactionRecordByExternalId,
     upsertCustomerByStripeId,
     findContactIdById,
+    findAccountIdById,
   };
 };
 


### PR DESCRIPTION
### Motivation
- Provide a single-record sync endpoint to reconcile a Salesforce Contact/Account with QuickBooks and create or verify linked QuickBooks documents. 
- Ensure robust linking between systems by reading/writing the QuickBooks "Salesforce ID" custom field and backfilling `QuickBooks_ID__c` on Salesforce when appropriate. 
- Improve Stripe true‑up behavior to prefer Salesforce Account matches (not just Contact) from Stripe metadata and to surface match paths for auditing.

### Description
- Add a new handler `salesforceRecordQboSync` that resolves a Salesforce `Contact` or `Account`, locates the matching QuickBooks customer, produces a dry‑run summary of planned creates/updates/backfills/conflicts, and can execute backfills and create QuickBooks documents when not dry‑running. 
- Extend `qboCustomersSync` to read `CustomField` entries (the QuickBooks `Salesforce ID`) and to prefer/validate that field when matching to Salesforce, including logic to backfill the QuickBooks `Salesforce ID` and to call a new `updateQuickBooksCustomerSalesforceId` dependency when creating or backfilling links. 
- Export and implement `updateQuickBooksCustomerSalesforceId` in `qboSvc`, add `updateQboCustomerSalesforceId` dependency wiring to `qboCustomersSync` and the new `salesforceRecordQboSync`, and add a suite of matching/fallback behaviors (Contact vs Account, QuickBooks_ID__c lookups, fallback name/email matches). 
- Enhance `stripeTrueUp` and `salesforceSvc` to support resolving `Account` IDs from metadata and to associate transactions with `account__c` when appropriate, including adding `findAccountIdById` to the Salesforce service. 
- Register the new `salesforceRecordQboSync` function in `src/index.ts` and add comprehensive tests under `__tests__` for the modified flows (`qboCustomersSync`, new `salesforceRecordQboSync`, and `stripeTrueUp`).

### Testing
- Ran unit tests with Vitest including `__tests__/qboCustomersSync.test.ts` (updated), `__tests__/salesforceRecordQboSync.test.ts` (new), and `__tests__/stripeTrueUp.test.ts` (updated). All test cases executed and passed. 
- Exercised dry‑run and non‑dry run flows for backfilling IDs, create/update branching, and conflict detection via the new `salesforceRecordQboSync` test cases which validated planned actions and side effects. 
- Verified existing Stripe true‑up scenarios still run and now also cover account metadata resolution and the associated assertions in the updated `stripeTrueUp` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04c20e79c8324bfbe48a0d60de603)