### PR TITLE
Add salesforceRecordQboSync handler and improve QBO↔Salesforce linking and Stripe metadata resolution

### DIFF
--- a/__tests__/qboCustomersSync.test.ts
+++ b/__tests__/qboCustomersSync.test.ts
@@ -8,8 +8,8 @@ describe('qboCustomersSync', () => {
   let handler: any;
   let internals: any;
 
-  beforeEach(() => {
-    const loaded = require('../dist/handlers/qboCustomersSync');
+  beforeEach(async () => {
+    const loaded = await import(`../src/handlers/qboCustomersSync?t=${Date.now()}`);
     handler = loaded.default || loaded;
     internals = handler.__internals;
   });
@@ -53,10 +53,7 @@ describe('qboCustomersSync', () => {
       .mockResolvedValueOnce([]);
 
     const query = vi.fn(async (soql: string) => {
-      if (
-        soql.includes("Email = 'ada@example.com'") ||
-        soql.includes("FirstName = 'Ada'")
-      ) {
+      if (soql.includes("Email = 'ada@example.com'") || soql.includes("FirstName = 'Ada'")) {
         return {
           records: [
             {
@@ -101,9 +98,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn();
     const update = vi.fn();
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -138,6 +137,7 @@ describe('qboCustomersSync', () => {
 
     expect(create).not.toHaveBeenCalled();
     expect(update).not.toHaveBeenCalled();
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
   });
 
   it('does not overwrite existing Salesforce fields unless overwrite=true', async () => {
@@ -164,10 +164,7 @@ describe('qboCustomersSync', () => {
       .mockResolvedValueOnce([]);
 
     const query = vi.fn(async (soql: string) => {
-      if (
-        soql.includes("Email = 'ada@example.com'") ||
-        soql.includes("FirstName = 'Ada'")
-      ) {
+      if (soql.includes("Email = 'ada@example.com'") || soql.includes("FirstName = 'Ada'")) {
         return {
           records: [
             {
@@ -195,9 +192,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn().mockResolvedValue({ success: true, id: '003_new' });
     const update = vi.fn().mockResolvedValue({ success: true, id: '003_existing' });
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -242,6 +241,7 @@ describe('qboCustomersSync', () => {
         Phone: '555-0002',
       })
     );
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('c2', '003_new');
   });
 
   it('supports create-only mode to skip updates on existing contacts', async () => {
@@ -289,9 +289,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn().mockResolvedValue({ success: true, id: '003_new' });
     const update = vi.fn().mockResolvedValue({ success: true, id: '003_existing' });
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -318,6 +320,7 @@ describe('qboCustomersSync', () => {
 
     expect(create).toHaveBeenCalledTimes(1);
     expect(update).not.toHaveBeenCalled();
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('c2', '003_new');
   });
 
   it('uses Contact record type id when available during create', async () => {
@@ -348,9 +351,11 @@ describe('qboCustomersSync', () => {
 
     const create = vi.fn().mockResolvedValue({ success: true, id: '003_new_rt' });
     const update = vi.fn();
+    const updateQboCustomerSalesforceId = vi.fn();
 
     internals.setDependencies({
       fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
       getSalesforceConnection: vi.fn().mockResolvedValue({
         query,
         sobject: vi.fn().mockReturnValue({ create, update }),
@@ -376,5 +381,314 @@ describe('qboCustomersSync', () => {
         Email: 'record.type@example.com',
       })
     );
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('c100', '003_new_rt');
+  });
+
+  it('prefers a populated QuickBooks Salesforce ID by validating Contact before Account', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cSFContact',
+          DisplayName: 'QBO Contact',
+          CustomField: [
+            { DefinitionId: '1', Name: 'Salesforce ID', StringValue: '003ValidContact' },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003ValidContact'")) {
+        return { records: [{ Id: '003ValidContact', FirstName: 'Valid', LastName: 'Contact' }] };
+      }
+
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+    const update = vi.fn().mockResolvedValue({ success: true, id: '003FromQboField' });
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'GET', url: 'http://localhost', query: { dryRun: 'true' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.counts.alreadyExistInSalesforce).toBe(1);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cSFContact',
+      salesforceId: '003ValidContact',
+      salesforceObject: 'Contact',
+      matchPath: 'quickbooks_salesforce_id',
+    });
+    expect(query).not.toHaveBeenCalledWith(expect.stringContaining('FROM Account WHERE Id ='));
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
+  });
+
+  it('falls back to Account when QuickBooks Salesforce ID is not a Contact', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cSFAccount',
+          DisplayName: 'QBO Account',
+          CustomField: [
+            { DefinitionId: '1', Name: 'Salesforce ID', StringValue: '001ValidAccount' },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '001ValidAccount'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Account WHERE Id = '001ValidAccount'")) {
+        return { records: [{ Id: '001ValidAccount', Name: 'Acme Org' }] };
+      }
+
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+    const update = vi.fn().mockResolvedValue({ success: true, id: '003FromQboField' });
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'GET', url: 'http://localhost', query: { dryRun: 'true' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cSFAccount',
+      salesforceId: '001ValidAccount',
+      salesforceObject: 'Account',
+      matchPath: 'quickbooks_salesforce_id',
+    });
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
+  });
+
+  it('backfills QuickBooks Salesforce ID when Contact is matched by QuickBooks_ID__c', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cQboLookup',
+          DisplayName: 'Lookup Contact',
+          GivenName: 'Lookup',
+          FamilyName: 'Contact',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Contact WHERE QuickBooks_ID__c = 'cQboLookup'")) {
+        return {
+          records: [
+            {
+              Id: '003FromQboField',
+              FirstName: 'Lookup',
+              LastName: 'Contact',
+              QuickBooks_ID__c: 'cQboLookup',
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Account WHERE QuickBooks_ID__c = 'cQboLookup'")) {
+        return { records: [] };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({
+          create: vi.fn(),
+          update: vi.fn().mockResolvedValue({ success: true, id: '003FromQboField' }),
+        }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'POST', url: 'http://localhost', query: { dryRun: 'false' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cQboLookup',
+      salesforceId: '003FromQboField',
+      salesforceObject: 'Contact',
+      matchPath: 'salesforce_quickbooks_id',
+    });
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('cQboLookup', '003FromQboField');
+  });
+
+  it('checks Account by QuickBooks_ID__c only after no Contact match exists', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([{ Id: 'cAccountLookup', DisplayName: 'Lookup Account' }])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Contact WHERE QuickBooks_ID__c = 'cAccountLookup'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Account WHERE QuickBooks_ID__c = 'cAccountLookup'")) {
+        return {
+          records: [
+            { Id: '001FromQboField', Name: 'Matched Account', QuickBooks_ID__c: 'cAccountLookup' },
+          ],
+        };
+      }
+
+      throw new Error(`Unexpected query: ${soql}`);
+    });
+
+    const updateQboCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update: vi.fn() }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'POST', url: 'http://localhost', query: { dryRun: 'false' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cAccountLookup',
+      salesforceId: '001FromQboField',
+      salesforceObject: 'Account',
+      matchPath: 'salesforce_quickbooks_id',
+    });
+    expect(updateQboCustomerSalesforceId).toHaveBeenCalledWith('cAccountLookup', '001FromQboField');
+  });
+
+  it('uses fallback matching when no deterministic ID match exists', async () => {
+    const fetchQboCustomersPage = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          Id: 'cFallback',
+          DisplayName: 'Fallback Match',
+          GivenName: 'Fallback',
+          FamilyName: 'Match',
+          PrimaryEmailAddr: { Address: 'fallback@example.com' },
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    const query = vi.fn(async (soql: string) => {
+      if (soql.includes('FROM RecordType')) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Contact WHERE QuickBooks_ID__c = 'cFallback'")) {
+        throw new Error("No such column 'QuickBooks_ID__c' on entity 'Contact'");
+      }
+
+      if (soql.includes("FROM Account WHERE QuickBooks_ID__c = 'cFallback'")) {
+        throw new Error("No such column 'QuickBooks_ID__c' on entity 'Account'");
+      }
+
+      if (soql.includes("Email = 'fallback@example.com'")) {
+        return {
+          records: [
+            {
+              Id: '003Fallback',
+              FirstName: 'Fallback',
+              LastName: 'Match',
+              Email: 'fallback@example.com',
+              Description: 'Legacy record',
+            },
+          ],
+        };
+      }
+
+      return { records: [] };
+    });
+
+    const update = vi.fn().mockResolvedValue({ success: true, id: '003Fallback' });
+    const updateQboCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      fetchQboCustomersPage,
+      updateQboCustomerSalesforceId,
+      getSalesforceConnection: vi.fn().mockResolvedValue({
+        query,
+        sobject: vi.fn().mockReturnValue({ create: vi.fn(), update }),
+      }),
+    });
+
+    const { context } = createContext();
+    const result = await handler(
+      { method: 'POST', url: 'http://localhost', query: { dryRun: 'false' } },
+      context
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.jsonBody.samples.matched[0]).toMatchObject({
+      qboCustomerId: 'cFallback',
+      salesforceId: '003Fallback',
+      matchPath: 'fallback_match',
+      salesforceObject: 'Contact',
+    });
+    expect(update).toHaveBeenCalled();
+    expect(updateQboCustomerSalesforceId).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/qboSvc.test.ts
+++ b/__tests__/qboSvc.test.ts
@@ -270,103 +270,107 @@ afterEach(() => {
 });
 
 describe('postChargeToQbo', () => {
-  it('posts sales receipt to clearing account and creates fee journal entry when using sales receipt strategy', async () => {
-    baseEnv.accounting.postingStrategy = 'sales-receipt';
-    const { fetcher, requests } = createFetchMock(
-      { QueryResponse: {} }, // Customer email lookup
-      { QueryResponse: {} }, // Customer name lookup
-      { Customer: { Id: 'cust-1', DisplayName: 'Donor Example' } }, // Customer create
-      {
-        QueryResponse: {
-          Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
-        },
-      }, // Item lookup
-      { QueryResponse: {} }, // Duplicate check for sales receipt
-      { SalesReceipt: { Id: 'sr-1' } }, // Sales receipt create
-      { QueryResponse: {} }, // Duplicate check for fee journal entry
-      { JournalEntry: { Id: 'fee-je-1' } } // Fee journal entry create
-    );
-    const { postChargeToQbo } = await importQboSvc();
+  it(
+    'posts sales receipt to clearing account and creates fee journal entry when using sales receipt strategy',
+    async () => {
+      baseEnv.accounting.postingStrategy = 'sales-receipt';
+      const { fetcher, requests } = createFetchMock(
+        { QueryResponse: {} }, // Customer email lookup
+        { QueryResponse: {} }, // Customer name lookup
+        { Customer: { Id: 'cust-1', DisplayName: 'Donor Example' } }, // Customer create
+        {
+          QueryResponse: {
+            Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
+          },
+        }, // Item lookup
+        { QueryResponse: {} }, // Duplicate check for sales receipt
+        { SalesReceipt: { Id: 'sr-1' } }, // Sales receipt create
+        { QueryResponse: {} }, // Duplicate check for fee journal entry
+        { JournalEntry: { Id: 'fee-je-1' } } // Fee journal entry create
+      );
+      const { postChargeToQbo } = await importQboSvc();
 
-    const result = await postChargeToQbo({
-      gross: 10_000,
-      fee: 325,
-      memo: 'Charge memo',
-      date: new Date('2024-03-01'),
-      stripe: buildStripeContext(),
-      options: { fetcher, accessToken: 'token' },
-    });
+      const result = await postChargeToQbo({
+        gross: 10_000,
+        fee: 325,
+        memo: 'Charge memo',
+        date: new Date('2024-03-01'),
+        stripe: buildStripeContext(),
+        options: { fetcher, accessToken: 'token' },
+      });
 
-    expect(result).toEqual({ qboId: 'sr-1', type: 'sales-receipt' });
-    expect(fetcher).toHaveBeenCalledTimes(6); // Customer lookups (2), customer create, item lookup, duplicate check, sales receipt
+      expect(result).toEqual({ qboId: 'sr-1', type: 'sales-receipt' });
+      expect(fetcher).toHaveBeenCalledTimes(6); // Customer lookups (2), customer create, item lookup, duplicate check, sales receipt
 
-    const [emailLookupRequest, nameLookupRequest, customerCreateRequest] = requests;
-    expect(emailLookupRequest.url).toContain('/query?query=');
-    expect(nameLookupRequest.url).toContain('/query?query=');
-    expect(customerCreateRequest.url).toContain('/customer');
-    expect(customerCreateRequest.init?.method).toBe('POST');
+      const [emailLookupRequest, nameLookupRequest, customerCreateRequest] = requests;
+      expect(emailLookupRequest.url).toContain('/query?query=');
+      expect(nameLookupRequest.url).toContain('/query?query=');
+      expect(customerCreateRequest.url).toContain('/customer');
+      expect(customerCreateRequest.init?.method).toBe('POST');
 
-    const itemLookupRequest = requests.find(
-      (request) =>
-        request !== emailLookupRequest &&
-        request !== nameLookupRequest &&
-        request !== customerCreateRequest &&
-        request.url.includes('/query?query=')
-    );
-    expect(itemLookupRequest?.url).toContain('/query?query=');
-    expect(itemLookupRequest?.init?.method ?? 'GET').toBe('GET');
+      const itemLookupRequest = requests.find(
+        (request) =>
+          request !== emailLookupRequest &&
+          request !== nameLookupRequest &&
+          request !== customerCreateRequest &&
+          request.url.includes('/query?query=')
+      );
+      expect(itemLookupRequest?.url).toContain('/query?query=');
+      expect(itemLookupRequest?.init?.method ?? 'GET').toBe('GET');
 
-    const customerBody = JSON.parse((customerCreateRequest.init?.body ?? '{}') as string);
-    expect(customerBody).toMatchObject({
-      DisplayName: 'Donor Example',
-      PrimaryEmailAddr: { Address: 'donor@example.com' },
-      BillAddr: expect.objectContaining({ Line1: '123 Donation Ave', City: 'Givington' }),
-    });
+      const customerBody = JSON.parse((customerCreateRequest.init?.body ?? '{}') as string);
+      expect(customerBody).toMatchObject({
+        DisplayName: 'Donor Example',
+        PrimaryEmailAddr: { Address: 'donor@example.com' },
+        BillAddr: expect.objectContaining({ Line1: '123 Donation Ave', City: 'Givington' }),
+      });
 
-    const salesReceiptRequest = requests.find((request) => request.url.includes('salesreceipt'));
-    const feeJournalRequest = requests.find((request) => request.url.includes('journalentry'));
+      const salesReceiptRequest = requests.find((request) => request.url.includes('salesreceipt'));
+      const feeJournalRequest = requests.find((request) => request.url.includes('journalentry'));
 
-    expect(salesReceiptRequest).toBeDefined();
-    expect(feeJournalRequest).toBeUndefined();
+      expect(salesReceiptRequest).toBeDefined();
+      expect(feeJournalRequest).toBeUndefined();
 
-    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
-    expect(salesReceiptBody.DepositToAccountRef).toMatchObject({
-      value: 'QBO_ACCOUNT_STRIPE_CLEARING',
-      name: 'Stripe Clearing',
-    });
-    expect(salesReceiptBody.Line[0].SalesItemLineDetail.ItemRef).toMatchObject({
-      value: 'QBO_ITEM_REVENUE',
-      name: 'Stripe Sales Item',
-    });
-    expect(salesReceiptBody.CustomerRef).toMatchObject({
-      value: 'cust-1',
-      name: 'Donor Example',
-    });
-    expect(salesReceiptBody.BillEmail).toEqual({ Address: 'donor@example.com' });
-    expect(salesReceiptBody.BillAddr).toMatchObject({
-      Line1: '123 Donation Ave',
-      City: 'Givington',
-      PostalCode: '94105',
-    });
-    expect(salesReceiptBody.ShipAddr).toMatchObject({
-      Line1: '123 Donation Ave',
-      City: 'Givington',
-    });
+      const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
+      expect(salesReceiptBody.DepositToAccountRef).toMatchObject({
+        value: 'QBO_ACCOUNT_STRIPE_CLEARING',
+        name: 'Stripe Clearing',
+      });
+      expect(salesReceiptBody.Line[0].SalesItemLineDetail.ItemRef).toMatchObject({
+        value: 'QBO_ITEM_REVENUE',
+        name: 'Stripe Sales Item',
+      });
+      expect(salesReceiptBody.CustomerRef).toMatchObject({
+        value: 'cust-1',
+        name: 'Donor Example',
+      });
+      expect(salesReceiptBody.BillEmail).toEqual({ Address: 'donor@example.com' });
+      expect(salesReceiptBody.BillAddr).toMatchObject({
+        Line1: '123 Donation Ave',
+        City: 'Givington',
+        PostalCode: '94105',
+      });
+      expect(salesReceiptBody.ShipAddr).toMatchObject({
+        Line1: '123 Donation Ave',
+        City: 'Givington',
+      });
 
-    // Fee should be present as the second line on the sales receipt with the fees account referenced
-    expect(salesReceiptBody.Line[1].Amount).toBe(-3.25);
-    expect(salesReceiptBody.Line[1].SalesItemLineDetail.ItemAccountRef).toMatchObject({
-      value: 'QBO_ACCOUNT_FEES',
-      name: 'Stripe Fees',
-    });
+      // Fee should be present as the second line on the sales receipt with the fees account referenced
+      expect(salesReceiptBody.Line[1].Amount).toBe(-3.25);
+      expect(salesReceiptBody.Line[1].SalesItemLineDetail.ItemAccountRef).toMatchObject({
+        value: 'QBO_ACCOUNT_FEES',
+        name: 'Stripe Fees',
+      });
 
-    // Verify CustomerMemo (statement message) includes amounts and stripe charge id
-    expect(salesReceiptBody.CustomerMemo).toBeDefined();
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Original Charge Amount: 100.00');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Fees: 3.25');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Net Amount Received: 96.75');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Charge ID: ch_test');
-  }, { timeout: 20000 });
+      // Verify CustomerMemo (statement message) includes amounts and stripe charge id
+      expect(salesReceiptBody.CustomerMemo).toBeDefined();
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Original Charge Amount: 100.00');
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Fees: 3.25');
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Net Amount Received: 96.75');
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Charge ID: ch_test');
+    },
+    { timeout: 20000 }
+  );
 
   it('prefers donor name over checkout category when deriving QuickBooks payee/customer', async () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
@@ -564,7 +568,10 @@ describe('postChargeToQbo', () => {
       fee: 0,
       memo: 'Charge memo',
       date: new Date('2024-03-01'),
-      stripe: buildStripeContext({}, { metadata: { cover_fees: 'true', cover_fees_amount: String(coverAmount) } }),
+      stripe: buildStripeContext(
+        {},
+        { metadata: { cover_fees: 'true', cover_fees_amount: String(coverAmount) } }
+      ),
       options: { fetcher, accessToken: 'token' },
     });
 
@@ -576,7 +583,7 @@ describe('postChargeToQbo', () => {
     // only the main line should exist; cover fees should have been ignored
     expect(salesReceiptBody.Line.length).toBe(1);
     expect(salesReceiptBody.Line[0].Amount).toBe(50.0);
-    expect(salesReceiptBody.Line.find((l:any) => l.Amount < 0)).toBeUndefined();
+    expect(salesReceiptBody.Line.find((l: any) => l.Amount < 0)).toBeUndefined();
   });
 
   it('reads cover fees from paymentIntent/charge metadata when session unavailable', async () => {
@@ -664,48 +671,59 @@ describe('postChargeToQbo', () => {
     });
   });
 
-  it('includes invoice and subscription details in CustomerMemo when available', async () => {
-    baseEnv.accounting.postingStrategy = 'sales-receipt';
-    const { fetcher, requests } = createFetchMock(
-      { QueryResponse: {} }, // Customer email lookup
-      { QueryResponse: {} }, // Customer name lookup
-      { Customer: { Id: 'cust-2', DisplayName: 'Donor Example' } }, // Customer create
-      {
-        QueryResponse: {
-          Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
-        },
-      }, // Item lookup
-      { QueryResponse: {} }, // Duplicate check for sales receipt
-      { SalesReceipt: { Id: 'sr-2' } }, // Sales receipt create
-      { QueryResponse: {} }, // Duplicate check for fee journal entry (unused)
-      { JournalEntry: { Id: 'fee-je-2' } } // Fee journal entry create (unused)
-    );
-    const { postChargeToQbo } = await importQboSvc();
+  it(
+    'includes invoice and subscription details in CustomerMemo when available',
+    async () => {
+      baseEnv.accounting.postingStrategy = 'sales-receipt';
+      const { fetcher, requests } = createFetchMock(
+        { QueryResponse: {} }, // Customer email lookup
+        { QueryResponse: {} }, // Customer name lookup
+        { Customer: { Id: 'cust-2', DisplayName: 'Donor Example' } }, // Customer create
+        {
+          QueryResponse: {
+            Item: { Id: 'QBO_ITEM_REVENUE', Name: 'Stripe Sales Item' },
+          },
+        }, // Item lookup
+        { QueryResponse: {} }, // Duplicate check for sales receipt
+        { SalesReceipt: { Id: 'sr-2' } }, // Sales receipt create
+        { QueryResponse: {} }, // Duplicate check for fee journal entry (unused)
+        { JournalEntry: { Id: 'fee-je-2' } } // Fee journal entry create (unused)
+      );
+      const { postChargeToQbo } = await importQboSvc();
 
-    const result = await postChargeToQbo({
-      gross: 2_585, // $25.85
-      fee: 87, // $0.87
-      memo: 'Charge memo',
-      date: new Date('2024-03-01'),
-      stripe: buildStripeContext({ invoice: 'in_1SlBuhBJf9YYVP9mdUcoaPkw' }, { invoice: { number: '3OKSMZT1-0002' }, subscription: 'sub_1SZx7kBJf9YYVP9mCJ3HXqDy' }),
-      options: { fetcher, accessToken: 'token' },
-    });
+      const result = await postChargeToQbo({
+        gross: 2_585, // $25.85
+        fee: 87, // $0.87
+        memo: 'Charge memo',
+        date: new Date('2024-03-01'),
+        stripe: buildStripeContext(
+          { invoice: 'in_1SlBuhBJf9YYVP9mdUcoaPkw' },
+          { invoice: { number: '3OKSMZT1-0002' }, subscription: 'sub_1SZx7kBJf9YYVP9mCJ3HXqDy' }
+        ),
+        options: { fetcher, accessToken: 'token' },
+      });
 
-    expect(result).toEqual({ qboId: 'sr-2', type: 'sales-receipt' });
+      expect(result).toEqual({ qboId: 'sr-2', type: 'sales-receipt' });
 
-    const salesReceiptRequest = requests.find((request) => request.url.includes('salesreceipt'));
-    expect(salesReceiptRequest).toBeDefined();
-    const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
+      const salesReceiptRequest = requests.find((request) => request.url.includes('salesreceipt'));
+      expect(salesReceiptRequest).toBeDefined();
+      const salesReceiptBody = JSON.parse((salesReceiptRequest?.init?.body ?? '{}') as string);
 
-    expect(salesReceiptBody.CustomerMemo).toBeDefined();
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Original Charge Amount: 25.85');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Fees: 0.87');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Net Amount Received: 24.98');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Charge ID: ch_test');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Invoice ID: in_1SlBuhBJf9YYVP9mdUcoaPkw');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Invoice Number: 3OKSMZT1-0002');
-    expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Subscription ID: sub_1SZx7kBJf9YYVP9mCJ3HXqDy');
-  }, { timeout: 20000 });
+      expect(salesReceiptBody.CustomerMemo).toBeDefined();
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Original Charge Amount: 25.85');
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Fees: 0.87');
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Net Amount Received: 24.98');
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Charge ID: ch_test');
+      expect(salesReceiptBody.CustomerMemo.value).toContain(
+        'Stripe Invoice ID: in_1SlBuhBJf9YYVP9mdUcoaPkw'
+      );
+      expect(salesReceiptBody.CustomerMemo.value).toContain('Stripe Invoice Number: 3OKSMZT1-0002');
+      expect(salesReceiptBody.CustomerMemo.value).toContain(
+        'Stripe Subscription ID: sub_1SZx7kBJf9YYVP9mCJ3HXqDy'
+      );
+    },
+    { timeout: 20000 }
+  );
 
   it('uses default sales item when checkout metadata is missing', async () => {
     baseEnv.accounting.postingStrategy = 'sales-receipt';
@@ -822,6 +840,45 @@ describe('postChargeToQbo', () => {
       name: 'Donor Example',
     });
     expect(salesReceiptBody.BillEmail).toEqual({ Address: 'donor@example.com' });
+  });
+
+  it('requests enhanced custom fields when loading a QuickBooks customer by id', async () => {
+    const { fetcher, requests } = createFetchMock({
+      Customer: {
+        Id: '1205',
+        DisplayName: 'Debug Customer',
+        SyncToken: '1',
+        CustomField: [
+          {
+            DefinitionId: '1000000002',
+            Name: 'Salesforce ID',
+            Type: 'StringType',
+            StringValue: '003UQ00000gBJolYAG',
+          },
+        ],
+      },
+    });
+
+    const { getQuickBooksCustomerById } = await importQboSvc();
+    const result = await getQuickBooksCustomerById('1205', {
+      fetcher,
+      accessToken: 'token',
+    });
+
+    expect(result).toMatchObject({
+      Id: '1205',
+      CustomField: [
+        expect.objectContaining({
+          Name: 'Salesforce ID',
+          StringValue: '003UQ00000gBJolYAG',
+        }),
+      ],
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].url).toContain('/customer/1205?');
+    expect(requests[0].url).toContain('minorversion=75');
+    expect(requests[0].url).toContain('include=enhancedAllCustomFields');
   });
 
   it.skip('prefers the Stripe customer name over billing details when refreshing QuickBooks customers', async () => {

--- a/__tests__/salesforceCrm.test.js
+++ b/__tests__/salesforceCrm.test.js
@@ -80,6 +80,10 @@ describe('SalesforceCrmService (JS)', () => {
       'Id'
     );
     expect(result).toEqual({ success: true, id: 'match_id' });
+    expect(conn.query).toHaveBeenCalledWith(
+      expect.stringContaining('Received_At__c = 2025-03-03T00:00:00Z')
+    );
+    expect(conn.query).not.toHaveBeenCalledWith(expect.stringContaining("Received_At__c = '"));
   });
 
   it('does not override when content match is ambiguous', async () => {
@@ -110,6 +114,34 @@ describe('SalesforceCrmService (JS)', () => {
     const result = await service.upsertTransactionsRecord(transactionData, 'Stripe_Payment_Intent_Id__c');
 
     expect(upsertMock).toHaveBeenCalledWith(expect.any(Object), 'Stripe_Payment_Intent_Id__c');
+    expect(result).toEqual({ success: true, id: 'new' });
+  });
+
+  it('skips content match lookup when Received_At__c is not a valid datetime', async () => {
+    const conn = makeMockConnection();
+
+    const transactionData = {
+      Status__c: 'paid',
+      Amount_Gross__c: 41.57,
+      Contact__c: '003abc',
+      Received_At__c: 'definitely-not-a-datetime',
+      Stripe_Payment_Intent_Id__c: 'pi_invalid_date',
+    };
+
+    const upsertMock = vi.fn().mockResolvedValue({ success: true, id: 'new' });
+    conn.sobject.mockReturnValue({ upsert: upsertMock });
+
+    const service = new SalesforceCrmService({});
+    service.conn = conn;
+    service.authenticate = async () => conn;
+
+    const result = await service.upsertTransactionsRecord(transactionData, 'Stripe_Payment_Intent_Id__c');
+
+    expect(conn.query).not.toHaveBeenCalledWith(expect.stringContaining('Received_At__c ='));
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ Received_At__c: 'definitely-not-a-datetime' }),
+      'Stripe_Payment_Intent_Id__c'
+    );
     expect(result).toEqual({ success: true, id: 'new' });
   });
 

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -386,6 +386,151 @@ describe('salesforceRecordQboSync', () => {
     ]);
   });
 
+  it('resolves an Account using a child Contact QuickBooks_ID__c when the account itself has no QuickBooks lookup field', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '001ACCOUNTVIAQBOLOOKUP'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Account WHERE Id = '001ACCOUNTVIAQBOLOOKUP'")) {
+        return { records: [{ Id: '001ACCOUNTVIAQBOLOOKUP', Name: 'Account Via QBO Lookup' }] };
+      }
+
+      if (soql.includes("FROM Contact WHERE AccountId = '001ACCOUNTVIAQBOLOOKUP'")) {
+        return {
+          records: [{ Id: '003CONTACTWITHQBO', QuickBooks_ID__c: '410' }],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Account__c = '001ACCOUNTVIAQBOLOOKUP'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '410'")) {
+        return [{ Id: '410', DisplayName: 'Account Via QBO Lookup' }];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '410'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '410',
+        DisplayName: 'Account Via QBO Lookup',
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=001ACCOUNTVIAQBOLOOKUP&dryRun=true',
+          query: new URLSearchParams({
+            salesforceId: '001ACCOUNTVIAQBOLOOKUP',
+            dryRun: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Account');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('410');
+  });
+
+  it('resolves a Contact using the parent Account QuickBooks_ID__c when the contact itself has no QuickBooks lookup field', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003CONTACTVIAQBOLOOKUP'")) {
+        return {
+          records: [
+            {
+              Id: '003CONTACTVIAQBOLOOKUP',
+              FirstName: 'Lookup',
+              LastName: 'Contact',
+              AccountId: '001ACCOUNTWITHQBO',
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Account WHERE Id = '001ACCOUNTWITHQBO'")) {
+        return {
+          records: [{ Id: '001ACCOUNTWITHQBO', Name: 'Account With QBO', QuickBooks_ID__c: '411' }],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003CONTACTVIAQBOLOOKUP'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '411'")) {
+        return [{ Id: '411', DisplayName: 'Contact Via Account QBO Lookup' }];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '411'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '411',
+        DisplayName: 'Contact Via Account QBO Lookup',
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003CONTACTVIAQBOLOOKUP&dryRun=true',
+          query: new URLSearchParams({
+            salesforceId: '003CONTACTVIAQBOLOOKUP',
+            dryRun: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Contact');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('411');
+  });
+
   it('backfills QuickBooks Salesforce ID when the linked customer is missing it', async () => {
     const connection = createConnection(async (soql: string) => {
       if (soql.includes("FROM Contact WHERE Id = '003BACKFILL'")) {

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -564,6 +564,14 @@ describe('salesforceRecordQboSync', () => {
         return { records: [] };
       }
 
+      if (soql.includes("FROM Campaign WHERE Class__c = 'UNRESTRICTED FUNDS:General'")) {
+        return { records: [{ Id: '701CLASSMATCH' }] };
+      }
+
+      if (soql.includes("FROM Campaign WHERE Name = 'General Giving'")) {
+        return { records: [{ Id: '701GENERAL' }] };
+      }
+
       return { records: [] };
     });
 
@@ -580,6 +588,7 @@ describe('salesforceRecordQboSync', () => {
             TxnDate: '2026-03-22',
             TotalAmt: 125,
             PrivateNote: 'Imported from QBO',
+            ClassRef: { name: 'UNRESTRICTED FUNDS:General' },
           },
         ];
       }
@@ -646,13 +655,254 @@ describe('salesforceRecordQboSync', () => {
         amount_fee__c: 0,
         amount_net__c: 125,
         currency_iso_code__c: 'USD',
+        campaign__c: '701CLASSMATCH',
         qbo_doc_type__c: 'sales-receipt',
         qbo_doc_id__c: '7301',
         posted_to_qbo__c: true,
       }),
       'qbo_doc_id__c'
     );
+    expect(upsertTransactionByExternalId.mock.calls[0][0]).not.toHaveProperty('Name');
     expect(body.summary.manualReviewItems).toEqual([]);
+  });
+
+  it('defaults imported QBO sales receipts to the General Giving campaign when class matching is unknown', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003GENERAL'")) {
+        return {
+          records: [
+            { Id: '003GENERAL', FirstName: 'General', LastName: 'Giving', QuickBooks_ID__c: '518' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003GENERAL'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Campaign WHERE Class__c = 'UNKNOWN:Class'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Campaign WHERE Name = 'General Giving'")) {
+        return { records: [{ Id: '701GENERAL' }] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '518'")) {
+        return [{ Id: '518', DisplayName: 'General Giving Contact' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '518'")) {
+        return [
+          {
+            Id: '7303',
+            DocNumber: '7303',
+            TxnDate: '2026-03-24',
+            TotalAmt: 65,
+            PrivateNote: 'Imported from QBO',
+            ClassRef: { name: 'UNKNOWN:Class' },
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const upsertTransactionByExternalId = vi
+      .fn()
+      .mockResolvedValue({ success: true, id: 'a01GeneralCampaign' });
+    const getQuickBooksCustomerById = vi.fn(async () => ({
+      Id: '518',
+      DisplayName: 'General Giving Contact',
+      CurrencyRef: { value: 'USD' },
+      CustomField: [{ Name: 'Salesforce ID', StringValue: '003GENERAL' }],
+    }));
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () =>
+        ({ markPostedToQbo: vi.fn(), upsertTransactionByExternalId }) as any,
+      qboQuery,
+      getQuickBooksCustomerById,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003GENERAL&dryRun=false&importQboReceipts=true',
+          query: new URLSearchParams({
+            salesforceId: '003GENERAL',
+            dryRun: 'false',
+            importQboReceipts: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(upsertTransactionByExternalId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        qbo_doc_id__c: '7303',
+        campaign__c: '701GENERAL',
+      }),
+      'qbo_doc_id__c'
+    );
+    expect(body.summary.manualReviewItems).toEqual([]);
+  });
+
+  it('defaults imported QBO sales receipts to General Giving campaign and skips duplicate transaction imports', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003DUPLICATE'")) {
+        return {
+          records: [
+            {
+              Id: '003DUPLICATE',
+              FirstName: 'Duplicate',
+              LastName: 'Check',
+              QuickBooks_ID__c: '517',
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003DUPLICATE'")) {
+        return {
+          records: [
+            {
+              Id: 'a01Existing',
+              Transaction_Type__c: 'charge',
+              Amount_Gross__c: 125,
+              Received_At__c: '2026-03-22T00:00:00.000Z',
+              QBO_Doc_Id__c: null,
+              QBO_Doc_Type__c: null,
+              Posted_to_QBO__c: false,
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Campaign WHERE Class__c = 'UNKNOWN:Class'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Campaign WHERE Name = 'General Giving'")) {
+        return { records: [{ Id: '701GENERAL' }] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '517'")) {
+        return [
+          {
+            Id: '517',
+            DisplayName: 'QBO Duplicate Contact',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003DUPLICATE' }],
+          },
+        ];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '517'")) {
+        return [
+          {
+            Id: '7301',
+            DocNumber: '7301',
+            TxnDate: '2026-03-22',
+            TotalAmt: 125,
+            PrivateNote: 'Imported from QBO',
+            ClassRef: { name: 'UNKNOWN:Class' },
+          },
+          {
+            Id: '7302',
+            DocNumber: '7302',
+            TxnDate: '2026-03-23',
+            TotalAmt: 55,
+            PrivateNote: 'Imported from QBO 2',
+            ClassRef: { name: 'UNKNOWN:Class' },
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const getQuickBooksCustomerById = vi.fn(async () => ({
+      Id: '517',
+      DisplayName: 'QBO Duplicate Contact',
+      CurrencyRef: { value: 'USD' },
+      CustomField: [{ Name: 'Salesforce ID', StringValue: '003DUPLICATE' }],
+    }));
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () =>
+        ({ markPostedToQbo: vi.fn(), upsertTransactionByExternalId: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById,
+      updateQuickBooksCustomerSalesforceId: vi.fn(),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003DUPLICATE&dryRun=true&importQboReceipts=true',
+          query: new URLSearchParams({
+            salesforceId: '003DUPLICATE',
+            dryRun: 'true',
+            importQboReceipts: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.plannedCreates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'create_salesforce_transaction_from_qbo_sales_receipt',
+          qboDocId: '7302',
+        }),
+      ])
+    );
+    expect(body.summary.plannedCreates).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'create_salesforce_transaction_from_qbo_sales_receipt',
+          qboDocId: '7301',
+        }),
+      ])
+    );
+    expect(body.summary.plannedUpdates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'mark_salesforce_posted_to_qbo',
+          salesforceTransactionId: 'a01Existing',
+          qboDocId: '7301',
+          qboDocType: 'sales-receipt',
+        }),
+      ])
+    );
   });
 
   it('passes debug logging hooks into QuickBooks reads and updates when debug=true', async () => {

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -299,6 +299,102 @@ describe('salesforceRecordQboSync', () => {
     ]);
   });
 
+  it('resolves an Account when QuickBooks stores the Salesforce ID custom field in 15-character form', async () => {
+    const updateCalls: Array<{ objectName: string; payload: Record<string, unknown> }> = [];
+    const connection = createConnection(
+      async (soql: string) => {
+        if (soql.includes("FROM Contact WHERE Id = '001UQ00000haZGPYA2'")) {
+          return { records: [] };
+        }
+
+        if (soql.includes("FROM Account WHERE Id = '001UQ00000haZGPYA2'")) {
+          return {
+            records: [{ Id: '001UQ00000haZGPYA2', Name: 'TNND', QuickBooks_ID__c: null }],
+          };
+        }
+
+        if (soql.includes("FROM Contact WHERE AccountId = '001UQ00000haZGPYA2'")) {
+          return { records: [] };
+        }
+
+        if (soql.includes("FROM Transaction__c WHERE Account__c = '001UQ00000haZGPYA2'")) {
+          return { records: [] };
+        }
+
+        return { records: [] };
+      },
+      async (objectName: string, payload: Record<string, unknown>) => {
+        updateCalls.push({ objectName, payload });
+        return { success: true, id: String(payload.Id ?? 'updated') };
+      }
+    );
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [
+          {
+            Id: '613',
+            DisplayName: 'TNND',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '001UQ00000haZGP' }],
+          },
+        ];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '613'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '613',
+        DisplayName: 'TNND',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '001UQ00000haZGP' }],
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=001UQ00000haZGPYA2&dryRun=false',
+          query: new URLSearchParams({
+            salesforceId: '001UQ00000haZGPYA2',
+            dryRun: 'false',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Account');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('613');
+    expect(body.summary.linkingFields.quickbooksSalesforceFieldValue).toBe('001UQ00000haZGP');
+    expect(body.summary.plannedBackfills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'backfill_salesforce_quickbooks_id',
+          qboCustomerId: '613',
+          salesforceId: '001UQ00000haZGPYA2',
+        }),
+      ])
+    );
+    expect(updateCalls).toEqual([
+      {
+        objectName: 'Account',
+        payload: { Id: '001UQ00000haZGPYA2', QuickBooks_ID__c: '613' },
+      },
+    ]);
+  });
+
   it('resolves a Contact when the QuickBooks customer is linked to the parent Account Salesforce ID', async () => {
     const updateCalls: Array<{ objectName: string; payload: Record<string, unknown> }> = [];
     const connection = createConnection(

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -73,7 +73,7 @@ describe('salesforceRecordQboSync', () => {
         ];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -151,7 +151,7 @@ describe('salesforceRecordQboSync', () => {
     );
 
     const qboQuery = vi.fn(async (query: string) => {
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [
           {
             Id: '345',
@@ -243,7 +243,7 @@ describe('salesforceRecordQboSync', () => {
     );
 
     const qboQuery = vi.fn(async (query: string) => {
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [
           {
             Id: '346',
@@ -330,7 +330,7 @@ describe('salesforceRecordQboSync', () => {
     );
 
     const qboQuery = vi.fn(async (query: string) => {
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [
           {
             Id: '613',
@@ -419,7 +419,7 @@ describe('salesforceRecordQboSync', () => {
     });
 
     const qboQuery = vi.fn(async (query: string) => {
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [{ Id: '613', DisplayName: 'TNND' }];
       }
 
@@ -496,7 +496,7 @@ describe('salesforceRecordQboSync', () => {
     );
 
     const qboQuery = vi.fn(async (query: string) => {
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [
           {
             Id: '347',
@@ -580,7 +580,7 @@ describe('salesforceRecordQboSync', () => {
         return [{ Id: '410', DisplayName: 'Account Via QBO Lookup' }];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -655,7 +655,7 @@ describe('salesforceRecordQboSync', () => {
         return [{ Id: '411', DisplayName: 'Contact Via Account QBO Lookup' }];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -721,7 +721,7 @@ describe('salesforceRecordQboSync', () => {
     });
 
     const qboQuery = vi.fn(async (query: string) => {
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [{ Id: '412', DisplayName: 'Acme Foundation' }];
       }
 
@@ -794,7 +794,7 @@ describe('salesforceRecordQboSync', () => {
         ];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -891,7 +891,7 @@ describe('salesforceRecordQboSync', () => {
         ];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -985,7 +985,7 @@ describe('salesforceRecordQboSync', () => {
         ];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [
           {
             Id: '200',
@@ -1063,7 +1063,7 @@ describe('salesforceRecordQboSync', () => {
         return [];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -1153,7 +1153,7 @@ describe('salesforceRecordQboSync', () => {
         ];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -1269,7 +1269,7 @@ describe('salesforceRecordQboSync', () => {
         ];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -1396,7 +1396,7 @@ describe('salesforceRecordQboSync', () => {
         ];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 
@@ -1491,7 +1491,7 @@ describe('salesforceRecordQboSync', () => {
         return [];
       }
 
-      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+      if (query.includes('FROM Customer WHERE CustomField =')) {
         return [];
       }
 

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -395,6 +395,76 @@ describe('salesforceRecordQboSync', () => {
     ]);
   });
 
+  it('uses an authoritative QuickBooks customer read to match a paged customer by Salesforce ID', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '001UQ00000haZGPYA2'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Account WHERE Id = '001UQ00000haZGPYA2'")) {
+        return {
+          records: [{ Id: '001UQ00000haZGPYA2', Name: 'TNND', QuickBooks_ID__c: null }],
+        };
+      }
+
+      if (soql.includes("FROM Contact WHERE AccountId = '001UQ00000haZGPYA2'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Account__c = '001UQ00000haZGPYA2'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [{ Id: '613', DisplayName: 'TNND' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '613'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const getQuickBooksCustomerById = vi.fn(async () => ({
+      Id: '613',
+      DisplayName: 'TNND',
+      CustomField: [{ Name: 'Salesforce ID', StringValue: '001UQ00000haZGP' }],
+    }));
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=001UQ00000haZGPYA2&dryRun=true',
+          query: new URLSearchParams({
+            salesforceId: '001UQ00000haZGPYA2',
+            dryRun: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('613');
+    expect(body.summary.linkingFields.quickbooksSalesforceFieldValue).toBe('001UQ00000haZGP');
+    expect(getQuickBooksCustomerById).toHaveBeenCalledWith('613', undefined);
+  });
+
   it('resolves a Contact when the QuickBooks customer is linked to the parent Account Salesforce ID', async () => {
     const updateCalls: Array<{ objectName: string; payload: Record<string, unknown> }> = [];
     const connection = createConnection(

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -212,6 +212,180 @@ describe('salesforceRecordQboSync', () => {
     ]);
   });
 
+  it('resolves an Account when the QuickBooks customer is linked to a child Contact Salesforce ID', async () => {
+    const updateCalls: Array<{ objectName: string; payload: Record<string, unknown> }> = [];
+    const connection = createConnection(
+      async (soql: string) => {
+        if (soql.includes("FROM Contact WHERE Id = '001ACCOUNTVIACONTACT'")) {
+          return { records: [] };
+        }
+
+        if (soql.includes("FROM Account WHERE Id = '001ACCOUNTVIACONTACT'")) {
+          return {
+            records: [{ Id: '001ACCOUNTVIACONTACT', Name: 'Account Via Contact', QuickBooks_ID__c: null }],
+          };
+        }
+
+        if (soql.includes("FROM Contact WHERE AccountId = '001ACCOUNTVIACONTACT'")) {
+          return { records: [{ Id: '003CHILDCONTACT' }] };
+        }
+
+        if (soql.includes("FROM Transaction__c WHERE Account__c = '001ACCOUNTVIACONTACT'")) {
+          return { records: [] };
+        }
+
+        return { records: [] };
+      },
+      async (objectName: string, payload: Record<string, unknown>) => {
+        updateCalls.push({ objectName, payload });
+        return { success: true, id: String(payload.Id ?? 'updated') };
+      }
+    );
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [
+          {
+            Id: '346',
+            DisplayName: 'Account Via Contact',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003CHILDCONTACT' }],
+          },
+        ];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '346'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '346',
+        DisplayName: 'Account Via Contact',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '003CHILDCONTACT' }],
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=001ACCOUNTVIACONTACT&dryRun=false',
+          query: new URLSearchParams({
+            salesforceId: '001ACCOUNTVIACONTACT',
+            dryRun: 'false',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Account');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('346');
+    expect(body.summary.linkingFields.quickbooksSalesforceFieldValue).toBe('003CHILDCONTACT');
+    expect(updateCalls).toEqual([
+      {
+        objectName: 'Account',
+        payload: { Id: '001ACCOUNTVIACONTACT', QuickBooks_ID__c: '346' },
+      },
+    ]);
+  });
+
+  it('resolves a Contact when the QuickBooks customer is linked to the parent Account Salesforce ID', async () => {
+    const updateCalls: Array<{ objectName: string; payload: Record<string, unknown> }> = [];
+    const connection = createConnection(
+      async (soql: string) => {
+        if (soql.includes("FROM Contact WHERE Id = '003CONTACTVIAACCOUNT'")) {
+          return {
+            records: [
+              {
+                Id: '003CONTACTVIAACCOUNT',
+                FirstName: 'Contact',
+                LastName: 'Via Account',
+                AccountId: '001PARENTACCOUNT',
+                QuickBooks_ID__c: null,
+              },
+            ],
+          };
+        }
+
+        if (soql.includes("FROM Transaction__c WHERE Contact__c = '003CONTACTVIAACCOUNT'")) {
+          return { records: [] };
+        }
+
+        return { records: [] };
+      },
+      async (objectName: string, payload: Record<string, unknown>) => {
+        updateCalls.push({ objectName, payload });
+        return { success: true, id: String(payload.Id ?? 'updated') };
+      }
+    );
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [
+          {
+            Id: '347',
+            DisplayName: 'Contact Via Account',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '001PARENTACCOUNT' }],
+          },
+        ];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '347'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '347',
+        DisplayName: 'Contact Via Account',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '001PARENTACCOUNT' }],
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003CONTACTVIAACCOUNT&dryRun=false',
+          query: new URLSearchParams({
+            salesforceId: '003CONTACTVIAACCOUNT',
+            dryRun: 'false',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Contact');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('347');
+    expect(body.summary.linkingFields.quickbooksSalesforceFieldValue).toBe('001PARENTACCOUNT');
+    expect(updateCalls).toEqual([
+      {
+        objectName: 'Contact',
+        payload: { Id: '003CONTACTVIAACCOUNT', QuickBooks_ID__c: '347' },
+      },
+    ]);
+  });
+
   it('backfills QuickBooks Salesforce ID when the linked customer is missing it', async () => {
     const connection = createConnection(async (soql: string) => {
       if (soql.includes("FROM Contact WHERE Id = '003BACKFILL'")) {

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -1,0 +1,653 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { createContext, normalizeResponse } = require('./testUtils');
+
+describe('salesforceRecordQboSync', () => {
+  let handler: any;
+  let internals: any;
+
+  beforeEach(async () => {
+    const loaded = await import(`../src/handlers/salesforceRecordQboSync?t=${Date.now()}`);
+    handler = loaded.default || loaded;
+    internals = handler.__internals;
+  });
+
+  afterEach(() => {
+    internals?.resetDependencies?.();
+    vi.restoreAllMocks();
+  });
+
+  const createConnection = (
+    queryImpl: (soql: string) => Promise<{ records: any[] } | any[]>,
+    updateImpl: (
+      objectName: string,
+      payload: Record<string, unknown>
+    ) => Promise<any> = async () => ({
+      success: true,
+      id: 'updated',
+    })
+  ) => ({
+    query: vi.fn(queryImpl),
+    sobject: vi.fn((objectName: string) => ({
+      update: vi.fn((payload: Record<string, unknown>) => updateImpl(objectName, payload)),
+    })),
+  });
+
+  it('dry-runs a Contact record resolved via Salesforce QuickBooks_ID__c without duplicating synced transactions', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003CONTACT'")) {
+        return {
+          records: [
+            { Id: '003CONTACT', FirstName: 'Ada', LastName: 'Lovelace', QuickBooks_ID__c: '200' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003CONTACT'")) {
+        return {
+          records: [
+            {
+              Id: 'a01Txn',
+              Transaction_Type__c: 'refund',
+              QBO_Doc_Id__c: '900',
+              QBO_Doc_Type__c: 'journal-entry',
+              Posted_to_QBO__c: true,
+            },
+          ],
+        };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '200'")) {
+        return [
+          {
+            Id: '200',
+            DisplayName: 'Ada Lovelace',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONTACT' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM JournalEntry WHERE Id = '900'")) {
+        return [{ Id: '900', DocNumber: 'REF-1' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '200'")) {
+        return [];
+      }
+
+      throw new Error(`Unexpected QBO query: ${query}`);
+    });
+
+    const markPostedToQbo = vi.fn();
+    const postRefundToQbo = vi.fn();
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '200',
+        DisplayName: 'Ada Lovelace',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONTACT' }],
+      })),
+      postRefundToQbo,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003CONTACT&dryRun=true',
+          query: new URLSearchParams({ salesforceId: '003CONTACT', dryRun: 'true' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Contact');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('200');
+    expect(body.summary.transactionCounts.salesforce.refund).toBe(1);
+    expect(body.summary.transactionCounts.quickbooks.refund).toBe(1);
+    expect(body.summary.plannedCreates).toEqual([]);
+    expect(postRefundToQbo).not.toHaveBeenCalled();
+    expect(markPostedToQbo).not.toHaveBeenCalled();
+  });
+
+  it('resolves an Account via QuickBooks custom field and backfills Salesforce QuickBooks_ID__c', async () => {
+    const updateCalls: Array<{ objectName: string; payload: Record<string, unknown> }> = [];
+    const connection = createConnection(
+      async (soql: string) => {
+        if (soql.includes("FROM Contact WHERE Id = '001ACCOUNT'")) {
+          return { records: [] };
+        }
+
+        if (soql.includes("FROM Account WHERE Id = '001ACCOUNT'")) {
+          return { records: [{ Id: '001ACCOUNT', Name: 'Acme Org', QuickBooks_ID__c: null }] };
+        }
+
+        if (soql.includes("FROM Transaction__c WHERE Account__c = '001ACCOUNT'")) {
+          return { records: [] };
+        }
+
+        return { records: [] };
+      },
+      async (objectName: string, payload: Record<string, unknown>) => {
+        updateCalls.push({ objectName, payload });
+        return { success: true, id: String(payload.Id ?? 'updated') };
+      }
+    );
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [
+          {
+            Id: '345',
+            DisplayName: 'Acme Org',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '001ACCOUNT' }],
+          },
+        ];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '345'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '345',
+        DisplayName: 'Acme Org',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '001ACCOUNT' }],
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=001ACCOUNT&dryRun=false',
+          query: new URLSearchParams({ salesforceId: '001ACCOUNT', dryRun: 'false' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Account');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('345');
+    expect(body.summary.plannedBackfills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'backfill_salesforce_quickbooks_id',
+          qboCustomerId: '345',
+          salesforceId: '001ACCOUNT',
+        }),
+      ])
+    );
+    expect(updateCalls).toEqual([
+      {
+        objectName: 'Account',
+        payload: { Id: '001ACCOUNT', QuickBooks_ID__c: '345' },
+      },
+    ]);
+  });
+
+  it('backfills QuickBooks Salesforce ID when the linked customer is missing it', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003BACKFILL'")) {
+        return {
+          records: [
+            { Id: '003BACKFILL', FirstName: 'Grace', LastName: 'Hopper', QuickBooks_ID__c: '456' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003BACKFILL'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '456'")) {
+        return [
+          {
+            Id: '456',
+            DisplayName: 'Grace Hopper',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '456'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const updateQuickBooksCustomerSalesforceId = vi.fn();
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '456',
+        DisplayName: 'Grace Hopper',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '' }],
+      })),
+      updateQuickBooksCustomerSalesforceId,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003BACKFILL&dryRun=false',
+          query: new URLSearchParams({ salesforceId: '003BACKFILL', dryRun: 'false' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.plannedBackfills).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'backfill_qbo_salesforce_id',
+          qboCustomerId: '456',
+          salesforceId: '003BACKFILL',
+        }),
+      ])
+    );
+    expect(updateQuickBooksCustomerSalesforceId).toHaveBeenCalledWith('456', '003BACKFILL');
+  });
+
+  it('creates a QuickBooks document for a supported Salesforce-only refund transaction', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003REFUND'")) {
+        return {
+          records: [
+            { Id: '003REFUND', FirstName: 'Linus', LastName: 'Pauling', QuickBooks_ID__c: '777' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003REFUND'")) {
+        return {
+          records: [
+            {
+              Id: 'a01Refund',
+              Name: 'Refund Transaction',
+              Transaction_Type__c: 'refund',
+              Amount_Gross__c: -25,
+              Memo__c: 'Refund Transaction',
+              Received_At__c: '2025-01-01T00:00:00.000Z',
+              Posted_to_QBO__c: false,
+              QBO_Doc_Id__c: null,
+              QBO_Doc_Type__c: null,
+            },
+          ],
+        };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '777'")) {
+        return [
+          {
+            Id: '777',
+            DisplayName: 'Linus Pauling',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003REFUND' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '777'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const postRefundToQbo = vi.fn().mockResolvedValue({ qboId: 'JE-1', type: 'journal-entry' });
+    const markPostedToQbo = vi.fn();
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '777',
+        DisplayName: 'Linus Pauling',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '003REFUND' }],
+      })),
+      postRefundToQbo,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003REFUND&dryRun=false',
+          query: new URLSearchParams({ salesforceId: '003REFUND', dryRun: 'false' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.plannedCreates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'create_qbo_document',
+          salesforceTransactionId: 'a01Refund',
+          transactionType: 'refund',
+        }),
+      ])
+    );
+    expect(postRefundToQbo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        amount: 2500,
+        memo: 'Refund Transaction',
+      })
+    );
+    expect(markPostedToQbo).toHaveBeenCalledWith('a01Refund', {
+      id: 'JE-1',
+      type: 'journal-entry',
+    });
+  });
+
+  it('flags conflicts instead of guessing when Salesforce and QuickBooks links disagree', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003CONFLICT'")) {
+        return {
+          records: [
+            {
+              Id: '003CONFLICT',
+              FirstName: 'Katherine',
+              LastName: 'Johnson',
+              QuickBooks_ID__c: '100',
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003CONFLICT'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '100'")) {
+        return [
+          {
+            Id: '100',
+            DisplayName: 'Customer A',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONFLICT' }],
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [
+          {
+            Id: '200',
+            DisplayName: 'Customer B',
+            CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONFLICT' }],
+          },
+        ];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '100',
+        DisplayName: 'Customer A',
+        CustomField: [{ Name: 'Salesforce ID', StringValue: '003CONFLICT' }],
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003CONFLICT&dryRun=true',
+          query: new URLSearchParams({ salesforceId: '003CONFLICT', dryRun: 'true' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(409);
+    expect(body.summary.conflicts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'cross_system_link_conflict',
+        }),
+      ])
+    );
+  });
+
+  it('uses an authoritative QuickBooks customer read to recognize the Salesforce custom field', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003AUTHORITATIVE'")) {
+        return {
+          records: [
+            {
+              Id: '003AUTHORITATIVE',
+              FirstName: 'Andrew',
+              LastName: 'Van Hersh',
+              QuickBooks_ID__c: '517',
+            },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003AUTHORITATIVE'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '517'")) {
+        return [{ Id: '517', DisplayName: 'ANDREW VAN HERSH' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '517'")) {
+        return [];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const getQuickBooksCustomerById = vi.fn(async () => ({
+      Id: '517',
+      DisplayName: 'ANDREW VAN HERSH',
+      CurrencyRef: { value: 'USD' },
+      CustomField: [{ Name: 'Salesforce ID', StringValue: '003AUTHORITATIVE' }],
+    }));
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () =>
+        ({ markPostedToQbo: vi.fn(), upsertTransactionByExternalId: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003AUTHORITATIVE&dryRun=true',
+          query: new URLSearchParams({ salesforceId: '003AUTHORITATIVE', dryRun: 'true' }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('517');
+    expect(body.summary.linkingFields.quickbooksSalesforceFieldValue).toBe('003AUTHORITATIVE');
+    expect(body.summary.plannedBackfills).toEqual([]);
+  });
+
+  it('optionally imports Salesforce transactions from QBO-only sales receipts', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003IMPORT'")) {
+        return {
+          records: [
+            { Id: '003IMPORT', FirstName: 'Qbo', LastName: 'Import', QuickBooks_ID__c: '517' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003IMPORT'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '517'")) {
+        return [{ Id: '517', DisplayName: 'QBO Import Contact' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '517'")) {
+        return [
+          {
+            Id: '7301',
+            DocNumber: '7301',
+            TxnDate: '2026-03-22',
+            TotalAmt: 125,
+            PrivateNote: 'Imported from QBO',
+          },
+        ];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const upsertTransactionByExternalId = vi
+      .fn()
+      .mockResolvedValue({ success: true, id: 'a01Imported' });
+    const getQuickBooksCustomerById = vi.fn(async () => ({
+      Id: '517',
+      DisplayName: 'QBO Import Contact',
+      CurrencyRef: { value: 'USD' },
+      CustomField: [{ Name: 'Salesforce ID', StringValue: '003IMPORT' }],
+    }));
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () =>
+        ({ markPostedToQbo: vi.fn(), upsertTransactionByExternalId }) as any,
+      qboQuery,
+      getQuickBooksCustomerById,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003IMPORT&dryRun=false&importQboReceipts=true',
+          query: new URLSearchParams({
+            salesforceId: '003IMPORT',
+            dryRun: 'false',
+            importQboReceipts: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.importQboReceipts).toBe(true);
+    expect(body.summary.plannedCreates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'create_salesforce_transaction_from_qbo_sales_receipt',
+          qboDocId: '7301',
+          salesforceId: '003IMPORT',
+        }),
+      ])
+    );
+    expect(upsertTransactionByExternalId).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction_type__c: 'charge',
+        status__c: 'paid',
+        contact__c: '003IMPORT',
+        amount_gross__c: 125,
+        amount_fee__c: 0,
+        amount_net__c: 125,
+        currency_iso_code__c: 'USD',
+        qbo_doc_type__c: 'sales-receipt',
+        qbo_doc_id__c: '7301',
+        posted_to_qbo__c: true,
+      }),
+      'qbo_doc_id__c'
+    );
+    expect(body.summary.manualReviewItems).toEqual([]);
+  });
+});

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -938,7 +938,7 @@ describe('salesforceRecordQboSync', () => {
     expect(body.summary.plannedBackfills).toEqual([]);
   });
 
-  it('optionally imports Salesforce transactions from QBO-only sales receipts', async () => {
+  it('imports QBO-only sales receipts using a matching line-level Class__c campaign before the General Giving fallback', async () => {
     const connection = createConnection(async (soql: string) => {
       if (soql.includes("FROM Contact WHERE Id = '003IMPORT'")) {
         return {
@@ -952,8 +952,8 @@ describe('salesforceRecordQboSync', () => {
         return { records: [] };
       }
 
-      if (soql.includes("FROM Campaign WHERE Class__c = 'UNRESTRICTED FUNDS:General'")) {
-        return { records: [{ Id: '701CLASSMATCH' }] };
+      if (soql.includes("FROM Campaign WHERE Class__c = 'Program Income:Volunteer App Processing'")) {
+        return { records: [{ Id: '701PROGRAMCLASS' }] };
       }
 
       if (soql.includes("FROM Campaign WHERE Name = 'General Giving'")) {
@@ -976,7 +976,13 @@ describe('salesforceRecordQboSync', () => {
             TxnDate: '2026-03-22',
             TotalAmt: 125,
             PrivateNote: 'Imported from QBO',
-            ClassRef: { name: 'UNRESTRICTED FUNDS:General' },
+            Line: [
+              {
+                SalesItemLineDetail: {
+                  ClassRef: { name: 'Program Income:Volunteer App Processing' },
+                },
+              },
+            ],
           },
         ];
       }
@@ -1043,7 +1049,7 @@ describe('salesforceRecordQboSync', () => {
         amount_fee__c: 0,
         amount_net__c: 125,
         currency_iso_code__c: 'USD',
-        campaign__c: '701CLASSMATCH',
+        campaign__c: '701PROGRAMCLASS',
         qbo_doc_type__c: 'sales-receipt',
         qbo_doc_id__c: '7301',
         posted_to_qbo__c: true,

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -288,7 +288,11 @@ describe('salesforceRecordQboSync', () => {
         }),
       ])
     );
-    expect(updateQuickBooksCustomerSalesforceId).toHaveBeenCalledWith('456', '003BACKFILL');
+    expect(updateQuickBooksCustomerSalesforceId).toHaveBeenCalledWith(
+      '456',
+      '003BACKFILL',
+      undefined
+    );
   });
 
   it('creates a QuickBooks document for a supported Salesforce-only refund transaction', async () => {
@@ -649,5 +653,93 @@ describe('salesforceRecordQboSync', () => {
       'qbo_doc_id__c'
     );
     expect(body.summary.manualReviewItems).toEqual([]);
+  });
+
+  it('passes debug logging hooks into QuickBooks reads and updates when debug=true', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '003DEBUG'")) {
+        return {
+          records: [
+            { Id: '003DEBUG', FirstName: 'Debug', LastName: 'Mode', QuickBooks_ID__c: '1205' },
+          ],
+        };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Contact__c = '003DEBUG'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes("FROM Customer WHERE Id = '1205'")) {
+        return [{ Id: '1205', DisplayName: 'Debug Customer' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '1205'")) {
+        return [];
+      }
+
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [];
+      }
+
+      return [];
+    });
+
+    const getQuickBooksCustomerById = vi.fn(async () => ({
+      Id: '1205',
+      DisplayName: 'Debug Customer',
+      CustomField: [{ Name: 'Salesforce ID', StringValue: '' }],
+    }));
+    const updateQuickBooksCustomerSalesforceId = vi.fn().mockResolvedValue({});
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () =>
+        ({ markPostedToQbo: vi.fn(), upsertTransactionByExternalId: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById,
+      updateQuickBooksCustomerSalesforceId,
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=003DEBUG&dryRun=false&debug=true',
+          query: new URLSearchParams({
+            salesforceId: '003DEBUG',
+            dryRun: 'false',
+            debug: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.debug).toBe(true);
+    expect(qboQuery.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({
+        debugLogger: expect.any(Function),
+      })
+    );
+    expect(getQuickBooksCustomerById).toHaveBeenCalledWith(
+      '1205',
+      expect.objectContaining({
+        debugLogger: expect.any(Function),
+      })
+    );
+    expect(updateQuickBooksCustomerSalesforceId).toHaveBeenCalledWith(
+      '1205',
+      '003DEBUG',
+      expect.objectContaining({
+        debugLogger: expect.any(Function),
+      })
+    );
   });
 });

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -531,6 +531,72 @@ describe('salesforceRecordQboSync', () => {
     expect(body.summary.resolvedQuickBooksCustomerId).toBe('411');
   });
 
+  it('resolves an Account by exact QuickBooks customer display name when no IDs are available', async () => {
+    const connection = createConnection(async (soql: string) => {
+      if (soql.includes("FROM Contact WHERE Id = '001ACCOUNTBYNAME'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Account WHERE Id = '001ACCOUNTBYNAME'")) {
+        return {
+          records: [{ Id: '001ACCOUNTBYNAME', Name: 'Acme Foundation' }],
+        };
+      }
+
+      if (soql.includes("FROM Contact WHERE AccountId = '001ACCOUNTBYNAME'")) {
+        return { records: [] };
+      }
+
+      if (soql.includes("FROM Transaction__c WHERE Account__c = '001ACCOUNTBYNAME'")) {
+        return { records: [] };
+      }
+
+      return { records: [] };
+    });
+
+    const qboQuery = vi.fn(async (query: string) => {
+      if (query.includes('STARTPOSITION 1 MAXRESULTS 200')) {
+        return [{ Id: '412', DisplayName: 'Acme Foundation' }];
+      }
+
+      if (query.includes("FROM SalesReceipt WHERE CustomerRef = '412'")) {
+        return [];
+      }
+
+      return [];
+    });
+
+    internals.setDependencies({
+      getSalesforceConnection: async () => connection as any,
+      createSalesforceSvc: () => ({ markPostedToQbo: vi.fn() }) as any,
+      qboQuery,
+      getQuickBooksCustomerById: vi.fn(async () => ({
+        Id: '412',
+        DisplayName: 'Acme Foundation',
+      })),
+    });
+
+    const { context } = createContext();
+    const response = normalizeResponse(
+      await handler(
+        {
+          method: 'GET',
+          url: 'http://localhost/api/qbo/salesforce-record-sync?salesforceId=001ACCOUNTBYNAME&dryRun=true',
+          query: new URLSearchParams({
+            salesforceId: '001ACCOUNTBYNAME',
+            dryRun: 'true',
+          }),
+        } as any,
+        context
+      )
+    );
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.summary.resolvedSalesforceObjectType).toBe('Account');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBe('412');
+  });
+
   it('backfills QuickBooks Salesforce ID when the linked customer is missing it', async () => {
     const connection = createConnection(async (soql: string) => {
       if (soql.includes("FROM Contact WHERE Id = '003BACKFILL'")) {

--- a/__tests__/salesforceRecordQboSync.test.ts
+++ b/__tests__/salesforceRecordQboSync.test.ts
@@ -531,7 +531,7 @@ describe('salesforceRecordQboSync', () => {
     expect(body.summary.resolvedQuickBooksCustomerId).toBe('411');
   });
 
-  it('resolves an Account by exact QuickBooks customer display name when no IDs are available', async () => {
+  it('leaves an Account unresolved when only an exact QuickBooks customer display name matches', async () => {
     const connection = createConnection(async (soql: string) => {
       if (soql.includes("FROM Contact WHERE Id = '001ACCOUNTBYNAME'")) {
         return { records: [] };
@@ -592,9 +592,12 @@ describe('salesforceRecordQboSync', () => {
     );
     const body = JSON.parse(response.body);
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(409);
+    expect(body.error).toBe('quickbooks_customer_not_resolved');
     expect(body.summary.resolvedSalesforceObjectType).toBe('Account');
-    expect(body.summary.resolvedQuickBooksCustomerId).toBe('412');
+    expect(body.summary.resolvedQuickBooksCustomerId).toBeNull();
+    expect(body.summary.conflicts).toEqual([]);
+    expect(body.summary.plannedBackfills).toEqual([]);
   });
 
   it('backfills QuickBooks Salesforce ID when the linked customer is missing it', async () => {

--- a/__tests__/salesforceSvc.test.ts
+++ b/__tests__/salesforceSvc.test.ts
@@ -126,6 +126,23 @@ describe('createSalesforceSvc', () => {
     expect(result).toBe('sf_1');
   });
 
+  it('drops Name from transaction upserts so auto-number Name fields are never written', async () => {
+    const { upsert, sobject, query } = createMockConnection();
+    upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);
+
+    const service: SalesforceSvc = createSalesforceSvc({
+      connection: { upsert, sobject, query } as unknown as Connection,
+    });
+
+    const dto = buildDto();
+    dto.Name = 'Should not be sent';
+
+    await service.upsertTransactionByExternalId(dto, 'stripe_payment_intent_id__c');
+
+    const [, records] = upsert.mock.calls[0];
+    expect(records[0]).not.toHaveProperty('Name');
+  });
+
   it('normalizes payout linkage upserts to Salesforce API names', async () => {
     const { upsert, sobject, query } = createMockConnection();
     upsert.mockResolvedValue([{ success: true, id: 'a1', errors: [] }]);

--- a/__tests__/salesforceSvc.test.ts
+++ b/__tests__/salesforceSvc.test.ts
@@ -259,6 +259,112 @@ describe('createSalesforceSvc', () => {
     expect(result).toEqual({ success: true, id: 'a1', errors: [] });
   });
 
+  it('falls back to create when the upsert key is not an external-id field', async () => {
+    const { upsert, query, sobject } = createMockConnection();
+    const create = vi.fn().mockResolvedValue([{ success: true, id: 'a01_created', errors: [] }]);
+    sobject.mockReturnValue({ create });
+
+    upsert.mockResolvedValue([
+      {
+        success: false,
+        id: undefined,
+        errors: [
+          {
+            message:
+              'Field name provided, QBO_Doc_Id__c does not match an External ID, Salesforce Id, or indexed field for Transaction__c',
+          },
+        ],
+      },
+    ]);
+
+    query.mockImplementation((soql: string) => {
+      if (soql.includes("SELECT Id FROM RecordType")) {
+        return Promise.resolve({ records: [{ Id: '012000000000000AAA' }] });
+      }
+      if (soql.includes("QBO_Doc_Id__c = '7764'")) {
+        return Promise.resolve({ records: [] });
+      }
+      return Promise.resolve({ records: [] });
+    });
+
+    const service: SalesforceSvc = createSalesforceSvc({
+      connection: { upsert, query, sobject } as unknown as Connection,
+    });
+
+    const dto = buildDto();
+    dto.stripe_payment_intent_id__c = null;
+    dto.stripe_charge_id__c = null;
+    dto.stripe_checkout_session_id__c = null;
+    dto.qbo_doc_id__c = '7764';
+
+    const result = await service.upsertTransactionByExternalId(dto, 'qbo_doc_id__c');
+
+    expect(upsert).toHaveBeenCalledWith(
+      'Transaction__c',
+      [expect.objectContaining({ QBO_Doc_Id__c: '7764' })],
+      'QBO_Doc_Id__c',
+      { allOrNone: true }
+    );
+    expect(query).toHaveBeenCalledWith(
+      "SELECT Id FROM Transaction__c WHERE QBO_Doc_Id__c = '7764' AND RecordTypeId = '012000000000000AAA' LIMIT 1"
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ QBO_Doc_Id__c: '7764' }),
+      { allOrNone: true }
+    );
+    expect(result).toEqual({ success: true, id: 'a01_created', errors: [], created: true });
+  });
+
+  it('falls back to Salesforce Id update when the upsert key is not an external-id field but a record exists', async () => {
+    const { upsert, query, sobject } = createMockConnection();
+
+    upsert
+      .mockResolvedValueOnce([
+        {
+          success: false,
+          id: undefined,
+          errors: [
+            {
+              message:
+                'Field name provided, QBO_Doc_Id__c does not match an External ID, Salesforce Id, or indexed field for Transaction__c',
+            },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([{ success: true, id: 'a01_existing', errors: [] }]);
+
+    query.mockImplementation((soql: string) => {
+      if (soql.includes("SELECT Id FROM RecordType")) {
+        return Promise.resolve({ records: [{ Id: '012000000000000AAA' }] });
+      }
+      if (soql.includes("QBO_Doc_Id__c = '7764'")) {
+        return Promise.resolve({ records: [{ Id: 'a01_existing' }] });
+      }
+      return Promise.resolve({ records: [] });
+    });
+
+    const service: SalesforceSvc = createSalesforceSvc({
+      connection: { upsert, query, sobject } as unknown as Connection,
+    });
+
+    const dto = buildDto();
+    dto.stripe_payment_intent_id__c = null;
+    dto.stripe_charge_id__c = null;
+    dto.stripe_checkout_session_id__c = null;
+    dto.qbo_doc_id__c = '7764';
+
+    const result = await service.upsertTransactionByExternalId(dto, 'qbo_doc_id__c');
+
+    expect(upsert).toHaveBeenCalledTimes(2);
+    expect(upsert.mock.calls[1]).toEqual([
+      'Transaction__c',
+      [expect.objectContaining({ Id: 'a01_existing', QBO_Doc_Id__c: '7764' })],
+      'Id',
+      { allOrNone: true },
+    ]);
+    expect(result).toEqual({ success: true, id: 'a01_existing', errors: [] });
+  });
+
   it('prevents duplicate creation by checking other external ids when upserting', async () => {
     const { upsert, query, sobject } = createMockConnection();
     // The DTO has both a payment intent and a charge id, but we will upsert

--- a/__tests__/salesforceSvc.test.ts
+++ b/__tests__/salesforceSvc.test.ts
@@ -394,6 +394,10 @@ describe('createSalesforceSvc', () => {
     );
 
     expect(result).toEqual({ success: true, id: 'content_match', errors: [] });
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('Received_At__c = 2025-02-02T12:00:00Z')
+    );
+    expect(query).not.toHaveBeenCalledWith(expect.stringContaining("Received_At__c = '"));
   });
 
   it('does not treat ambiguous content matches as existing', async () => {
@@ -436,6 +440,33 @@ describe('createSalesforceSvc', () => {
       { allOrNone: true }
     );
     expect(result).toEqual({ success: true, id: 'new', errors: [] });
+  });
+
+  it('skips content-signature lookup when received_at__c is not a valid datetime', async () => {
+    const { upsert, query, sobject } = createMockConnection();
+    upsert.mockResolvedValue([{ success: true, id: 'new', errors: [] }]);
+
+    const service: SalesforceSvc = createSalesforceSvc({
+      connection: { upsert, query, sobject } as unknown as Connection,
+    });
+
+    const dto = buildDto();
+    dto.stripe_payment_intent_id__c = 'pi_invalid_date';
+    dto.stripe_charge_id__c = null;
+    dto.stripe_checkout_session_id__c = null;
+    dto.contact__c = '003cust';
+    dto.amount_gross__c = 41.57;
+    dto.received_at__c = 'not-a-datetime';
+
+    await service.upsertTransactionByExternalId(dto, 'stripe_payment_intent_id__c');
+
+    expect(query).not.toHaveBeenCalledWith(expect.stringContaining('Received_At__c ='));
+    expect(upsert).toHaveBeenCalledWith(
+      'Transaction__c',
+      [expect.objectContaining({ Received_At__c: 'not-a-datetime' })],
+      TRANSACTION_FIELD_API_NAMES.stripe_payment_intent_id__c,
+      { allOrNone: true }
+    );
   });
 
   it('matches existing contact when Stripe customer ID is in a delimited Stripe_Customer_Id__c list', async () => {

--- a/__tests__/stripeTrueUp.test.ts
+++ b/__tests__/stripeTrueUp.test.ts
@@ -42,9 +42,7 @@ describe('stripeTrueUp contact helper', () => {
     const result = await findOrCreateContactInSalesforce({} as any, customer, null, noopLog);
 
     expect(result).toEqual({ id: '003abc' });
-    expect(createMock).toHaveBeenCalledWith(
-      expect.objectContaining({ RecordTypeId: 'rt-999' })
-    );
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ RecordTypeId: 'rt-999' }));
     // should have performed two queries
     expect(connection.query).toHaveBeenCalledTimes(2);
   });
@@ -163,7 +161,11 @@ describe('stripeTrueUp handler overrides', () => {
     });
 
     const { context } = createContext();
-    const req = createQueryRequest({ from: '2026-01-01T00:00:00Z', type: 'payments', bypassQbo: 'true' });
+    const req = createQueryRequest({
+      from: '2026-01-01T00:00:00Z',
+      type: 'payments',
+      bypassQbo: 'true',
+    });
 
     const response = await (stripeTrueUpHandler as any)(req, context);
     const body = JSON.parse(response.body);
@@ -181,7 +183,9 @@ describe('stripeTrueUp handler overrides', () => {
     const internals = (stripeTrueUpHandler as any).__internals;
     const store = createIdempotencyStore();
     const salesforce = {
-      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'a01_existing', success: true }),
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_existing', success: true }),
       linkPayoutOnTransactions: vi.fn(),
       markPostedToQbo: vi.fn(),
       findTransactionIdByExternalId: vi.fn().mockResolvedValue('a01_existing'),
@@ -383,7 +387,9 @@ describe('stripeTrueUp handler overrides', () => {
     const internals = (stripeTrueUpHandler as any).__internals;
     const store = createIdempotencyStore();
     const salesforce = {
-      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'a01_txn_meta', success: true }),
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_txn_meta', success: true }),
       linkPayoutOnTransactions: vi.fn(),
       markPostedToQbo: vi.fn(),
       findTransactionIdByExternalId: vi.fn().mockResolvedValue(null),
@@ -477,11 +483,15 @@ describe('stripeTrueUp handler overrides', () => {
     const internals = (stripeTrueUpHandler as any).__internals;
     const store = createIdempotencyStore();
     const salesforce = {
-      upsertTransactionByExternalId: vi.fn().mockResolvedValue({ id: 'a01_txn_cmeta', success: true }),
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_txn_cmeta', success: true }),
       linkPayoutOnTransactions: vi.fn(),
       markPostedToQbo: vi.fn(),
       findTransactionIdByExternalId: vi.fn().mockResolvedValue(null),
-      upsertCustomerByStripeId: vi.fn().mockResolvedValue({ id: '003_created_again', success: true }),
+      upsertCustomerByStripeId: vi
+        .fn()
+        .mockResolvedValue({ id: '003_created_again', success: true }),
       findContactIdById: vi.fn().mockResolvedValue('003FromCustomerMetaAAA'),
     };
 
@@ -564,6 +574,101 @@ describe('stripeTrueUp handler overrides', () => {
       'stripe_charge_id__c',
       undefined
     );
+
+    internals.resetDependencies();
+  });
+
+  it('checks Account after no Contact match for Stripe salesforce_id metadata', async () => {
+    const internals = (stripeTrueUpHandler as any).__internals;
+    const store = createIdempotencyStore();
+    const salesforce = {
+      upsertTransactionByExternalId: vi
+        .fn()
+        .mockResolvedValue({ id: 'a01_txn_account', success: true }),
+      linkPayoutOnTransactions: vi.fn(),
+      markPostedToQbo: vi.fn(),
+      findTransactionIdByExternalId: vi.fn().mockResolvedValue(null),
+      upsertCustomerByStripeId: vi.fn(),
+      findContactIdById: vi.fn().mockResolvedValue(null),
+      findAccountIdById: vi.fn().mockResolvedValue('001StripeAccountAAA'),
+    };
+
+    const stripe = {
+      customers: {
+        retrieve: vi.fn(),
+      },
+      invoices: {
+        retrieve: vi.fn(),
+      },
+      paymentIntents: {
+        retrieve: vi.fn(),
+      },
+      subscriptions: {
+        retrieve: vi.fn(),
+      },
+      products: {
+        retrieve: vi.fn(),
+      },
+      prices: {
+        retrieve: vi.fn(),
+      },
+    };
+
+    internals.setDependencies({
+      stripe: { getClient: vi.fn().mockReturnValue(stripe) },
+      fetchers: {
+        payments: vi.fn().mockResolvedValue([
+          {
+            id: 'ch_account_meta',
+            status: 'succeeded',
+            customer: null,
+            currency: 'usd',
+            created: 1_700_000_000,
+            metadata: {
+              salesforce_id: '001StripeAccountAAA',
+            },
+            balance_transaction: {
+              id: 'bt_account_meta',
+              amount: 1500,
+              fee: 45,
+              type: 'charge',
+              currency: 'usd',
+              created: 1_700_000_000,
+            },
+          },
+        ]),
+      },
+      idempotencyStore: store,
+      getSalesforceSvc: async () => salesforce as any,
+      accounting: {
+        postChargeToQbo: vi.fn(),
+      },
+    });
+
+    const { context } = createContext();
+    const req = createQueryRequest({
+      from: '2026-01-01T00:00:00Z',
+      type: 'payments',
+      bypassQbo: 'true',
+    });
+
+    const response = await (stripeTrueUpHandler as any)(req, context);
+    const body = JSON.parse(response.body);
+
+    expect(response.status).toBe(200);
+    expect(body.counts.processed).toBe(1);
+    expect(salesforce.findContactIdById).toHaveBeenCalledWith('001StripeAccountAAA');
+    expect(salesforce.findAccountIdById).toHaveBeenCalledWith('001StripeAccountAAA');
+    expect(salesforce.upsertCustomerByStripeId).not.toHaveBeenCalled();
+    const [transactionPayload, externalIdField, upsertOptions] =
+      salesforce.upsertTransactionByExternalId.mock.calls[0];
+    expect(transactionPayload).toMatchObject({
+      stripe_charge_id__c: 'ch_account_meta',
+      account__c: '001StripeAccountAAA',
+    });
+    expect(transactionPayload.contact__c).toBeUndefined();
+    expect(externalIdField).toBe('stripe_charge_id__c');
+    expect(upsertOptions).toBeUndefined();
 
     internals.resetDependencies();
   });

--- a/src/handlers/qboCustomersSync.ts
+++ b/src/handlers/qboCustomersSync.ts
@@ -1,7 +1,7 @@
 import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
 
 import { logger } from '../lib/logger';
-import { query as qboQuery } from '../services/qboSvc';
+import { query as qboQuery, updateQuickBooksCustomerSalesforceId } from '../services/qboSvc';
 import { SalesforceService, buildSalesforceConfig } from '../services/salesforceService';
 
 type QboEmailAddress = { Address?: string | null };
@@ -18,6 +18,12 @@ type QboAddress = {
 };
 
 type QboWebAddress = { URI?: string | null };
+type QboCustomField = {
+  DefinitionId?: string | null;
+  Name?: string | null;
+  Type?: string | null;
+  StringValue?: string | null;
+};
 
 type QboCustomer = {
   Id?: string | number | null;
@@ -38,6 +44,7 @@ type QboCustomer = {
   BillAddr?: QboAddress | null;
   ShipAddr?: QboAddress | null;
   WebAddr?: QboWebAddress | null;
+  CustomField?: QboCustomField[] | null;
   Active?: boolean | null;
 };
 
@@ -64,6 +71,13 @@ type SalesforceContact = {
   OtherPostalCode?: string | null;
   OtherCountry?: string | null;
   Description?: string | null;
+  QuickBooks_ID__c?: string | null;
+};
+
+type SalesforceAccount = {
+  Id?: string;
+  Name?: string | null;
+  QuickBooks_ID__c?: string | null;
 };
 
 type QueryResult<T> = {
@@ -74,9 +88,7 @@ type SaveResult = { success: boolean; id?: string };
 
 type SalesforceConnectionLike = {
   query: <T = unknown>(soql: string) => Promise<QueryResult<T> | T[]>;
-  sobject: (
-    name: string
-  ) => {
+  sobject: (name: string) => {
     create: (record: Record<string, unknown>) => Promise<SaveResult | SaveResult[]>;
     update: (record: Record<string, unknown>) => Promise<SaveResult | SaveResult[]>;
   };
@@ -89,6 +101,7 @@ type SyncDependencies = {
     includeInactive: boolean;
   }) => Promise<QboCustomer[]>;
   getSalesforceConnection: () => Promise<SalesforceConnectionLike>;
+  updateQboCustomerSalesforceId: (customerId: string, salesforceId: string) => Promise<void>;
 };
 
 type RecordTypeLookup = {
@@ -125,7 +138,17 @@ type NormalizedQboCustomer = {
 };
 
 type MatchResult =
-  | { status: 'matched'; contact: SalesforceContact }
+  | {
+      status: 'matched';
+      target: 'Contact' | 'Account';
+      record: SalesforceContact | SalesforceAccount;
+      path:
+        | 'quickbooks_salesforce_id'
+        | 'salesforce_quickbooks_id'
+        | 'fallback_match'
+        | 'created_new_salesforce_record';
+      shouldBackfillQuickBooksSalesforceId?: boolean;
+    }
   | { status: 'not-found' }
   | { status: 'duplicate'; reason: string; candidates: SalesforceContact[] };
 
@@ -293,7 +316,14 @@ const normalizeQboCustomer = (customer: QboCustomer): NormalizedQboCustomer | nu
   };
 };
 
-const markerForQboCustomer = (qboCustomerId: string): string => `${QBO_MARKER_PREFIX}${qboCustomerId}]`;
+const getQboSalesforceId = (customer: QboCustomer): string | null => {
+  const customFields = Array.isArray(customer.CustomField) ? customer.CustomField : [];
+  const salesforceField = customFields.find((field) => field?.Name === 'Salesforce ID');
+  return toTrimmed(salesforceField?.StringValue);
+};
+
+const markerForQboCustomer = (qboCustomerId: string): string =>
+  `${QBO_MARKER_PREFIX}${qboCustomerId}]`;
 
 const hasMarker = (description: string | null | undefined, marker: string): boolean => {
   if (!description) {
@@ -320,10 +350,7 @@ const mergeDescriptionWithMarker = (
   return `${base}${separator}${marker}`;
 };
 
-const equalsIgnoreCase = (
-  a: string | null | undefined,
-  b: string | null | undefined
-): boolean => {
+const equalsIgnoreCase = (a: string | null | undefined, b: string | null | undefined): boolean => {
   const left = a?.trim().toLowerCase();
   const right = b?.trim().toLowerCase();
   return Boolean(left && right && left === right);
@@ -463,7 +490,9 @@ const resolveContactRecordTypeId = async (
     "SELECT Id FROM RecordType WHERE SObjectType = 'Contact' AND (Name = 'Contact' OR DeveloperName = 'Contact') AND IsActive = true ORDER BY IsDefaultRecordTypeMapping DESC LIMIT 1";
 
   const result = toRecords(await connection.query<RecordTypeLookup>(soql));
-  const found = result.find((record) => typeof record.Id === 'string' && record.Id.trim().length > 0);
+  const found = result.find(
+    (record) => typeof record.Id === 'string' && record.Id.trim().length > 0
+  );
 
   cachedContactRecordTypeId = found?.Id?.trim() ?? null;
   return cachedContactRecordTypeId;
@@ -515,8 +544,8 @@ const buildUpdatePayload = (
 
   const marker = markerForQboCustomer(customer.id);
   const baseDescription = overwrite
-    ? buildQboDescription(customer) ?? existing.Description ?? null
-    : existing.Description ?? null;
+    ? (buildQboDescription(customer) ?? existing.Description ?? null)
+    : (existing.Description ?? null);
   const nextDescription = mergeDescriptionWithMarker(baseDescription, marker);
 
   if (nextDescription !== (existing.Description ?? null)) {
@@ -528,8 +557,63 @@ const buildUpdatePayload = (
 
 const findSalesforceMatch = async (
   connection: SalesforceConnectionLike,
+  rawCustomer: QboCustomer,
   customer: NormalizedQboCustomer
 ): Promise<MatchResult> => {
+  const quickBooksSalesforceId = getQboSalesforceId(rawCustomer);
+
+  if (quickBooksSalesforceId) {
+    const contact = await findContactBySalesforceId(connection, quickBooksSalesforceId);
+    if (contact) {
+      return {
+        status: 'matched',
+        target: 'Contact',
+        record: contact,
+        path: 'quickbooks_salesforce_id',
+      };
+    }
+
+    const account = await findAccountBySalesforceId(connection, quickBooksSalesforceId);
+    if (account) {
+      return {
+        status: 'matched',
+        target: 'Account',
+        record: account,
+        path: 'quickbooks_salesforce_id',
+      };
+    }
+  } else {
+    const contactByQboId = await findByQuickBooksId<SalesforceContact>(
+      connection,
+      'Contact',
+      customer.id
+    );
+    if (contactByQboId.record) {
+      return {
+        status: 'matched',
+        target: 'Contact',
+        record: contactByQboId.record,
+        path: 'salesforce_quickbooks_id',
+        shouldBackfillQuickBooksSalesforceId: true,
+      };
+    }
+
+    const accountByQboId = await findByQuickBooksId<SalesforceAccount>(
+      connection,
+      'Account',
+      customer.id
+    );
+    if (accountByQboId.record) {
+      return {
+        status: 'matched',
+        target: 'Account',
+        record: accountByQboId.record,
+        path: 'salesforce_quickbooks_id',
+        shouldBackfillQuickBooksSalesforceId: true,
+      };
+    }
+  }
+
   const marker = markerForQboCustomer(customer.id);
 
   const candidates = await executeContactQueryWithFieldFallback(connection, customer);
@@ -550,7 +634,12 @@ const findSalesforceMatch = async (
   }
 
   if (selected.length === 1) {
-    return { status: 'matched', contact: selected[0] };
+    return {
+      status: 'matched',
+      target: 'Contact',
+      record: selected[0],
+      path: 'fallback_match',
+    };
   }
 
   return {
@@ -592,6 +681,83 @@ const parseUnsupportedContactField = (error: unknown): string | null => {
   }
 
   return null;
+};
+
+const parseUnsupportedObjectField = (
+  error: unknown,
+  objectName: 'Contact' | 'Account'
+): string | null => {
+  const message = error instanceof Error ? error.message : String(error);
+  const patterns = [
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on entity '${objectName}'`, 'i'),
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on sobject of type ${objectName}`, 'i'),
+  ];
+
+  for (const pattern of patterns) {
+    const match = message.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+};
+
+const findContactBySalesforceId = async (
+  connection: SalesforceConnectionLike,
+  salesforceId: string
+): Promise<SalesforceContact | null> => {
+  const soql =
+    `SELECT Id, FirstName, LastName, Email FROM Contact ` +
+    `WHERE Id = '${escapeSoqlLiteral(salesforceId)}' LIMIT 1`;
+  const records = toRecords(await connection.query<SalesforceContact>(soql));
+  return (
+    records.find((record) => typeof record.Id === 'string' && record.Id.trim().length > 0) ?? null
+  );
+};
+
+const findAccountBySalesforceId = async (
+  connection: SalesforceConnectionLike,
+  salesforceId: string
+): Promise<SalesforceAccount | null> => {
+  const soql = `SELECT Id, Name FROM Account WHERE Id = '${escapeSoqlLiteral(salesforceId)}' LIMIT 1`;
+  const records = toRecords(await connection.query<SalesforceAccount>(soql));
+  return (
+    records.find((record) => typeof record.Id === 'string' && record.Id.trim().length > 0) ?? null
+  );
+};
+
+const findByQuickBooksId = async <T extends { Id?: string }>(
+  connection: SalesforceConnectionLike,
+  objectName: 'Contact' | 'Account',
+  qboCustomerId: string
+): Promise<{ supported: boolean; record: T | null }> => {
+  const selectFields =
+    objectName === 'Contact'
+      ? 'Id, FirstName, LastName, Email, QuickBooks_ID__c'
+      : 'Id, Name, QuickBooks_ID__c';
+  const soql =
+    `SELECT ${selectFields} FROM ${objectName} ` +
+    `WHERE QuickBooks_ID__c = '${escapeSoqlLiteral(qboCustomerId)}' LIMIT 1`;
+
+  try {
+    const records = toRecords(await connection.query<T>(soql));
+    const record =
+      records.find(
+        (candidate) => typeof candidate.Id === 'string' && candidate.Id.trim().length > 0
+      ) ?? null;
+    return { supported: true, record };
+  } catch (error) {
+    const unsupportedField = parseUnsupportedObjectField(error, objectName);
+    if (unsupportedField?.toLowerCase() === 'quickbooks_id__c') {
+      logger.info('[qboCustomersSync] Salesforce object does not support QuickBooks_ID__c lookup', {
+        objectName,
+      });
+      return { supported: false, record: null };
+    }
+
+    throw error;
+  }
 };
 
 const executeContactQueryWithFieldFallback = async (
@@ -638,7 +804,11 @@ const executeContactQueryWithFieldFallback = async (
       whereClauses.push(`MobilePhone = '${escapeSoqlLiteral(customer.mobilePhone)}'`);
     }
 
-    if (customer.firstName && selectFields.includes('FirstName') && selectFields.includes('LastName')) {
+    if (
+      customer.firstName &&
+      selectFields.includes('FirstName') &&
+      selectFields.includes('LastName')
+    ) {
       whereClauses.push(
         `(FirstName = '${escapeSoqlLiteral(customer.firstName)}' AND LastName = '${escapeSoqlLiteral(
           customer.lastName
@@ -673,9 +843,12 @@ const executeContactQueryWithFieldFallback = async (
       }
 
       const [removedField] = selectFields.splice(index, 1);
-      logger.warn('[qboCustomersSync] Salesforce contact field unsupported; retrying query without field', {
-        removedField,
-      });
+      logger.warn(
+        '[qboCustomersSync] Salesforce contact field unsupported; retrying query without field',
+        {
+          removedField,
+        }
+      );
     }
   }
 
@@ -724,10 +897,13 @@ const executeContactSaveWithFieldFallback = async (
       }
 
       delete workingPayload[unsupportedField];
-      logger.warn('[qboCustomersSync] Salesforce contact field unsupported; retrying save without field', {
-        operation,
-        removedField: unsupportedField,
-      });
+      logger.warn(
+        '[qboCustomersSync] Salesforce contact field unsupported; retrying save without field',
+        {
+          operation,
+          removedField: unsupportedField,
+        }
+      );
     } catch (error) {
       const unsupportedField = parseUnsupportedContactField(error);
       if (!unsupportedField || !(unsupportedField in workingPayload) || unsupportedField === 'Id') {
@@ -735,10 +911,13 @@ const executeContactSaveWithFieldFallback = async (
       }
 
       delete workingPayload[unsupportedField];
-      logger.warn('[qboCustomersSync] Salesforce contact field unsupported; retrying save without field', {
-        operation,
-        removedField: unsupportedField,
-      });
+      logger.warn(
+        '[qboCustomersSync] Salesforce contact field unsupported; retrying save without field',
+        {
+          operation,
+          removedField: unsupportedField,
+        }
+      );
     }
   }
 
@@ -747,7 +926,9 @@ const executeContactSaveWithFieldFallback = async (
 
 const parseUnsupportedCustomerField = (error: unknown): string | null => {
   const message = error instanceof Error ? error.message : String(error);
-  const match = message.match(/Property\s+([A-Za-z0-9_]+)\s+not\s+found\s+for\s+Entity\s+Customer/i);
+  const match = message.match(
+    /Property\s+([A-Za-z0-9_]+)\s+not\s+found\s+for\s+Entity\s+Customer/i
+  );
   if (!match) {
     return null;
   }
@@ -782,6 +963,7 @@ const queryQboCustomersWithFieldFallback = async (
     'BillAddr',
     'ShipAddr',
     'WebAddr',
+    'CustomField',
     'Active',
   ];
 
@@ -800,8 +982,8 @@ const queryQboCustomersWithFieldFallback = async (
         throw error;
       }
 
-      const index = selectFields.findIndex((field) =>
-        field.toLowerCase() === unsupportedField.toLowerCase()
+      const index = selectFields.findIndex(
+        (field) => field.toLowerCase() === unsupportedField.toLowerCase()
       );
 
       if (index === -1) {
@@ -853,6 +1035,9 @@ const createDefaultDependencies = (): SyncDependencies => ({
   getSalesforceConnection: async () => {
     const service = new SalesforceService(buildSalesforceConfig());
     return (await service.authenticate()) as unknown as SalesforceConnectionLike;
+  },
+  updateQboCustomerSalesforceId: async (customerId: string, salesforceId: string) => {
+    await updateQuickBooksCustomerSalesforceId(customerId, salesforceId);
   },
 });
 
@@ -910,9 +1095,12 @@ const syncQboCustomersToSalesforce = async (
       contactRecordTypeId = await resolveContactRecordTypeId(salesforce);
     } catch (error) {
       contactRecordTypeId = null;
-      logger.warn('[qboCustomersSync] Unable to resolve Contact record type; defaulting to org default', {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        '[qboCustomersSync] Unable to resolve Contact record type; defaulting to org default',
+        {
+          error: error instanceof Error ? error.message : String(error),
+        }
+      );
     }
 
     const startedAt = Date.now();
@@ -985,7 +1173,7 @@ const syncQboCustomersToSalesforce = async (
         }
 
         try {
-          const match = await findSalesforceMatch(salesforce, normalized);
+          const match = await findSalesforceMatch(salesforce, rawCustomer, normalized);
 
           if (match.status === 'duplicate') {
             counts.duplicateConflicts += 1;
@@ -1004,17 +1192,44 @@ const syncQboCustomersToSalesforce = async (
 
           if (match.status === 'matched') {
             counts.alreadyExistInSalesforce += 1;
-            const updatePayload = buildUpdatePayload(match.contact, normalized, overwrite);
-            if (updatePayload) {
+            const updatePayload =
+              match.target === 'Contact'
+                ? buildUpdatePayload(match.record as SalesforceContact, normalized, overwrite)
+                : null;
+            if (updatePayload && match.target === 'Contact') {
               counts.wouldUpdate += 1;
             }
+
+            logger.info('[qboCustomersSync] Matched existing Salesforce record', {
+              qboCustomerId: normalized.id,
+              salesforceId: match.record.Id,
+              salesforceObject: match.target,
+              matchPath: match.path,
+            });
 
             if (samples.matched.length < exampleLimit) {
               samples.matched.push({
                 qboCustomerId: normalized.id,
                 qboDisplayName: normalized.displayName,
-                salesforceContactId: match.contact.Id,
+                salesforceId: match.record.Id,
+                salesforceObject: match.target,
+                matchPath: match.path,
                 wouldUpdate: Boolean(updatePayload),
+              });
+            }
+
+            if (
+              match.path === 'salesforce_quickbooks_id' &&
+              match.shouldBackfillQuickBooksSalesforceId &&
+              !getQboSalesforceId(rawCustomer) &&
+              match.record.Id &&
+              !dryRun
+            ) {
+              await deps.updateQboCustomerSalesforceId(normalized.id, match.record.Id);
+              logger.info('[qboCustomersSync] Backfilled QuickBooks Salesforce ID', {
+                qboCustomerId: normalized.id,
+                salesforceId: match.record.Id,
+                matchPath: 'backfilled_quickbooks_salesforce_id',
               });
             }
 
@@ -1030,7 +1245,9 @@ const syncQboCustomersToSalesforce = async (
                 updatePayload
               );
               if (!saveResult?.success) {
-                throw new Error(`Failed to update Salesforce contact ${String(match.contact.Id ?? '')}`);
+                throw new Error(
+                  `Failed to update Salesforce contact ${String(match.record.Id ?? '')}`
+                );
               }
               counts.updated += 1;
             }
@@ -1066,7 +1283,18 @@ const syncQboCustomersToSalesforce = async (
               createPayload
             );
             if (!saveResult?.success) {
-              throw new Error(`Failed to create Salesforce contact for QBO customer ${normalized.id}`);
+              throw new Error(
+                `Failed to create Salesforce contact for QBO customer ${normalized.id}`
+              );
+            }
+            logger.info('[qboCustomersSync] Created Salesforce record for QuickBooks customer', {
+              qboCustomerId: normalized.id,
+              salesforceId: saveResult.id,
+              salesforceObject: 'Contact',
+              matchPath: 'created_new_salesforce_record',
+            });
+            if (saveResult.id) {
+              await deps.updateQboCustomerSalesforceId(normalized.id, saveResult.id);
             }
             counts.created += 1;
           }

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -299,6 +299,12 @@ const getComparableSalesforceIds = (value: string | null | undefined): string[] 
   return [...ids];
 };
 
+const hasMatchingSalesforceId = (
+  salesforceId: string | null | undefined,
+  normalizedIds: Set<string>
+): boolean =>
+  getComparableSalesforceIds(salesforceId).some((value) => normalizedIds.has(value.toLowerCase()));
+
 const fetchSalesforceRecordById = async (
   connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
   objectType: SalesforceObjectType,
@@ -449,7 +455,8 @@ const findQuickBooksCustomerById = async (
 
 const findQuickBooksCustomersBySalesforceId = async (
   salesforceIds: string[],
-  queryFn: typeof qboQuery
+  queryFn: typeof qboQuery,
+  getCustomerByIdFn: typeof getQuickBooksCustomerById
 ): Promise<QboCustomer[]> => {
   const normalizedIds = new Set(
     salesforceIds
@@ -471,12 +478,27 @@ const findQuickBooksCustomersBySalesforceId = async (
     }
 
     matches.push(
-      ...page.filter(
-        (customer) => {
-          const qboSalesforceId = getQboSalesforceId(customer)?.toLowerCase();
-          return !!qboSalesforceId && normalizedIds.has(qboSalesforceId);
-        }
-      )
+      ...(await Promise.all(
+        page.map(async (customer) => {
+          if (hasMatchingSalesforceId(getQboSalesforceId(customer), normalizedIds)) {
+            return customer;
+          }
+
+          const customerId = normalizeQboCustomerId(customer.Id);
+          if (Array.isArray(customer.CustomField) || !customerId) {
+            return null;
+          }
+
+          try {
+            const authoritativeCustomer = (await getCustomerByIdFn(customerId)) as QboCustomer | null;
+            return hasMatchingSalesforceId(getQboSalesforceId(authoritativeCustomer), normalizedIds)
+              ? authoritativeCustomer
+              : null;
+          } catch {
+            return null;
+          }
+        })
+      )).filter((customer): customer is QboCustomer => !!customer)
     );
 
     if (page.length < DEFAULT_QBO_PAGE_SIZE) {
@@ -919,7 +941,12 @@ const salesforceRecordQboSync = async (
     );
     const qboCustomersBySalesforceId = await findQuickBooksCustomersBySalesforceId(
       salesforceLookupCandidateIds,
-      qboQueryWithDebug
+      qboQueryWithDebug,
+      (customerId) =>
+        dependencies.getQuickBooksCustomerById(
+          customerId,
+          qboDebugLogger ? { debugLogger: qboDebugLogger } : undefined
+        )
     );
     if (qboCustomersBySalesforceId.length > 1) {
       summary.conflicts.push({

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -54,6 +54,14 @@ type QboSalesReceipt = {
   PrivateNote?: string | null;
   CustomerRef?: { value?: string | null; name?: string | null } | null;
   ClassRef?: { value?: string | null; name?: string | null } | null;
+  Line?:
+    | Array<{
+        DetailType?: string | null;
+        SalesItemLineDetail?: {
+          ClassRef?: { value?: string | null; name?: string | null } | null;
+        } | null;
+      }>
+    | null;
 };
 
 type SalesforceTransaction = {
@@ -521,9 +529,7 @@ const fetchQuickBooksSalesReceiptsForCustomer = async (
   customerId: string,
   queryFn: typeof qboQuery
 ): Promise<QboSalesReceipt[]> => {
-  const queryText =
-    'SELECT Id, DocNumber, TxnDate, TotalAmt, PrivateNote, CustomerRef, ClassRef FROM SalesReceipt ' +
-    `WHERE CustomerRef = '${escapeQboLiteral(customerId)}'`;
+  const queryText = `SELECT * FROM SalesReceipt WHERE CustomerRef = '${escapeQboLiteral(customerId)}'`;
   const records = await queryFn<QboSalesReceipt[]>(queryText);
   return Array.isArray(records) ? records : [];
 };
@@ -707,12 +713,33 @@ const fetchCampaignIdByName = async (connection: Connection, name: string): Prom
   return toTrimmed(records[0]?.Id);
 };
 
+const resolveSalesReceiptClassName = (receipt: QboSalesReceipt): string | null => {
+  const headerClassName = toTrimmed(receipt.ClassRef?.name);
+  if (headerClassName) {
+    return headerClassName;
+  }
+
+  const lineClassNames = new Set<string>();
+  for (const line of receipt.Line ?? []) {
+    const lineClassName = toTrimmed(line?.SalesItemLineDetail?.ClassRef?.name);
+    if (lineClassName) {
+      lineClassNames.add(lineClassName);
+    }
+  }
+
+  if (lineClassNames.size === 1) {
+    return [...lineClassNames][0];
+  }
+
+  return null;
+};
+
 const resolveCampaignIdForSalesReceipt = async (
   connection: Connection,
   receipt: QboSalesReceipt
 ): Promise<string | null> => {
   const generalGivingCampaignId = await fetchCampaignIdByName(connection, 'General Giving');
-  const className = toTrimmed(receipt.ClassRef?.name);
+  const className = resolveSalesReceiptClassName(receipt);
   if (!className) {
     return generalGivingCampaignId;
   }

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -1,0 +1,1045 @@
+import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+
+import env from '../config/env';
+import type { TransactionUpsertDTO } from '../domain/transactions';
+import { transactionTypeSchema } from '../domain/transactions';
+import { logger } from '../lib/logger';
+import {
+  getQuickBooksCustomerById,
+  postChargeToQbo,
+  postDisputeToQbo,
+  postPayoutToQbo,
+  postRefundToQbo,
+  query as qboQuery,
+  updateQuickBooksCustomerSalesforceId,
+} from '../services/qboSvc';
+import { buildSalesforceConfig, SalesforceService } from '../services/salesforceService';
+import { createSalesforceSvc } from '../services/salesforceSvc';
+
+type SalesforceObjectType = 'Contact' | 'Account';
+type QuickBooksDocType = 'sales-receipt' | 'journal-entry' | 'bank-deposit';
+
+type SalesforceRecord = {
+  Id?: string;
+  FirstName?: string | null;
+  LastName?: string | null;
+  Email?: string | null;
+  Name?: string | null;
+  QuickBooks_ID__c?: string | null;
+};
+
+type QboCustomField = {
+  DefinitionId?: string | null;
+  Name?: string | null;
+  Type?: string | null;
+  StringValue?: string | null;
+};
+
+type QboCustomer = {
+  Id?: string | number | null;
+  DisplayName?: string | null;
+  PrimaryEmailAddr?: { Address?: string | null } | null;
+  CurrencyRef?: { value?: string | null; name?: string | null } | null;
+  Active?: boolean | null;
+  CustomField?: QboCustomField[] | null;
+};
+
+type QboSalesReceipt = {
+  Id?: string | number | null;
+  DocNumber?: string | null;
+  TxnDate?: string | null;
+  TotalAmt?: number | null;
+  PrivateNote?: string | null;
+  CustomerRef?: { value?: string | null; name?: string | null } | null;
+};
+
+type SalesforceTransaction = {
+  Id?: string;
+  Name?: string | null;
+  Transaction_Type__c?: string | null;
+  Amount_Gross__c?: number | null;
+  Amount_Fee__c?: number | null;
+  Amount_Net__c?: number | null;
+  Memo__c?: string | null;
+  Received_At__c?: string | null;
+  Posted_to_QBO__c?: boolean | null;
+  QBO_Doc_Type__c?: string | null;
+  QBO_Doc_Id__c?: string | null;
+  Stripe_Payout_Id__c?: string | null;
+  Posting_Error__c?: string | null;
+};
+
+type PlannedAction =
+  | {
+      type: 'create_qbo_document';
+      salesforceTransactionId: string;
+      transactionType: string;
+      reason: string;
+    }
+  | {
+      type: 'backfill_qbo_salesforce_id';
+      qboCustomerId: string;
+      salesforceId: string;
+      reason: string;
+    }
+  | {
+      type: 'backfill_salesforce_quickbooks_id';
+      salesforceId: string;
+      qboCustomerId: string;
+      objectType: SalesforceObjectType;
+      fieldName: 'QuickBooks_ID__c';
+      reason: string;
+    }
+  | {
+      type: 'mark_salesforce_posted_to_qbo';
+      salesforceTransactionId: string;
+      qboDocId: string;
+      qboDocType: QuickBooksDocType;
+      reason: string;
+    }
+  | {
+      type: 'create_salesforce_transaction_from_qbo_sales_receipt';
+      qboDocId: string;
+      qboDocNumber: string | null;
+      salesforceId: string;
+      objectType: SalesforceObjectType;
+      reason: string;
+    };
+
+type ConflictItem = {
+  code: string;
+  message: string;
+  salesforceTransactionId?: string;
+  qboDocId?: string;
+};
+
+type HandlerSummary = {
+  resolvedSalesforceObjectType: SalesforceObjectType | null;
+  resolvedSalesforceRecordId: string | null;
+  resolvedQuickBooksCustomerId: string | null;
+  linkingFields: {
+    salesforceQuickBooksField: 'QuickBooks_ID__c';
+    salesforceQuickBooksFieldSupported: boolean;
+    salesforceQuickBooksFieldValue: string | null;
+    quickbooksSalesforceField: 'Salesforce ID';
+    quickbooksSalesforceFieldValue: string | null;
+  };
+  supportedTransactionTypes: string[];
+  transactionCounts: {
+    salesforce: Record<string, number>;
+    quickbooks: Record<string, number>;
+  };
+  plannedCreates: PlannedAction[];
+  plannedUpdates: PlannedAction[];
+  plannedBackfills: PlannedAction[];
+  conflicts: ConflictItem[];
+  manualReviewItems: ConflictItem[];
+};
+
+type Dependencies = {
+  getSalesforceConnection: () => Promise<Awaited<ReturnType<SalesforceService['authenticate']>>>;
+  createSalesforceSvc: (
+    connection: Awaited<ReturnType<SalesforceService['authenticate']>>
+  ) => ReturnType<typeof createSalesforceSvc>;
+  qboQuery: typeof qboQuery;
+  getQuickBooksCustomerById: typeof getQuickBooksCustomerById;
+  updateQuickBooksCustomerSalesforceId: typeof updateQuickBooksCustomerSalesforceId;
+  postChargeToQbo: typeof postChargeToQbo;
+  postRefundToQbo: typeof postRefundToQbo;
+  postDisputeToQbo: typeof postDisputeToQbo;
+  postPayoutToQbo: typeof postPayoutToQbo;
+};
+
+type ResolvedSalesforceRecord = {
+  objectType: SalesforceObjectType;
+  record: SalesforceRecord;
+  quickBooksFieldSupported: boolean;
+};
+
+const DEFAULT_QBO_PAGE_SIZE = 200;
+let dependencyOverrides: Partial<Dependencies> | null = null;
+
+const toRecords = <T>(result: { records?: T[] } | T[] | null | undefined): T[] => {
+  if (!result) {
+    return [];
+  }
+
+  if (Array.isArray(result)) {
+    return result;
+  }
+
+  return Array.isArray(result.records) ? result.records : [];
+};
+
+const toTrimmed = (value: unknown): string | null => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const parseBoolean = (value: unknown, defaultValue: boolean): boolean => {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['false', '0', 'no', 'n', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+};
+
+const escapeSoqlLiteral = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+const escapeQboLiteral = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+
+const parseUnsupportedField = (error: unknown, objectName: SalesforceObjectType): string | null => {
+  const message = error instanceof Error ? error.message : String(error);
+  const patterns = [
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on entity '${objectName}'`, 'i'),
+    new RegExp(`No such column '([A-Za-z0-9_]+)' on sobject of type ${objectName}`, 'i'),
+  ];
+
+  for (const pattern of patterns) {
+    const match = message.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+
+  return null;
+};
+
+const readSalesforceId = async (request: HttpRequest): Promise<string | null> => {
+  const readFromQuery = (): string | null => {
+    if (request.query && typeof request.query.get === 'function') {
+      return toTrimmed(request.query.get('salesforceId'));
+    }
+
+    return toTrimmed(
+      (request.query as unknown as Record<string, unknown> | undefined)?.salesforceId
+    );
+  };
+
+  const fromQuery = readFromQuery();
+  if (fromQuery) {
+    return fromQuery;
+  }
+
+  if (request.method === 'POST') {
+    try {
+      const body = (await request.json()) as Record<string, unknown>;
+      return toTrimmed(body?.salesforceId);
+    } catch (error) {
+      return null;
+    }
+  }
+
+  return null;
+};
+
+const getQboSalesforceId = (customer: QboCustomer | null | undefined): string | null => {
+  const customFields = Array.isArray(customer?.CustomField) ? customer.CustomField : [];
+  const field = customFields.find((entry) => entry?.Name === 'Salesforce ID');
+  return toTrimmed(field?.StringValue);
+};
+
+const normalizeQboCustomerId = (value: unknown): string | null => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return toTrimmed(value);
+};
+
+const fetchSalesforceRecordById = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  objectType: SalesforceObjectType,
+  salesforceId: string
+): Promise<{ record: SalesforceRecord | null; quickBooksFieldSupported: boolean }> => {
+  const baseFields = objectType === 'Contact' ? 'Id, FirstName, LastName, Email' : 'Id, Name';
+  const withQuickBooksField = `${baseFields}, QuickBooks_ID__c`;
+  const escapedId = escapeSoqlLiteral(salesforceId);
+
+  try {
+    const records = toRecords(
+      await connection.query<SalesforceRecord>(
+        `SELECT ${withQuickBooksField} FROM ${objectType} WHERE Id = '${escapedId}' LIMIT 1`
+      )
+    );
+    return {
+      record:
+        records.find((entry) => typeof entry.Id === 'string' && entry.Id.trim().length > 0) ?? null,
+      quickBooksFieldSupported: true,
+    };
+  } catch (error) {
+    const unsupportedField = parseUnsupportedField(error, objectType);
+    if (unsupportedField?.toLowerCase() !== 'quickbooks_id__c') {
+      throw error;
+    }
+
+    const records = toRecords(
+      await connection.query<SalesforceRecord>(
+        `SELECT ${baseFields} FROM ${objectType} WHERE Id = '${escapedId}' LIMIT 1`
+      )
+    );
+    return {
+      record:
+        records.find((entry) => typeof entry.Id === 'string' && entry.Id.trim().length > 0) ?? null,
+      quickBooksFieldSupported: false,
+    };
+  }
+};
+
+const resolveSalesforceRecord = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  salesforceId: string
+): Promise<ResolvedSalesforceRecord | null> => {
+  const contact = await fetchSalesforceRecordById(connection, 'Contact', salesforceId);
+  if (contact.record) {
+    return {
+      objectType: 'Contact',
+      record: contact.record,
+      quickBooksFieldSupported: contact.quickBooksFieldSupported,
+    };
+  }
+
+  const account = await fetchSalesforceRecordById(connection, 'Account', salesforceId);
+  if (account.record) {
+    return {
+      objectType: 'Account',
+      record: account.record,
+      quickBooksFieldSupported: account.quickBooksFieldSupported,
+    };
+  }
+
+  return null;
+};
+
+const queryQboCustomersPage = async (
+  startPosition: number,
+  queryFn: typeof qboQuery
+): Promise<QboCustomer[]> => {
+  const queryText =
+    'SELECT Id, DisplayName, PrimaryEmailAddr, Active, CustomField FROM Customer ' +
+    `STARTPOSITION ${startPosition} MAXRESULTS ${DEFAULT_QBO_PAGE_SIZE}`;
+  const records = await queryFn<QboCustomer[]>(queryText);
+  return Array.isArray(records) ? records : [];
+};
+
+const findQuickBooksCustomerById = async (
+  customerId: string,
+  queryFn: typeof qboQuery
+): Promise<QboCustomer | null> => {
+  const queryText =
+    'SELECT Id, DisplayName, PrimaryEmailAddr, Active, CustomField FROM Customer ' +
+    `WHERE Id = '${escapeQboLiteral(customerId)}' MAXRESULTS 1`;
+  const records = await queryFn<QboCustomer[]>(queryText);
+  const list = Array.isArray(records) ? records : [];
+  return list.find((entry) => normalizeQboCustomerId(entry?.Id) === customerId) ?? null;
+};
+
+const findQuickBooksCustomersBySalesforceId = async (
+  salesforceId: string,
+  queryFn: typeof qboQuery
+): Promise<QboCustomer[]> => {
+  const matches: QboCustomer[] = [];
+  let startPosition = 1;
+
+  while (true) {
+    const page = await queryQboCustomersPage(startPosition, queryFn);
+    if (!page.length) {
+      break;
+    }
+
+    matches.push(
+      ...page.filter(
+        (customer) => getQboSalesforceId(customer)?.toLowerCase() === salesforceId.toLowerCase()
+      )
+    );
+
+    if (page.length < DEFAULT_QBO_PAGE_SIZE) {
+      break;
+    }
+
+    startPosition += page.length;
+  }
+
+  return matches;
+};
+
+const updateSalesforceQuickBooksId = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  objectType: SalesforceObjectType,
+  salesforceId: string,
+  qboCustomerId: string
+): Promise<void> => {
+  const payload = {
+    Id: salesforceId,
+    QuickBooks_ID__c: qboCustomerId,
+  };
+
+  try {
+    const result = await connection.sobject(objectType).update(payload);
+    const saveResult = Array.isArray(result) ? result[0] : result;
+    if (!saveResult?.success) {
+      throw new Error(`Failed to update ${objectType} ${salesforceId} with QuickBooks_ID__c.`);
+    }
+  } catch (error) {
+    const unsupportedField = parseUnsupportedField(error, objectType);
+    if (unsupportedField?.toLowerCase() === 'quickbooks_id__c') {
+      throw new Error(`${objectType}.QuickBooks_ID__c is not supported in this org.`);
+    }
+
+    throw error;
+  }
+};
+
+const loadSalesforceTransactions = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  objectType: SalesforceObjectType,
+  salesforceId: string
+): Promise<SalesforceTransaction[]> => {
+  const relationshipField = objectType === 'Contact' ? 'Contact__c' : 'Account__c';
+  const soql =
+    'SELECT Id, Name, Transaction_Type__c, Amount_Gross__c, Amount_Fee__c, Amount_Net__c, ' +
+    'Memo__c, Received_At__c, Posted_to_QBO__c, QBO_Doc_Type__c, QBO_Doc_Id__c, ' +
+    'Stripe_Payout_Id__c, Posting_Error__c ' +
+    `FROM Transaction__c WHERE ${relationshipField} = '${escapeSoqlLiteral(salesforceId)}' ` +
+    'ORDER BY Received_At__c DESC NULLS LAST';
+  return toRecords(await connection.query<SalesforceTransaction>(soql));
+};
+
+const fetchQuickBooksDocument = async (
+  qboDocType: QuickBooksDocType,
+  qboDocId: string,
+  queryFn: typeof qboQuery
+): Promise<Record<string, unknown> | null> => {
+  const entityName =
+    qboDocType === 'sales-receipt'
+      ? 'SalesReceipt'
+      : qboDocType === 'bank-deposit'
+        ? 'Deposit'
+        : 'JournalEntry';
+  const queryText = `SELECT * FROM ${entityName} WHERE Id = '${escapeQboLiteral(qboDocId)}'`;
+  const records = await queryFn<Record<string, unknown>[]>(queryText);
+  const list = Array.isArray(records) ? records : [];
+  return list.length > 0 ? list[0] : null;
+};
+
+const fetchQuickBooksSalesReceiptsForCustomer = async (
+  customerId: string,
+  queryFn: typeof qboQuery
+): Promise<QboSalesReceipt[]> => {
+  const queryText =
+    'SELECT Id, DocNumber, TxnDate, TotalAmt, PrivateNote, CustomerRef FROM SalesReceipt ' +
+    `WHERE CustomerRef = '${escapeQboLiteral(customerId)}'`;
+  const records = await queryFn<QboSalesReceipt[]>(queryText);
+  return Array.isArray(records) ? records : [];
+};
+
+const readBooleanQuery = (request: HttpRequest, key: string, defaultValue: boolean): boolean => {
+  if (request.query && typeof request.query.get === 'function') {
+    return parseBoolean(request.query.get(key), defaultValue);
+  }
+
+  return parseBoolean(
+    (request.query as unknown as Record<string, unknown> | undefined)?.[key],
+    defaultValue
+  );
+};
+
+const toCountMap = (types: string[]): Record<string, number> =>
+  Object.fromEntries(types.map((type) => [type, 0]));
+
+const toDate = (value: string | null | undefined): Date => {
+  const parsed = value ? new Date(value) : new Date();
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+};
+
+const toCents = (amount: number | null | undefined): number => {
+  if (typeof amount !== 'number' || Number.isNaN(amount)) {
+    return 0;
+  }
+
+  return Math.round(Math.abs(amount) * 100);
+};
+
+const executeTransactionCreate = async (
+  transaction: SalesforceTransaction,
+  dependencies: Dependencies
+): Promise<{ qboId: string; type: QuickBooksDocType }> => {
+  const transactionType = toTrimmed(transaction.Transaction_Type__c);
+  const memo = toTrimmed(transaction.Memo__c) || toTrimmed(transaction.Name) || undefined;
+  const date = toDate(transaction.Received_At__c);
+
+  switch (transactionType) {
+    case 'refund': {
+      return await dependencies.postRefundToQbo({
+        amount: toCents(transaction.Amount_Gross__c),
+        memo,
+        date,
+      });
+    }
+    case 'dispute': {
+      return await dependencies.postDisputeToQbo({
+        lossAmount: toCents(transaction.Amount_Gross__c),
+        feeAmount: toCents(transaction.Amount_Fee__c),
+        memo,
+        date,
+      });
+    }
+    case 'payout': {
+      return await dependencies.postPayoutToQbo({
+        amount: toCents(transaction.Amount_Gross__c),
+        memo,
+        date,
+        payoutId: toTrimmed(transaction.Stripe_Payout_Id__c) || undefined,
+      });
+    }
+    case 'charge': {
+      if (env.accounting.postingStrategy !== 'je-transfer') {
+        throw new Error(
+          'Charge sync requires existing Stripe checkout metadata when accounting.postingStrategy is sales-receipt.'
+        );
+      }
+
+      return await dependencies.postChargeToQbo({
+        gross: toCents(transaction.Amount_Gross__c),
+        fee: toCents(transaction.Amount_Fee__c),
+        memo,
+        date,
+        stripe: {},
+      });
+    }
+    default:
+      throw new Error(
+        `Unsupported transaction type for QuickBooks sync: ${transactionType ?? 'unknown'}`
+      );
+  }
+};
+
+const buildSalesforceTransactionFromQboSalesReceipt = (
+  receipt: QboSalesReceipt,
+  resolvedRecord: ResolvedSalesforceRecord,
+  qboCustomer: QboCustomer
+): TransactionUpsertDTO | null => {
+  const qboDocId = normalizeQboCustomerId(receipt.Id);
+  const amountGross =
+    typeof receipt.TotalAmt === 'number' && Number.isFinite(receipt.TotalAmt)
+      ? receipt.TotalAmt
+      : null;
+
+  if (!qboDocId || amountGross === null) {
+    return null;
+  }
+
+  const docNumber = toTrimmed(receipt.DocNumber);
+  const note = toTrimmed(receipt.PrivateNote);
+  const currencyCode = toTrimmed(qboCustomer.CurrencyRef?.value)?.toUpperCase() ?? null;
+
+  return {
+    Name: docNumber ? `QBO SalesReceipt ${docNumber}` : `QBO SalesReceipt ${qboDocId}`,
+    transaction_type__c: 'charge',
+    status__c: 'paid',
+    amount_gross__c: amountGross,
+    amount_fee__c: 0,
+    amount_net__c: amountGross,
+    currency_iso_code__c: currencyCode,
+    memo__c: note ?? (docNumber ? `Imported from QuickBooks SalesReceipt ${docNumber}` : null),
+    contact__c: resolvedRecord.objectType === 'Contact' ? (resolvedRecord.record.Id ?? null) : null,
+    account__c: resolvedRecord.objectType === 'Account' ? (resolvedRecord.record.Id ?? null) : null,
+    received_at__c: toTrimmed(receipt.TxnDate),
+    posted_to_qbo__c: true,
+    qbo_doc_type__c: 'sales-receipt',
+    qbo_doc_id__c: qboDocId,
+  };
+};
+
+const buildSummary = (): HandlerSummary => ({
+  resolvedSalesforceObjectType: null,
+  resolvedSalesforceRecordId: null,
+  resolvedQuickBooksCustomerId: null,
+  linkingFields: {
+    salesforceQuickBooksField: 'QuickBooks_ID__c',
+    salesforceQuickBooksFieldSupported: false,
+    salesforceQuickBooksFieldValue: null,
+    quickbooksSalesforceField: 'Salesforce ID',
+    quickbooksSalesforceFieldValue: null,
+  },
+  supportedTransactionTypes: [...transactionTypeSchema.options],
+  transactionCounts: {
+    salesforce: toCountMap([...transactionTypeSchema.options]),
+    quickbooks: toCountMap([...transactionTypeSchema.options]),
+  },
+  plannedCreates: [],
+  plannedUpdates: [],
+  plannedBackfills: [],
+  conflicts: [],
+  manualReviewItems: [],
+});
+
+const createDefaultDependencies = (): Dependencies => ({
+  getSalesforceConnection: async () => {
+    const salesforceService = new SalesforceService(buildSalesforceConfig());
+    return await salesforceService.authenticate();
+  },
+  createSalesforceSvc: (connection) => createSalesforceSvc({ connection }),
+  qboQuery,
+  getQuickBooksCustomerById,
+  updateQuickBooksCustomerSalesforceId,
+  postChargeToQbo,
+  postRefundToQbo,
+  postDisputeToQbo,
+  postPayoutToQbo,
+});
+
+const resolveDependencies = (): Dependencies => ({
+  ...createDefaultDependencies(),
+  ...(dependencyOverrides ?? {}),
+});
+
+const salesforceRecordQboSync = async (
+  request: HttpRequest,
+  context: InvocationContext
+): Promise<HttpResponseInit> => {
+  const dryRun = readBooleanQuery(request, 'dryRun', true);
+  const importQboReceipts = readBooleanQuery(request, 'importQboReceipts', false);
+  const salesforceId = await readSalesforceId(request);
+  const summary = buildSummary();
+
+  if (!salesforceId) {
+    return {
+      status: 400,
+      jsonBody: {
+        error: 'bad_request',
+        message: 'salesforceId is required.',
+        dryRun,
+        importQboReceipts,
+        summary,
+      },
+    };
+  }
+
+  try {
+    const dependencies = resolveDependencies();
+    const connection = await dependencies.getSalesforceConnection();
+    const salesforceSvc = dependencies.createSalesforceSvc(connection);
+
+    const resolvedRecord = await resolveSalesforceRecord(connection, salesforceId);
+    if (!resolvedRecord) {
+      return {
+        status: 404,
+        jsonBody: {
+          error: 'salesforce_record_not_found',
+          message: `No Contact or Account was found for Salesforce ID ${salesforceId}.`,
+          dryRun,
+          importQboReceipts,
+          summary,
+        },
+      };
+    }
+
+    summary.resolvedSalesforceObjectType = resolvedRecord.objectType;
+    summary.resolvedSalesforceRecordId = resolvedRecord.record.Id ?? salesforceId;
+    summary.linkingFields.salesforceQuickBooksFieldSupported =
+      resolvedRecord.quickBooksFieldSupported;
+    summary.linkingFields.salesforceQuickBooksFieldValue =
+      toTrimmed(resolvedRecord.record.QuickBooks_ID__c) ?? null;
+
+    const salesforceQboId = toTrimmed(resolvedRecord.record.QuickBooks_ID__c);
+    const qboCustomersBySalesforceId = await findQuickBooksCustomersBySalesforceId(
+      salesforceId,
+      dependencies.qboQuery
+    );
+
+    if (qboCustomersBySalesforceId.length > 1) {
+      summary.conflicts.push({
+        code: 'multiple_qbo_customers_for_salesforce_id',
+        message: `Multiple QuickBooks customers reference Salesforce ID ${salesforceId}.`,
+      });
+    }
+
+    let qboCustomer: QboCustomer | null = null;
+
+    if (salesforceQboId) {
+      qboCustomer = await findQuickBooksCustomerById(salesforceQboId, dependencies.qboQuery);
+      if (!qboCustomer) {
+        summary.conflicts.push({
+          code: 'salesforce_quickbooks_id_not_found',
+          message: `Salesforce ${resolvedRecord.objectType} ${salesforceId} references QuickBooks customer ${salesforceQboId}, but that customer was not found.`,
+        });
+      }
+    }
+
+    const qboCustomerFromSalesforceId =
+      qboCustomersBySalesforceId.length === 1 ? qboCustomersBySalesforceId[0] : null;
+    const qboCustomerFromSalesforceIdValue = normalizeQboCustomerId(
+      qboCustomerFromSalesforceId?.Id
+    );
+
+    if (
+      qboCustomer &&
+      qboCustomerFromSalesforceIdValue &&
+      salesforceQboId !== qboCustomerFromSalesforceIdValue
+    ) {
+      summary.conflicts.push({
+        code: 'cross_system_link_conflict',
+        message:
+          `Salesforce ${resolvedRecord.objectType} ${salesforceId} points to QuickBooks customer ${salesforceQboId}, ` +
+          `but QuickBooks custom field "Salesforce ID" points to customer ${qboCustomerFromSalesforceIdValue}.`,
+      });
+    }
+
+    if (!qboCustomer && qboCustomerFromSalesforceId) {
+      qboCustomer = qboCustomerFromSalesforceId;
+      const qboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
+      if (resolvedRecord.quickBooksFieldSupported && qboCustomerId) {
+        summary.plannedBackfills.push({
+          type: 'backfill_salesforce_quickbooks_id',
+          salesforceId,
+          qboCustomerId,
+          objectType: resolvedRecord.objectType,
+          fieldName: 'QuickBooks_ID__c',
+          reason: 'determined_from_quickbooks_salesforce_id',
+        });
+      }
+    }
+
+    if (qboCustomer) {
+      const qboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
+      if (qboCustomerId) {
+        try {
+          const authoritativeCustomer = (await dependencies.getQuickBooksCustomerById(
+            qboCustomerId
+          )) as QboCustomer;
+          if (authoritativeCustomer) {
+            qboCustomer = authoritativeCustomer;
+          }
+        } catch (error) {
+          context.log(
+            '[salesforceRecordQboSync] Failed authoritative QuickBooks customer read; continuing with query result',
+            {
+              qboCustomerId,
+              error: error instanceof Error ? error.message : String(error),
+            }
+          );
+        }
+      }
+
+      const authoritativeQboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
+      const qboSalesforceId = getQboSalesforceId(qboCustomer);
+      summary.resolvedQuickBooksCustomerId = authoritativeQboCustomerId;
+      summary.linkingFields.quickbooksSalesforceFieldValue = qboSalesforceId;
+
+      if (qboSalesforceId && qboSalesforceId !== salesforceId) {
+        summary.conflicts.push({
+          code: 'quickbooks_salesforce_id_conflict',
+          message:
+            `QuickBooks customer ${authoritativeQboCustomerId} has custom field "Salesforce ID"=${qboSalesforceId}, ` +
+            `which does not match requested Salesforce ID ${salesforceId}.`,
+        });
+      }
+
+      if (!qboSalesforceId && authoritativeQboCustomerId) {
+        summary.plannedBackfills.push({
+          type: 'backfill_qbo_salesforce_id',
+          qboCustomerId: authoritativeQboCustomerId,
+          salesforceId,
+          reason: 'determined_from_salesforce_record',
+        });
+      }
+    }
+
+    if (!qboCustomer) {
+      return {
+        status: 409,
+        jsonBody: {
+          error: 'quickbooks_customer_not_resolved',
+          message: `Unable to deterministically resolve a QuickBooks customer for Salesforce ID ${salesforceId}.`,
+          dryRun,
+          importQboReceipts,
+          summary,
+        },
+      };
+    }
+
+    if (summary.conflicts.length > 0) {
+      return {
+        status: 409,
+        jsonBody: {
+          error: 'link_conflict',
+          message: 'Conflicting Salesforce/QuickBooks linking data was found.',
+          dryRun,
+          importQboReceipts,
+          summary,
+        },
+      };
+    }
+
+    const transactions = await loadSalesforceTransactions(
+      connection,
+      resolvedRecord.objectType,
+      salesforceId
+    );
+
+    for (const transaction of transactions) {
+      const transactionType = toTrimmed(transaction.Transaction_Type__c);
+      if (!transactionType || !(summary.transactionCounts.salesforce[transactionType] >= 0)) {
+        continue;
+      }
+
+      summary.transactionCounts.salesforce[transactionType] += 1;
+
+      const qboDocId = toTrimmed(transaction.QBO_Doc_Id__c);
+      const qboDocType = toTrimmed(transaction.QBO_Doc_Type__c) as QuickBooksDocType | null;
+
+      if (qboDocId && qboDocType) {
+        const qboDoc = await fetchQuickBooksDocument(qboDocType, qboDocId, dependencies.qboQuery);
+        if (!qboDoc) {
+          summary.conflicts.push({
+            code: 'linked_qbo_document_missing',
+            message: `QuickBooks document ${qboDocType}:${qboDocId} linked from Salesforce transaction ${transaction.Id} was not found.`,
+            salesforceTransactionId: transaction.Id,
+            qboDocId,
+          });
+          continue;
+        }
+
+        summary.transactionCounts.quickbooks[transactionType] += 1;
+
+        if (transaction.Posted_to_QBO__c !== true && transaction.Id) {
+          summary.plannedUpdates.push({
+            type: 'mark_salesforce_posted_to_qbo',
+            salesforceTransactionId: transaction.Id,
+            qboDocId,
+            qboDocType,
+            reason: 'linked_qbo_document_verified',
+          });
+        }
+
+        continue;
+      }
+
+      if (!transaction.Id) {
+        summary.manualReviewItems.push({
+          code: 'salesforce_transaction_missing_id',
+          message: 'Salesforce transaction record did not include an Id.',
+        });
+        continue;
+      }
+
+      if (transactionType === 'charge' && env.accounting.postingStrategy !== 'je-transfer') {
+        summary.manualReviewItems.push({
+          code: 'charge_sales_receipt_mapping_not_verified',
+          message:
+            `Salesforce transaction ${transaction.Id} is a charge, but the existing QuickBooks ` +
+            'sales-receipt flow depends on Stripe checkout metadata not stored on Transaction__c.',
+          salesforceTransactionId: transaction.Id,
+        });
+        continue;
+      }
+
+      summary.plannedCreates.push({
+        type: 'create_qbo_document',
+        salesforceTransactionId: transaction.Id,
+        transactionType,
+        reason: 'missing_qbo_doc_link',
+      });
+    }
+
+    let salesReceipts: QboSalesReceipt[] = [];
+    const qboCustomerId = summary.resolvedQuickBooksCustomerId;
+    if (qboCustomerId) {
+      salesReceipts = await fetchQuickBooksSalesReceiptsForCustomer(
+        qboCustomerId,
+        dependencies.qboQuery
+      );
+      const linkedQboIds = new Set(
+        transactions.map((transaction) => toTrimmed(transaction.QBO_Doc_Id__c)).filter(Boolean)
+      );
+
+      for (const receipt of salesReceipts) {
+        const receiptId = normalizeQboCustomerId(receipt.Id);
+        if (!receiptId || linkedQboIds.has(receiptId)) {
+          continue;
+        }
+
+        if (importQboReceipts) {
+          summary.plannedCreates.push({
+            type: 'create_salesforce_transaction_from_qbo_sales_receipt',
+            qboDocId: receiptId,
+            qboDocNumber: toTrimmed(receipt.DocNumber),
+            salesforceId,
+            objectType: resolvedRecord.objectType,
+            reason: 'qbo_sales_receipt_missing_salesforce_transaction',
+          });
+        } else {
+          summary.manualReviewItems.push({
+            code: 'quickbooks_only_sales_receipt_unmapped',
+            message:
+              `QuickBooks SalesReceipt ${receiptId} is linked to customer ${qboCustomerId}, but no verified ` +
+              'codebase mapping exists to create Transaction__c records from QuickBooks-only documents.',
+            qboDocId: receiptId,
+          });
+        }
+      }
+    }
+
+    if (!dryRun) {
+      for (const action of summary.plannedBackfills) {
+        if (action.type === 'backfill_qbo_salesforce_id') {
+          await dependencies.updateQuickBooksCustomerSalesforceId(
+            action.qboCustomerId,
+            action.salesforceId
+          );
+          context.log('[salesforceRecordQboSync] Backfilled QuickBooks Salesforce ID', action);
+        }
+
+        if (action.type === 'backfill_salesforce_quickbooks_id') {
+          await updateSalesforceQuickBooksId(
+            connection,
+            action.objectType,
+            action.salesforceId,
+            action.qboCustomerId
+          );
+          context.log('[salesforceRecordQboSync] Backfilled Salesforce QuickBooks_ID__c', action);
+        }
+      }
+
+      for (const action of summary.plannedCreates) {
+        if (action.type === 'create_qbo_document') {
+          const transaction = transactions.find(
+            (entry) => entry.Id === action.salesforceTransactionId
+          );
+          if (!transaction) {
+            continue;
+          }
+
+          const createdDoc = await executeTransactionCreate(transaction, dependencies);
+          await salesforceSvc.markPostedToQbo(action.salesforceTransactionId, {
+            id: createdDoc.qboId,
+            type: createdDoc.type,
+          });
+          context.log(
+            '[salesforceRecordQboSync] Created QuickBooks document from Salesforce transaction',
+            {
+              salesforceTransactionId: action.salesforceTransactionId,
+              qboDocId: createdDoc.qboId,
+              qboDocType: createdDoc.type,
+              transactionType: action.transactionType,
+            }
+          );
+        }
+
+        if (action.type === 'create_salesforce_transaction_from_qbo_sales_receipt') {
+          const receipt = salesReceipts.find(
+            (entry) => normalizeQboCustomerId(entry.Id) === action.qboDocId
+          );
+          if (!receipt) {
+            continue;
+          }
+
+          const transactionDto = buildSalesforceTransactionFromQboSalesReceipt(
+            receipt,
+            resolvedRecord,
+            qboCustomer
+          );
+          if (!transactionDto) {
+            summary.manualReviewItems.push({
+              code: 'quickbooks_sales_receipt_import_missing_fields',
+              message: `QuickBooks SalesReceipt ${action.qboDocId} could not be imported because required fields were missing.`,
+              qboDocId: action.qboDocId,
+            });
+            continue;
+          }
+
+          await salesforceSvc.upsertTransactionByExternalId(transactionDto, 'qbo_doc_id__c');
+          context.log(
+            '[salesforceRecordQboSync] Imported QuickBooks SalesReceipt into Salesforce transaction',
+            {
+              qboDocId: action.qboDocId,
+              qboDocNumber: action.qboDocNumber,
+              salesforceId,
+              objectType: resolvedRecord.objectType,
+            }
+          );
+        }
+      }
+
+      for (const action of summary.plannedUpdates) {
+        if (action.type !== 'mark_salesforce_posted_to_qbo') {
+          continue;
+        }
+
+        await salesforceSvc.markPostedToQbo(action.salesforceTransactionId, {
+          id: action.qboDocId,
+          type: action.qboDocType,
+        });
+        context.log(
+          '[salesforceRecordQboSync] Marked Salesforce transaction as posted to QBO',
+          action
+        );
+      }
+    }
+
+    return {
+      status: 200,
+      jsonBody: {
+        success: true,
+        dryRun,
+        importQboReceipts,
+        summary,
+      },
+    };
+  } catch (error) {
+    logger.error('[salesforceRecordQboSync] Unhandled error', {
+      error: error instanceof Error ? error.message : String(error),
+      salesforceId,
+    });
+
+    return {
+      status: 500,
+      jsonBody: {
+        error: 'internal_error',
+        message: 'Failed to sync the Salesforce record with QuickBooks.',
+        details: error instanceof Error ? error.message : String(error),
+        dryRun,
+        importQboReceipts,
+        summary,
+      },
+    };
+  }
+};
+
+export default salesforceRecordQboSync;
+
+(
+  salesforceRecordQboSync as typeof salesforceRecordQboSync & {
+    __internals?: {
+      setDependencies: (overrides?: Partial<Dependencies> | null) => void;
+      resetDependencies: () => void;
+    };
+  }
+).__internals = {
+  setDependencies(overrides: Partial<Dependencies> | null = null) {
+    dependencyOverrides = overrides;
+  },
+  resetDependencies() {
+    dependencyOverrides = null;
+  },
+};

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -458,6 +458,68 @@ const findQuickBooksCustomersBySalesforceId = async (
   return matches;
 };
 
+const findQuickBooksCustomersBySalesforceRecord = async (
+  resolvedRecord: ResolvedSalesforceRecord,
+  queryFn: typeof qboQuery
+): Promise<QboCustomer[]> => {
+  const normalizedNames = new Set<string>();
+  const normalizedEmails = new Set<string>();
+
+  if (resolvedRecord.objectType === 'Account') {
+    const accountName = toTrimmed(resolvedRecord.record.Name)?.toLowerCase();
+    if (accountName) {
+      normalizedNames.add(accountName);
+    }
+  } else {
+    const fullName = [toTrimmed(resolvedRecord.record.FirstName), toTrimmed(resolvedRecord.record.LastName)]
+      .filter(Boolean)
+      .join(' ')
+      .trim()
+      .toLowerCase();
+    if (fullName) {
+      normalizedNames.add(fullName);
+    }
+
+    const email = toTrimmed(resolvedRecord.record.Email)?.toLowerCase();
+    if (email) {
+      normalizedEmails.add(email);
+    }
+  }
+
+  if (!normalizedNames.size && !normalizedEmails.size) {
+    return [];
+  }
+
+  const matches: QboCustomer[] = [];
+  let startPosition = 1;
+
+  while (true) {
+    const page = await queryQboCustomersPage(startPosition, queryFn);
+    if (!page.length) {
+      break;
+    }
+
+    matches.push(
+      ...page.filter((customer) => {
+        const displayName = toTrimmed(customer.DisplayName)?.toLowerCase();
+        const email = toTrimmed(customer.PrimaryEmailAddr?.Address)?.toLowerCase();
+        return (
+          (!!displayName && normalizedNames.has(displayName)) ||
+          (!!email && normalizedEmails.has(email))
+        );
+      })
+    );
+
+    if (page.length < DEFAULT_QBO_PAGE_SIZE) {
+      break;
+    }
+
+    startPosition += page.length;
+  }
+
+  return matches;
+};
+
 const updateSalesforceQuickBooksId = async (
   connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
   objectType: SalesforceObjectType,
@@ -871,11 +933,23 @@ const salesforceRecordQboSync = async (
       salesforceLookupCandidateIds,
       qboQueryWithDebug
     );
+    const qboCustomersByIdentity = await findQuickBooksCustomersBySalesforceRecord(
+      resolvedRecord,
+      qboQueryWithDebug
+    );
 
     if (qboCustomersBySalesforceId.length > 1) {
       summary.conflicts.push({
         code: 'multiple_qbo_customers_for_salesforce_id',
         message: `Multiple QuickBooks customers reference Salesforce ID ${salesforceId}.`,
+      });
+    }
+
+    if (qboCustomersByIdentity.length > 1) {
+      summary.conflicts.push({
+        code: 'multiple_qbo_customers_for_salesforce_identity',
+        message:
+          `Multiple QuickBooks customers exactly match Salesforce ${resolvedRecord.objectType} ${salesforceId} by name or email.`,
       });
     }
 
@@ -911,6 +985,7 @@ const salesforceRecordQboSync = async (
     const qboCustomerFromSalesforceIdValue = normalizeQboCustomerId(
       qboCustomerFromSalesforceId?.Id
     );
+    const qboCustomerFromIdentity = qboCustomersByIdentity.length === 1 ? qboCustomersByIdentity[0] : null;
 
     if (
       qboCustomer &&
@@ -936,6 +1011,21 @@ const salesforceRecordQboSync = async (
           objectType: resolvedRecord.objectType,
           fieldName: 'QuickBooks_ID__c',
           reason: 'determined_from_quickbooks_salesforce_id',
+        });
+      }
+    }
+
+    if (!qboCustomer && qboCustomerFromIdentity) {
+      qboCustomer = qboCustomerFromIdentity;
+      const qboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
+      if (resolvedRecord.quickBooksFieldSupported && qboCustomerId && !salesforceQboId) {
+        summary.plannedBackfills.push({
+          type: 'backfill_salesforce_quickbooks_id',
+          salesforceId,
+          qboCustomerId,
+          objectType: resolvedRecord.objectType,
+          fieldName: 'QuickBooks_ID__c',
+          reason: 'determined_from_salesforce_identity',
         });
       }
     }

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -285,6 +285,20 @@ const normalizeQboCustomerId = (value: unknown): string | null => {
   return toTrimmed(value);
 };
 
+const getComparableSalesforceIds = (value: string | null | undefined): string[] => {
+  const trimmed = toTrimmed(value);
+  if (!trimmed) {
+    return [];
+  }
+
+  const ids = new Set<string>([trimmed]);
+  if (trimmed.length >= 15) {
+    ids.add(trimmed.slice(0, 15));
+  }
+
+  return [...ids];
+};
+
 const fetchSalesforceRecordById = async (
   connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
   objectType: SalesforceObjectType,
@@ -358,7 +372,9 @@ const collectSalesforceLookupCandidates = async (
   const quickBooksIds = new Set<string>();
   const primaryId = toTrimmed(resolvedRecord.record.Id);
   if (primaryId) {
-    ids.add(primaryId);
+    for (const variant of getComparableSalesforceIds(primaryId)) {
+      ids.add(variant);
+    }
   }
 
   const primaryQuickBooksId = toTrimmed(resolvedRecord.record.QuickBooks_ID__c);
@@ -369,7 +385,9 @@ const collectSalesforceLookupCandidates = async (
   if (resolvedRecord.objectType === 'Contact') {
     const accountId = toTrimmed(resolvedRecord.record.AccountId);
     if (accountId) {
-      ids.add(accountId);
+      for (const variant of getComparableSalesforceIds(accountId)) {
+        ids.add(variant);
+      }
 
       const account = await fetchSalesforceRecordById(connection, 'Account', accountId);
       const accountQuickBooksId = toTrimmed(account.record?.QuickBooks_ID__c);
@@ -392,7 +410,9 @@ const collectSalesforceLookupCandidates = async (
   for (const contact of contacts) {
     const contactId = toTrimmed(contact.Id);
     if (contactId) {
-      ids.add(contactId);
+      for (const variant of getComparableSalesforceIds(contactId)) {
+        ids.add(variant);
+      }
     }
 
     const contactQuickBooksId = toTrimmed(contact.QuickBooks_ID__c);
@@ -432,7 +452,10 @@ const findQuickBooksCustomersBySalesforceId = async (
   queryFn: typeof qboQuery
 ): Promise<QboCustomer[]> => {
   const normalizedIds = new Set(
-    salesforceIds.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0)
+    salesforceIds
+      .flatMap((value) => getComparableSalesforceIds(value))
+      .map((value) => value.trim().toLowerCase())
+      .filter((value) => value.length > 0)
   );
   if (!normalizedIds.size) {
     return [];

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -26,6 +26,7 @@ type SalesforceRecord = {
   LastName?: string | null;
   Email?: string | null;
   Name?: string | null;
+  AccountId?: string | null;
   QuickBooks_ID__c?: string | null;
 };
 
@@ -276,7 +277,8 @@ const fetchSalesforceRecordById = async (
   objectType: SalesforceObjectType,
   salesforceId: string
 ): Promise<{ record: SalesforceRecord | null; quickBooksFieldSupported: boolean }> => {
-  const baseFields = objectType === 'Contact' ? 'Id, FirstName, LastName, Email' : 'Id, Name';
+  const baseFields =
+    objectType === 'Contact' ? 'Id, FirstName, LastName, Email, AccountId' : 'Id, Name';
   const withQuickBooksField = `${baseFields}, QuickBooks_ID__c`;
   const escapedId = escapeSoqlLiteral(salesforceId);
 
@@ -335,6 +337,43 @@ const resolveSalesforceRecord = async (
   return null;
 };
 
+const collectSalesforceLookupCandidateIds = async (
+  connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
+  resolvedRecord: ResolvedSalesforceRecord
+): Promise<string[]> => {
+  const ids = new Set<string>();
+  const primaryId = toTrimmed(resolvedRecord.record.Id);
+  if (primaryId) {
+    ids.add(primaryId);
+  }
+
+  if (resolvedRecord.objectType === 'Contact') {
+    const accountId = toTrimmed(resolvedRecord.record.AccountId);
+    if (accountId) {
+      ids.add(accountId);
+    }
+
+    return [...ids];
+  }
+
+  if (!primaryId) {
+    return [...ids];
+  }
+
+  const query =
+    `SELECT Id FROM Contact WHERE AccountId = '${escapeSoqlLiteral(primaryId)}' ` +
+    'ORDER BY CreatedDate ASC LIMIT 200';
+  const contacts = toRecords(await connection.query<{ Id?: string }>(query));
+  for (const contact of contacts) {
+    const contactId = toTrimmed(contact.Id);
+    if (contactId) {
+      ids.add(contactId);
+    }
+  }
+
+  return [...ids];
+};
+
 const queryQboCustomersPage = async (
   startPosition: number,
   queryFn: typeof qboQuery
@@ -359,9 +398,16 @@ const findQuickBooksCustomerById = async (
 };
 
 const findQuickBooksCustomersBySalesforceId = async (
-  salesforceId: string,
+  salesforceIds: string[],
   queryFn: typeof qboQuery
 ): Promise<QboCustomer[]> => {
+  const normalizedIds = new Set(
+    salesforceIds.map((value) => value.trim().toLowerCase()).filter((value) => value.length > 0)
+  );
+  if (!normalizedIds.size) {
+    return [];
+  }
+
   const matches: QboCustomer[] = [];
   let startPosition = 1;
 
@@ -373,7 +419,10 @@ const findQuickBooksCustomersBySalesforceId = async (
 
     matches.push(
       ...page.filter(
-        (customer) => getQboSalesforceId(customer)?.toLowerCase() === salesforceId.toLowerCase()
+        (customer) => {
+          const qboSalesforceId = getQboSalesforceId(customer)?.toLowerCase();
+          return !!qboSalesforceId && normalizedIds.has(qboSalesforceId);
+        }
       )
     );
 
@@ -788,8 +837,15 @@ const salesforceRecordQboSync = async (
       toTrimmed(resolvedRecord.record.QuickBooks_ID__c) ?? null;
 
     const salesforceQboId = toTrimmed(resolvedRecord.record.QuickBooks_ID__c);
+    const salesforceLookupCandidateIds = await collectSalesforceLookupCandidateIds(
+      connection,
+      resolvedRecord
+    );
+    const normalizedSalesforceLookupCandidateIds = new Set(
+      salesforceLookupCandidateIds.map((value) => value.toLowerCase())
+    );
     const qboCustomersBySalesforceId = await findQuickBooksCustomersBySalesforceId(
-      salesforceId,
+      salesforceLookupCandidateIds,
       qboQueryWithDebug
     );
 
@@ -875,7 +931,7 @@ const salesforceRecordQboSync = async (
       summary.resolvedQuickBooksCustomerId = authoritativeQboCustomerId;
       summary.linkingFields.quickbooksSalesforceFieldValue = qboSalesforceId;
 
-      if (qboSalesforceId && qboSalesforceId !== salesforceId) {
+      if (qboSalesforceId && !normalizedSalesforceLookupCandidateIds.has(qboSalesforceId.toLowerCase())) {
         summary.conflicts.push({
           code: 'quickbooks_salesforce_id_conflict',
           message:

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -172,7 +172,6 @@ type SalesforceLookupCandidates = {
   quickBooksIds: string[];
 };
 
-const DEFAULT_QBO_PAGE_SIZE = 200;
 let dependencyOverrides: Partial<Dependencies> | null = null;
 
 const toRecords = <T>(result: { records?: T[] } | T[] | null | undefined): T[] => {
@@ -430,17 +429,6 @@ const collectSalesforceLookupCandidates = async (
   return { salesforceIds: [...ids], quickBooksIds: [...quickBooksIds] };
 };
 
-const queryQboCustomersPage = async (
-  startPosition: number,
-  queryFn: typeof qboQuery
-): Promise<QboCustomer[]> => {
-  const queryText =
-    'SELECT Id, DisplayName, PrimaryEmailAddr, Active, CustomField FROM Customer ' +
-    `STARTPOSITION ${startPosition} MAXRESULTS ${DEFAULT_QBO_PAGE_SIZE}`;
-  const records = await queryFn<QboCustomer[]>(queryText);
-  return Array.isArray(records) ? records : [];
-};
-
 const findQuickBooksCustomerById = async (
   customerId: string,
   queryFn: typeof qboQuery
@@ -458,54 +446,44 @@ const findQuickBooksCustomersBySalesforceId = async (
   queryFn: typeof qboQuery,
   getCustomerByIdFn: typeof getQuickBooksCustomerById
 ): Promise<QboCustomer[]> => {
-  const normalizedIds = new Set(
-    salesforceIds
-      .flatMap((value) => getComparableSalesforceIds(value))
-      .map((value) => value.trim().toLowerCase())
-      .filter((value) => value.length > 0)
-  );
-  if (!normalizedIds.size) {
-    return [];
-  }
-
   const matches: QboCustomer[] = [];
-  let startPosition = 1;
+  const seenCustomerIds = new Set<string>();
+  const candidateSalesforceIds = [...new Set(salesforceIds.flatMap((value) => getComparableSalesforceIds(value)))];
+  const normalizedCandidateIds = new Set(candidateSalesforceIds.map((value) => value.toLowerCase()));
 
-  while (true) {
-    const page = await queryQboCustomersPage(startPosition, queryFn);
-    if (!page.length) {
-      break;
+  for (const candidateSalesforceId of candidateSalesforceIds) {
+    const queryText =
+      'SELECT Id, DisplayName, PrimaryEmailAddr, Active, CustomField FROM Customer ' +
+      `WHERE CustomField = '${escapeQboLiteral(candidateSalesforceId)}' MAXRESULTS 10`;
+    const records = await queryFn<QboCustomer[]>(queryText);
+    const list = Array.isArray(records) ? records : [];
+
+    for (const customer of list) {
+      const directMatch = hasMatchingSalesforceId(getQboSalesforceId(customer), normalizedCandidateIds);
+      const customerId = normalizeQboCustomerId(customer.Id);
+      if (directMatch && customerId && !seenCustomerIds.has(customerId)) {
+        seenCustomerIds.add(customerId);
+        matches.push(customer);
+        continue;
+      }
+
+      if (!customerId || seenCustomerIds.has(customerId)) {
+        continue;
+      }
+
+      try {
+        const authoritativeCustomer = (await getCustomerByIdFn(customerId)) as QboCustomer | null;
+        if (
+          authoritativeCustomer &&
+          hasMatchingSalesforceId(getQboSalesforceId(authoritativeCustomer), normalizedCandidateIds)
+        ) {
+          seenCustomerIds.add(customerId);
+          matches.push(authoritativeCustomer);
+        }
+      } catch {
+        continue;
+      }
     }
-
-    matches.push(
-      ...(await Promise.all(
-        page.map(async (customer) => {
-          if (hasMatchingSalesforceId(getQboSalesforceId(customer), normalizedIds)) {
-            return customer;
-          }
-
-          const customerId = normalizeQboCustomerId(customer.Id);
-          if (Array.isArray(customer.CustomField) || !customerId) {
-            return null;
-          }
-
-          try {
-            const authoritativeCustomer = (await getCustomerByIdFn(customerId)) as QboCustomer | null;
-            return hasMatchingSalesforceId(getQboSalesforceId(authoritativeCustomer), normalizedIds)
-              ? authoritativeCustomer
-              : null;
-          } catch {
-            return null;
-          }
-        })
-      )).filter((customer): customer is QboCustomer => !!customer)
-    );
-
-    if (page.length < DEFAULT_QBO_PAGE_SIZE) {
-      break;
-    }
-
-    startPosition += page.length;
   }
 
   return matches;

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -1,4 +1,5 @@
 import type { HttpRequest, HttpResponseInit, InvocationContext } from '@azure/functions';
+import type { Connection } from 'jsforce/lib/connection';
 
 import env from '../config/env';
 import type { TransactionUpsertDTO } from '../domain/transactions';
@@ -51,6 +52,7 @@ type QboSalesReceipt = {
   TotalAmt?: number | null;
   PrivateNote?: string | null;
   CustomerRef?: { value?: string | null; name?: string | null } | null;
+  ClassRef?: { value?: string | null; name?: string | null } | null;
 };
 
 type SalesforceTransaction = {
@@ -207,7 +209,10 @@ const escapeSoqlLiteral = (value: string): string =>
 const escapeQboLiteral = (value: string): string =>
   value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
-const parseUnsupportedField = (error: unknown, objectName: SalesforceObjectType): string | null => {
+const parseUnsupportedField = (
+  error: unknown,
+  objectName: SalesforceObjectType | 'Campaign'
+): string | null => {
   const message = error instanceof Error ? error.message : String(error);
   const patterns = [
     new RegExp(`No such column '([A-Za-z0-9_]+)' on entity '${objectName}'`, 'i'),
@@ -446,7 +451,7 @@ const fetchQuickBooksSalesReceiptsForCustomer = async (
   queryFn: typeof qboQuery
 ): Promise<QboSalesReceipt[]> => {
   const queryText =
-    'SELECT Id, DocNumber, TxnDate, TotalAmt, PrivateNote, CustomerRef FROM SalesReceipt ' +
+    'SELECT Id, DocNumber, TxnDate, TotalAmt, PrivateNote, CustomerRef, ClassRef FROM SalesReceipt ' +
     `WHERE CustomerRef = '${escapeQboLiteral(customerId)}'`;
   const records = await queryFn<QboSalesReceipt[]>(queryText);
   return Array.isArray(records) ? records : [];
@@ -553,7 +558,6 @@ const buildSalesforceTransactionFromQboSalesReceipt = (
   const currencyCode = toTrimmed(qboCustomer.CurrencyRef?.value)?.toUpperCase() ?? null;
 
   return {
-    Name: docNumber ? `QBO SalesReceipt ${docNumber}` : `QBO SalesReceipt ${qboDocId}`,
     transaction_type__c: 'charge',
     status__c: 'paid',
     amount_gross__c: amountGross,
@@ -568,6 +572,99 @@ const buildSalesforceTransactionFromQboSalesReceipt = (
     qbo_doc_type__c: 'sales-receipt',
     qbo_doc_id__c: qboDocId,
   };
+};
+
+const normalizeComparableDate = (value: string | null | undefined): string | null => {
+  const trimmed = toTrimmed(value);
+  if (!trimmed) {
+    return null;
+  }
+
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+
+  return parsed.toISOString().slice(0, 10);
+};
+
+const findMatchingSalesforceTransactionForReceipt = (
+  transactions: SalesforceTransaction[],
+  receipt: QboSalesReceipt
+): SalesforceTransaction | 'conflict' | null => {
+  const receiptAmount =
+    typeof receipt.TotalAmt === 'number' && Number.isFinite(receipt.TotalAmt) ? receipt.TotalAmt : null;
+  const receiptDate = normalizeComparableDate(receipt.TxnDate);
+  if (receiptAmount === null || !receiptDate) {
+    return null;
+  }
+
+  const matches = transactions.filter((transaction) => {
+    const transactionType = toTrimmed(transaction.Transaction_Type__c);
+    if (transactionType !== 'charge') {
+      return false;
+    }
+
+    const transactionAmount =
+      typeof transaction.Amount_Gross__c === 'number' && Number.isFinite(transaction.Amount_Gross__c)
+        ? transaction.Amount_Gross__c
+        : null;
+    const transactionDate = normalizeComparableDate(transaction.Received_At__c);
+    return transactionAmount === receiptAmount && transactionDate === receiptDate;
+  });
+
+  if (matches.length === 1) {
+    return matches[0];
+  }
+
+  return matches.length > 1 ? 'conflict' : null;
+};
+
+const fetchCampaignIdByName = async (connection: Connection, name: string): Promise<string | null> => {
+  const trimmedName = toTrimmed(name);
+  if (!trimmedName) {
+    return null;
+  }
+
+  const query =
+    `SELECT Id FROM Campaign WHERE Name = '${escapeSoqlLiteral(trimmedName)}' ` +
+    'ORDER BY IsActive DESC, CreatedDate DESC LIMIT 1';
+  const result = await connection.query<{ Id?: string }>(query);
+  const records = Array.isArray(result)
+    ? (result as Array<{ Id?: string }>)
+    : ((result as { records?: Array<{ Id?: string }> })?.records ?? []);
+  return toTrimmed(records[0]?.Id);
+};
+
+const resolveCampaignIdForSalesReceipt = async (
+  connection: Connection,
+  receipt: QboSalesReceipt
+): Promise<string | null> => {
+  const generalGivingCampaignId = await fetchCampaignIdByName(connection, 'General Giving');
+  const className = toTrimmed(receipt.ClassRef?.name);
+  if (!className) {
+    return generalGivingCampaignId;
+  }
+
+  try {
+    const query =
+      `SELECT Id FROM Campaign WHERE Class__c = '${escapeSoqlLiteral(className)}' ` +
+      'ORDER BY IsActive DESC, CreatedDate DESC LIMIT 2';
+    const result = await connection.query<{ Id?: string }>(query);
+    const records = Array.isArray(result)
+      ? (result as Array<{ Id?: string }>)
+      : ((result as { records?: Array<{ Id?: string }> })?.records ?? []);
+
+    if (records.length === 1) {
+      return toTrimmed(records[0]?.Id) ?? generalGivingCampaignId;
+    }
+  } catch (error) {
+    if (parseUnsupportedField(error, 'Campaign') !== 'Class__c') {
+      throw error;
+    }
+  }
+
+  return generalGivingCampaignId;
 };
 
 const buildSummary = (): HandlerSummary => ({
@@ -751,7 +848,9 @@ const salesforceRecordQboSync = async (
 
     if (qboCustomer) {
       const qboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
-      if (qboCustomerId) {
+      const shouldRefreshAuthoritativeCustomer =
+        !!qboDebugLogger || !Array.isArray(qboCustomer.CustomField);
+      if (qboCustomerId && shouldRefreshAuthoritativeCustomer) {
         try {
           const authoritativeCustomer = (await dependencies.getQuickBooksCustomerById(
             qboCustomerId,
@@ -911,6 +1010,32 @@ const salesforceRecordQboSync = async (
           continue;
         }
 
+        const matchedSalesforceTransaction = findMatchingSalesforceTransactionForReceipt(
+          transactions,
+          receipt
+        );
+        if (matchedSalesforceTransaction === 'conflict') {
+          summary.manualReviewItems.push({
+            code: 'quickbooks_sales_receipt_duplicate_salesforce_transactions',
+            message:
+              `QuickBooks SalesReceipt ${receiptId} matched multiple Salesforce charge transactions by amount and date; ` +
+              'skipping automatic import to avoid duplicate logging.',
+            qboDocId: receiptId,
+          });
+          continue;
+        }
+
+        if (matchedSalesforceTransaction?.Id) {
+          summary.plannedUpdates.push({
+            type: 'mark_salesforce_posted_to_qbo',
+            salesforceTransactionId: matchedSalesforceTransaction.Id,
+            qboDocId: receiptId,
+            qboDocType: 'sales-receipt',
+            reason: 'matched_existing_salesforce_transaction',
+          });
+          continue;
+        }
+
         if (importQboReceipts) {
           summary.plannedCreates.push({
             type: 'create_salesforce_transaction_from_qbo_sales_receipt',
@@ -1001,6 +1126,7 @@ const salesforceRecordQboSync = async (
             continue;
           }
 
+          transactionDto.campaign__c = await resolveCampaignIdForSalesReceipt(connection, receipt);
           await salesforceSvc.upsertTransactionByExternalId(transactionDto, 'qbo_doc_id__c');
           context.log(
             '[salesforceRecordQboSync] Imported QuickBooks SalesReceipt into Salesforce transaction',

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -159,6 +159,11 @@ type ResolvedSalesforceRecord = {
   quickBooksFieldSupported: boolean;
 };
 
+type SalesforceLookupCandidates = {
+  salesforceIds: string[];
+  quickBooksIds: string[];
+};
+
 const DEFAULT_QBO_PAGE_SIZE = 200;
 let dependencyOverrides: Partial<Dependencies> | null = null;
 
@@ -337,41 +342,58 @@ const resolveSalesforceRecord = async (
   return null;
 };
 
-const collectSalesforceLookupCandidateIds = async (
+const collectSalesforceLookupCandidates = async (
   connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
   resolvedRecord: ResolvedSalesforceRecord
-): Promise<string[]> => {
+): Promise<SalesforceLookupCandidates> => {
   const ids = new Set<string>();
+  const quickBooksIds = new Set<string>();
   const primaryId = toTrimmed(resolvedRecord.record.Id);
   if (primaryId) {
     ids.add(primaryId);
+  }
+
+  const primaryQuickBooksId = toTrimmed(resolvedRecord.record.QuickBooks_ID__c);
+  if (primaryQuickBooksId) {
+    quickBooksIds.add(primaryQuickBooksId);
   }
 
   if (resolvedRecord.objectType === 'Contact') {
     const accountId = toTrimmed(resolvedRecord.record.AccountId);
     if (accountId) {
       ids.add(accountId);
+
+      const account = await fetchSalesforceRecordById(connection, 'Account', accountId);
+      const accountQuickBooksId = toTrimmed(account.record?.QuickBooks_ID__c);
+      if (accountQuickBooksId) {
+        quickBooksIds.add(accountQuickBooksId);
+      }
     }
 
-    return [...ids];
+    return { salesforceIds: [...ids], quickBooksIds: [...quickBooksIds] };
   }
 
   if (!primaryId) {
-    return [...ids];
+    return { salesforceIds: [...ids], quickBooksIds: [...quickBooksIds] };
   }
 
   const query =
-    `SELECT Id FROM Contact WHERE AccountId = '${escapeSoqlLiteral(primaryId)}' ` +
+    `SELECT Id, QuickBooks_ID__c FROM Contact WHERE AccountId = '${escapeSoqlLiteral(primaryId)}' ` +
     'ORDER BY CreatedDate ASC LIMIT 200';
-  const contacts = toRecords(await connection.query<{ Id?: string }>(query));
+  const contacts = toRecords(await connection.query<SalesforceRecord>(query));
   for (const contact of contacts) {
     const contactId = toTrimmed(contact.Id);
     if (contactId) {
       ids.add(contactId);
     }
+
+    const contactQuickBooksId = toTrimmed(contact.QuickBooks_ID__c);
+    if (contactQuickBooksId) {
+      quickBooksIds.add(contactQuickBooksId);
+    }
   }
 
-  return [...ids];
+  return { salesforceIds: [...ids], quickBooksIds: [...quickBooksIds] };
 };
 
 const queryQboCustomersPage = async (
@@ -837,10 +859,11 @@ const salesforceRecordQboSync = async (
       toTrimmed(resolvedRecord.record.QuickBooks_ID__c) ?? null;
 
     const salesforceQboId = toTrimmed(resolvedRecord.record.QuickBooks_ID__c);
-    const salesforceLookupCandidateIds = await collectSalesforceLookupCandidateIds(
+    const salesforceLookupCandidates = await collectSalesforceLookupCandidates(
       connection,
       resolvedRecord
     );
+    const salesforceLookupCandidateIds = salesforceLookupCandidates.salesforceIds;
     const normalizedSalesforceLookupCandidateIds = new Set(
       salesforceLookupCandidateIds.map((value) => value.toLowerCase())
     );
@@ -857,6 +880,9 @@ const salesforceRecordQboSync = async (
     }
 
     let qboCustomer: QboCustomer | null = null;
+    const relatedQuickBooksIds = salesforceLookupCandidates.quickBooksIds.filter(
+      (value) => value !== salesforceQboId
+    );
 
     if (salesforceQboId) {
       qboCustomer = await findQuickBooksCustomerById(salesforceQboId, qboQueryWithDebug);
@@ -866,6 +892,18 @@ const salesforceRecordQboSync = async (
           message: `Salesforce ${resolvedRecord.objectType} ${salesforceId} references QuickBooks customer ${salesforceQboId}, but that customer was not found.`,
         });
       }
+    }
+
+    if (!qboCustomer && relatedQuickBooksIds.length > 1) {
+      summary.conflicts.push({
+        code: 'multiple_related_salesforce_quickbooks_ids',
+        message:
+          `Related Salesforce records for ${salesforceId} reference multiple QuickBooks customer IDs (${relatedQuickBooksIds.join(', ')}).`,
+      });
+    }
+
+    if (!qboCustomer && relatedQuickBooksIds.length === 1) {
+      qboCustomer = await findQuickBooksCustomerById(relatedQuickBooksIds[0], qboQueryWithDebug);
     }
 
     const qboCustomerFromSalesforceId =

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -458,68 +458,6 @@ const findQuickBooksCustomersBySalesforceId = async (
   return matches;
 };
 
-const findQuickBooksCustomersBySalesforceRecord = async (
-  resolvedRecord: ResolvedSalesforceRecord,
-  queryFn: typeof qboQuery
-): Promise<QboCustomer[]> => {
-  const normalizedNames = new Set<string>();
-  const normalizedEmails = new Set<string>();
-
-  if (resolvedRecord.objectType === 'Account') {
-    const accountName = toTrimmed(resolvedRecord.record.Name)?.toLowerCase();
-    if (accountName) {
-      normalizedNames.add(accountName);
-    }
-  } else {
-    const fullName = [toTrimmed(resolvedRecord.record.FirstName), toTrimmed(resolvedRecord.record.LastName)]
-      .filter(Boolean)
-      .join(' ')
-      .trim()
-      .toLowerCase();
-    if (fullName) {
-      normalizedNames.add(fullName);
-    }
-
-    const email = toTrimmed(resolvedRecord.record.Email)?.toLowerCase();
-    if (email) {
-      normalizedEmails.add(email);
-    }
-  }
-
-  if (!normalizedNames.size && !normalizedEmails.size) {
-    return [];
-  }
-
-  const matches: QboCustomer[] = [];
-  let startPosition = 1;
-
-  while (true) {
-    const page = await queryQboCustomersPage(startPosition, queryFn);
-    if (!page.length) {
-      break;
-    }
-
-    matches.push(
-      ...page.filter((customer) => {
-        const displayName = toTrimmed(customer.DisplayName)?.toLowerCase();
-        const email = toTrimmed(customer.PrimaryEmailAddr?.Address)?.toLowerCase();
-        return (
-          (!!displayName && normalizedNames.has(displayName)) ||
-          (!!email && normalizedEmails.has(email))
-        );
-      })
-    );
-
-    if (page.length < DEFAULT_QBO_PAGE_SIZE) {
-      break;
-    }
-
-    startPosition += page.length;
-  }
-
-  return matches;
-};
-
 const updateSalesforceQuickBooksId = async (
   connection: Awaited<ReturnType<SalesforceService['authenticate']>>,
   objectType: SalesforceObjectType,
@@ -933,23 +871,10 @@ const salesforceRecordQboSync = async (
       salesforceLookupCandidateIds,
       qboQueryWithDebug
     );
-    const qboCustomersByIdentity = await findQuickBooksCustomersBySalesforceRecord(
-      resolvedRecord,
-      qboQueryWithDebug
-    );
-
     if (qboCustomersBySalesforceId.length > 1) {
       summary.conflicts.push({
         code: 'multiple_qbo_customers_for_salesforce_id',
         message: `Multiple QuickBooks customers reference Salesforce ID ${salesforceId}.`,
-      });
-    }
-
-    if (qboCustomersByIdentity.length > 1) {
-      summary.conflicts.push({
-        code: 'multiple_qbo_customers_for_salesforce_identity',
-        message:
-          `Multiple QuickBooks customers exactly match Salesforce ${resolvedRecord.objectType} ${salesforceId} by name or email.`,
       });
     }
 
@@ -985,7 +910,6 @@ const salesforceRecordQboSync = async (
     const qboCustomerFromSalesforceIdValue = normalizeQboCustomerId(
       qboCustomerFromSalesforceId?.Id
     );
-    const qboCustomerFromIdentity = qboCustomersByIdentity.length === 1 ? qboCustomersByIdentity[0] : null;
 
     if (
       qboCustomer &&
@@ -1011,21 +935,6 @@ const salesforceRecordQboSync = async (
           objectType: resolvedRecord.objectType,
           fieldName: 'QuickBooks_ID__c',
           reason: 'determined_from_quickbooks_salesforce_id',
-        });
-      }
-    }
-
-    if (!qboCustomer && qboCustomerFromIdentity) {
-      qboCustomer = qboCustomerFromIdentity;
-      const qboCustomerId = normalizeQboCustomerId(qboCustomer.Id);
-      if (resolvedRecord.quickBooksFieldSupported && qboCustomerId && !salesforceQboId) {
-        summary.plannedBackfills.push({
-          type: 'backfill_salesforce_quickbooks_id',
-          salesforceId,
-          qboCustomerId,
-          objectType: resolvedRecord.objectType,
-          fieldName: 'QuickBooks_ID__c',
-          reason: 'determined_from_salesforce_identity',
         });
       }
     }

--- a/src/handlers/salesforceRecordQboSync.ts
+++ b/src/handlers/salesforceRecordQboSync.ts
@@ -619,6 +619,7 @@ const salesforceRecordQboSync = async (
 ): Promise<HttpResponseInit> => {
   const dryRun = readBooleanQuery(request, 'dryRun', true);
   const importQboReceipts = readBooleanQuery(request, 'importQboReceipts', false);
+  const debug = readBooleanQuery(request, 'debug', false);
   const salesforceId = await readSalesforceId(request);
   const summary = buildSummary();
 
@@ -630,6 +631,7 @@ const salesforceRecordQboSync = async (
         message: 'salesforceId is required.',
         dryRun,
         importQboReceipts,
+        debug,
         summary,
       },
     };
@@ -637,6 +639,32 @@ const salesforceRecordQboSync = async (
 
   try {
     const dependencies = resolveDependencies();
+    const qboDebugLogger = debug
+      ? (event: {
+          operation: string;
+          stage: 'request' | 'response' | 'error';
+          request?: Record<string, unknown>;
+          response?: unknown;
+          status?: number;
+          error?: string;
+        }) => {
+          context.log('[salesforceRecordQboSync][debug][qbo]', event);
+        }
+      : undefined;
+    const qboQueryWithDebug = (<T = unknown>(queryText: string) =>
+      dependencies.qboQuery<T>(
+        queryText,
+        qboDebugLogger ? { debugLogger: qboDebugLogger } : undefined
+      )) as typeof qboQuery;
+
+    if (debug) {
+      context.log('[salesforceRecordQboSync][debug] request', {
+        method: request.method,
+        salesforceId,
+        dryRun,
+        importQboReceipts,
+      });
+    }
     const connection = await dependencies.getSalesforceConnection();
     const salesforceSvc = dependencies.createSalesforceSvc(connection);
 
@@ -649,6 +677,7 @@ const salesforceRecordQboSync = async (
           message: `No Contact or Account was found for Salesforce ID ${salesforceId}.`,
           dryRun,
           importQboReceipts,
+          debug,
           summary,
         },
       };
@@ -664,7 +693,7 @@ const salesforceRecordQboSync = async (
     const salesforceQboId = toTrimmed(resolvedRecord.record.QuickBooks_ID__c);
     const qboCustomersBySalesforceId = await findQuickBooksCustomersBySalesforceId(
       salesforceId,
-      dependencies.qboQuery
+      qboQueryWithDebug
     );
 
     if (qboCustomersBySalesforceId.length > 1) {
@@ -677,7 +706,7 @@ const salesforceRecordQboSync = async (
     let qboCustomer: QboCustomer | null = null;
 
     if (salesforceQboId) {
-      qboCustomer = await findQuickBooksCustomerById(salesforceQboId, dependencies.qboQuery);
+      qboCustomer = await findQuickBooksCustomerById(salesforceQboId, qboQueryWithDebug);
       if (!qboCustomer) {
         summary.conflicts.push({
           code: 'salesforce_quickbooks_id_not_found',
@@ -725,7 +754,8 @@ const salesforceRecordQboSync = async (
       if (qboCustomerId) {
         try {
           const authoritativeCustomer = (await dependencies.getQuickBooksCustomerById(
-            qboCustomerId
+            qboCustomerId,
+            qboDebugLogger ? { debugLogger: qboDebugLogger } : undefined
           )) as QboCustomer;
           if (authoritativeCustomer) {
             qboCustomer = authoritativeCustomer;
@@ -773,6 +803,7 @@ const salesforceRecordQboSync = async (
           message: `Unable to deterministically resolve a QuickBooks customer for Salesforce ID ${salesforceId}.`,
           dryRun,
           importQboReceipts,
+          debug,
           summary,
         },
       };
@@ -786,6 +817,7 @@ const salesforceRecordQboSync = async (
           message: 'Conflicting Salesforce/QuickBooks linking data was found.',
           dryRun,
           importQboReceipts,
+          debug,
           summary,
         },
       };
@@ -809,7 +841,7 @@ const salesforceRecordQboSync = async (
       const qboDocType = toTrimmed(transaction.QBO_Doc_Type__c) as QuickBooksDocType | null;
 
       if (qboDocId && qboDocType) {
-        const qboDoc = await fetchQuickBooksDocument(qboDocType, qboDocId, dependencies.qboQuery);
+        const qboDoc = await fetchQuickBooksDocument(qboDocType, qboDocId, qboQueryWithDebug);
         if (!qboDoc) {
           summary.conflicts.push({
             code: 'linked_qbo_document_missing',
@@ -867,7 +899,7 @@ const salesforceRecordQboSync = async (
     if (qboCustomerId) {
       salesReceipts = await fetchQuickBooksSalesReceiptsForCustomer(
         qboCustomerId,
-        dependencies.qboQuery
+        qboQueryWithDebug
       );
       const linkedQboIds = new Set(
         transactions.map((transaction) => toTrimmed(transaction.QBO_Doc_Id__c)).filter(Boolean)
@@ -905,7 +937,8 @@ const salesforceRecordQboSync = async (
         if (action.type === 'backfill_qbo_salesforce_id') {
           await dependencies.updateQuickBooksCustomerSalesforceId(
             action.qboCustomerId,
-            action.salesforceId
+            action.salesforceId,
+            qboDebugLogger ? { debugLogger: qboDebugLogger } : undefined
           );
           context.log('[salesforceRecordQboSync] Backfilled QuickBooks Salesforce ID', action);
         }
@@ -1003,6 +1036,7 @@ const salesforceRecordQboSync = async (
         success: true,
         dryRun,
         importQboReceipts,
+        debug,
         summary,
       },
     };
@@ -1020,6 +1054,7 @@ const salesforceRecordQboSync = async (
         details: error instanceof Error ? error.message : String(error),
         dryRun,
         importQboReceipts,
+        debug,
         summary,
       },
     };

--- a/src/handlers/stripeTrueUp.ts
+++ b/src/handlers/stripeTrueUp.ts
@@ -35,10 +35,7 @@ import {
 import { SalesforceService, buildSalesforceConfig } from '../services/salesforceService';
 import { mapStripeToTransaction, type TransactionUpsertDTO } from '../domain/transactions';
 import { ensureSalesforceIdOnCustomer } from '../stripe/utils';
-import {
-  loadConfig,
-  normalizeTransactionCategory,
-} from '../config/contactMatching';
+import { loadConfig, normalizeTransactionCategory } from '../config/contactMatching';
 import {
   fetchStripeChargesSince,
   fetchStripeRefundsSince,
@@ -62,7 +59,7 @@ interface FetchServices {
 
 let qboFunctions: any = null;
 const createNoopAccountingServices = (): AccountingServices => ({
-  postChargeToQbo: async () => ({ success: false, error: 'QBO service not available' } as any),
+  postChargeToQbo: async () => ({ success: false, error: 'QBO service not available' }) as any,
   postRefundToQbo: async () => ({ success: false, error: 'QBO service not available' }),
   postPayoutToQbo: async () => ({ success: false, error: 'QBO service not available' }),
 });
@@ -374,19 +371,18 @@ const extractSalesforceIdFromMetadata = (
   );
 };
 
-const isLikelySalesforceContactId = (value: string): boolean => {
-  const trimmed = value.trim();
-  return /^003[a-zA-Z0-9]{12}(?:[a-zA-Z0-9]{3})?$/.test(trimmed);
-};
+type ResolvedSalesforceReference =
+  | { target: 'Contact'; id: string }
+  | { target: 'Account'; id: string };
 
-const resolveContactIdFromMetadata = async (
+const resolveSalesforceReferenceFromMetadata = async (
   salesforce: SalesforceSvc,
   metadata: Record<string, unknown> | null | undefined,
   contextLog: (...args: unknown[]) => void,
   sourceId: string,
   sourceType: 'charge' | 'refund',
   metadataSource: 'customer' | 'charge' = 'charge'
-): Promise<string | null> => {
+): Promise<ResolvedSalesforceReference | null> => {
   const metadataSalesforceId = extractSalesforceIdFromMetadata(metadata);
   if (!metadataSalesforceId) {
     return null;
@@ -402,8 +398,9 @@ const resolveContactIdFromMetadata = async (
           metadataSource,
           contactId: validatedContactId,
           metadataSalesforceId,
+          matchPath: 'stripe_salesforce_id',
         });
-        return validatedContactId;
+        return { target: 'Contact', id: validatedContactId };
       }
 
       contextLog('[StripeTrueUp] Stripe metadata salesforce_id did not match a Contact', {
@@ -412,26 +409,40 @@ const resolveContactIdFromMetadata = async (
         metadataSource,
         metadataSalesforceId,
       });
-      return null;
     }
 
-    if (isLikelySalesforceContactId(metadataSalesforceId)) {
-      contextLog('[StripeTrueUp] Using Stripe metadata salesforce_id as contact fallback', {
+    if (typeof salesforce.findAccountIdById === 'function') {
+      const validatedAccountId = await salesforce.findAccountIdById(metadataSalesforceId);
+      if (validatedAccountId) {
+        contextLog('[StripeTrueUp] Resolved account from Stripe metadata salesforce_id', {
+          sourceType,
+          sourceId,
+          metadataSource,
+          accountId: validatedAccountId,
+          metadataSalesforceId,
+          matchPath: 'stripe_salesforce_id',
+        });
+        return { target: 'Account', id: validatedAccountId };
+      }
+
+      contextLog('[StripeTrueUp] Stripe metadata salesforce_id did not match an Account', {
         sourceType,
         sourceId,
         metadataSource,
         metadataSalesforceId,
       });
-      return metadataSalesforceId;
     }
   } catch (error) {
-    contextLog('[StripeTrueUp] Failed to resolve contact from Stripe metadata salesforce_id', {
-      sourceType,
-      sourceId,
-      metadataSource,
-      metadataSalesforceId,
-      error: error instanceof Error ? error.message : String(error),
-    });
+    contextLog(
+      '[StripeTrueUp] Failed to resolve Salesforce record from Stripe metadata salesforce_id',
+      {
+        sourceType,
+        sourceId,
+        metadataSource,
+        metadataSalesforceId,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    );
   }
 
   return null;
@@ -800,7 +811,9 @@ const selectBestMatchingContact = (
     return null;
   }
 
-  const stripeIdMatch = candidates.find((contact) => contact.Stripe_Customer_Id__c === stripeCustomer.id);
+  const stripeIdMatch = candidates.find(
+    (contact) => contact.Stripe_Customer_Id__c === stripeCustomer.id
+  );
   if (stripeIdMatch) {
     return stripeIdMatch;
   }
@@ -808,9 +821,11 @@ const selectBestMatchingContact = (
   if (firstName && lastName) {
     const nameMatch = candidates.find((contact) => {
       const firstMatches =
-        typeof contact.FirstName === 'string' && contact.FirstName.toLowerCase() === firstName.toLowerCase();
+        typeof contact.FirstName === 'string' &&
+        contact.FirstName.toLowerCase() === firstName.toLowerCase();
       const lastMatches =
-        typeof contact.LastName === 'string' && contact.LastName.toLowerCase() === lastName.toLowerCase();
+        typeof contact.LastName === 'string' &&
+        contact.LastName.toLowerCase() === lastName.toLowerCase();
       return firstMatches && lastMatches;
     });
 
@@ -887,7 +902,10 @@ const findOrCreateContactInSalesforce = async (
   }
 
   const stripeCustomer = customer as Stripe.Customer;
-  const { customerName, firstName, lastName } = buildContactIdentity(stripeCustomer, transactionName);
+  const { customerName, firstName, lastName } = buildContactIdentity(
+    stripeCustomer,
+    transactionName
+  );
 
   contextLog('[StripeTrueUp] Starting contact find/create process', {
     customerId: stripeCustomer.id,
@@ -1182,8 +1200,7 @@ const processPayments = async (
 
         const customerMetadata =
           stripeCustomer && !stripeCustomer.deleted
-            ? (((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) ||
-              undefined)
+            ? ((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) || undefined
             : undefined;
         const customerMetadataSalesforceId = extractSalesforceIdFromMetadata(customerMetadata);
         const chargeMetadataSalesforceId = extractSalesforceIdFromMetadata(chargeObjectMetadata);
@@ -1216,8 +1233,9 @@ const processPayments = async (
         });
 
         let contactId: string | null = null;
+        let accountId: string | null = null;
         if (metadataSalesforceId && selectedMetadata) {
-          contactId = await resolveContactIdFromMetadata(
+          const resolvedReference = await resolveSalesforceReferenceFromMetadata(
             salesforce,
             selectedMetadata,
             (...args: unknown[]) => context.log(...args),
@@ -1226,9 +1244,15 @@ const processPayments = async (
             metadataSource || 'charge'
           );
 
-          if (!contactId) {
+          if (resolvedReference?.target === 'Contact') {
+            contactId = resolvedReference.id;
+          } else if (resolvedReference?.target === 'Account') {
+            accountId = resolvedReference.id;
+          }
+
+          if (!resolvedReference) {
             context.log(
-              '[StripeTrueUp] Stripe metadata salesforce_id provided but could not be resolved; skipping contact creation fallback',
+              '[StripeTrueUp] Stripe metadata salesforce_id provided but could not be resolved; skipping Salesforce creation fallback',
               {
                 chargeId: charge.id,
                 metadataSalesforceId,
@@ -1237,6 +1261,11 @@ const processPayments = async (
             );
           }
         } else if (stripeCustomer && !stripeCustomer.deleted) {
+          context.log('[StripeTrueUp] Falling back to existing Stripe customer matching flow', {
+            chargeId: charge.id,
+            customerId: stripeCustomer.id,
+            matchPath: 'fallback_match',
+          });
           context.log('[StripeTrueUp] Calling upsertCustomerByStripeId', {
             customerId: stripeCustomer.id,
             customerName: (stripeCustomer as Stripe.Customer).name,
@@ -1257,6 +1286,10 @@ const processPayments = async (
             context.log('[StripeTrueUp] Contact upsert completed', {
               contactId,
               success: !!contactId,
+              matchPath:
+                customerUpsertResult?.created === true
+                  ? 'created_new_salesforce_record'
+                  : 'fallback_match',
             });
 
             if (stripeCustomer && contactId) {
@@ -1371,12 +1404,22 @@ const processPayments = async (
 
         if (contactId) {
           transaction.contact__c = contactId;
+          delete transaction.account__c;
           context.log('[StripeTrueUp] Associated contact with transaction', {
             contactId,
             transactionStripeChargeId: transaction.stripe_charge_id__c,
+            matchPath: 'stripe_salesforce_id',
+          });
+        } else if (accountId) {
+          transaction.account__c = accountId;
+          delete transaction.contact__c;
+          context.log('[StripeTrueUp] Associated account with transaction', {
+            accountId,
+            transactionStripeChargeId: transaction.stripe_charge_id__c,
+            matchPath: 'stripe_salesforce_id',
           });
         } else {
-          context.log('[StripeTrueUp] No contact ID to associate with transaction', {
+          context.log('[StripeTrueUp] No Salesforce record ID to associate with transaction', {
             transactionStripeChargeId: transaction.stripe_charge_id__c,
           });
         }
@@ -1384,7 +1427,9 @@ const processPayments = async (
         context.log('[StripeTrueUp] Upserting transaction to Salesforce', {
           chargeId: charge.id,
           contactId: transaction.contact__c,
+          accountId: transaction.account__c,
           hasContact: !!transaction.contact__c,
+          hasAccount: !!transaction.account__c,
         });
 
         if (
@@ -1590,6 +1635,7 @@ const processRefunds = async (
           (chargeFragment?.metadata as Record<string, unknown> | undefined) || undefined;
 
         let contactId: string | null = null;
+        let accountId: string | null = null;
         let stripeCustomer: Stripe.Customer | Stripe.DeletedCustomer | null = null;
 
         if (chargeFragment && chargeFragment.customer) {
@@ -1602,8 +1648,7 @@ const processRefunds = async (
 
         const customerMetadata =
           stripeCustomer && !stripeCustomer.deleted
-            ? (((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) ||
-              undefined)
+            ? ((stripeCustomer as Stripe.Customer).metadata as Record<string, unknown>) || undefined
             : undefined;
         const customerMetadataSalesforceId = extractSalesforceIdFromMetadata(customerMetadata);
         const chargeMetadataSalesforceId = extractSalesforceIdFromMetadata(chargeMetadata);
@@ -1626,7 +1671,7 @@ const processRefunds = async (
               : null;
 
         if (metadataSalesforceId && selectedMetadata) {
-          contactId = await resolveContactIdFromMetadata(
+          const resolvedReference = await resolveSalesforceReferenceFromMetadata(
             salesforce,
             selectedMetadata,
             (...args: unknown[]) => context.log(...args),
@@ -1635,9 +1680,15 @@ const processRefunds = async (
             metadataSource || 'charge'
           );
 
-          if (!contactId) {
+          if (resolvedReference?.target === 'Contact') {
+            contactId = resolvedReference.id;
+          } else if (resolvedReference?.target === 'Account') {
+            accountId = resolvedReference.id;
+          }
+
+          if (!resolvedReference) {
             context.log(
-              '[StripeTrueUp] Stripe metadata salesforce_id provided on refund charge but could not be resolved; skipping contact creation fallback',
+              '[StripeTrueUp] Stripe metadata salesforce_id provided on refund charge but could not be resolved; skipping Salesforce creation fallback',
               {
                 refundId: refund.id,
                 chargeId: chargeFragment?.id ?? chargeId,
@@ -1647,6 +1698,15 @@ const processRefunds = async (
             );
           }
         } else if (chargeFragment && chargeFragment.customer) {
+          context.log(
+            '[StripeTrueUp] Falling back to existing Stripe customer matching flow for refund',
+            {
+              refundId: refund.id,
+              chargeId: chargeFragment.id,
+              customerId: extractStripeId(chargeFragment.customer),
+              matchPath: 'fallback_match',
+            }
+          );
           context.log('[StripeTrueUp] Processing refund customer', {
             refundId: refund.id,
             chargeId: chargeFragment.id,
@@ -1686,6 +1746,10 @@ const processRefunds = async (
                 refundId: refund.id,
                 contactId,
                 success: !!contactId,
+                matchPath:
+                  customerUpsertResult?.created === true
+                    ? 'created_new_salesforce_record'
+                    : 'fallback_match',
               });
             } catch (error) {
               context.log('[StripeTrueUp] Failed to upsert contact for refund', {
@@ -1750,20 +1814,35 @@ const processRefunds = async (
 
         if (contactId) {
           transaction.contact__c = contactId;
+          delete transaction.account__c;
           context.log('[StripeTrueUp] Associated contact with refund transaction', {
             contactId,
             refundId: refund.id,
+            matchPath: 'stripe_salesforce_id',
+          });
+        } else if (accountId) {
+          transaction.account__c = accountId;
+          delete transaction.contact__c;
+          context.log('[StripeTrueUp] Associated account with refund transaction', {
+            accountId,
+            refundId: refund.id,
+            matchPath: 'stripe_salesforce_id',
           });
         } else {
-          context.log('[StripeTrueUp] No contact ID to associate with refund transaction', {
-            refundId: refund.id,
-          });
+          context.log(
+            '[StripeTrueUp] No Salesforce record ID to associate with refund transaction',
+            {
+              refundId: refund.id,
+            }
+          );
         }
 
         context.log('[StripeTrueUp] Upserting refund transaction to Salesforce', {
           refundId: refund.id,
           contactId: transaction.contact__c,
+          accountId: transaction.account__c,
           hasContact: !!transaction.contact__c,
+          hasAccount: !!transaction.account__c,
         });
 
         if (
@@ -2100,9 +2179,7 @@ const validateEnvironment = (
       errors.push('QBO_CLIENT_SECRET is not configured (QuickBooks sync will fail)');
     }
     if (!process.env.QBO_REALM_ID && !process.env.QBO_COMPANY_ID) {
-      errors.push(
-        'QBO_REALM_ID or QBO_COMPANY_ID is not configured (QuickBooks sync will fail)'
-      );
+      errors.push('QBO_REALM_ID or QBO_COMPANY_ID is not configured (QuickBooks sync will fail)');
     }
   }
 
@@ -2122,7 +2199,10 @@ const stripeTrueUp = async (req: HttpRequest, context: InvocationContext): Promi
 
     const bypassQboDefault = parseBoolean(process.env.STRIPE_TRUE_UP_BYPASS_QBO, false);
     const bypassQboParam =
-      query.bypassQbo ?? query.skipQbo ?? getHeader(req, 'x-bypass-qbo') ?? getHeader(req, 'x-skip-qbo');
+      query.bypassQbo ??
+      query.skipQbo ??
+      getHeader(req, 'x-bypass-qbo') ??
+      getHeader(req, 'x-skip-qbo');
     const bypassQbo = parseBoolean(bypassQboParam, bypassQboDefault);
 
     const defaultLiveMode = process.env.STRIPE_TRUE_UP_MODE === 'live';
@@ -2223,27 +2303,9 @@ const stripeTrueUp = async (req: HttpRequest, context: InvocationContext): Promi
         limit
       );
     } else if (type === 'refunds') {
-      summary = await processRefunds(
-        context,
-        stripe,
-        from,
-        to,
-        dryRun,
-        resubmit,
-        bypassQbo,
-        limit
-      );
+      summary = await processRefunds(context, stripe, from, to, dryRun, resubmit, bypassQbo, limit);
     } else {
-      summary = await processPayouts(
-        context,
-        stripe,
-        from,
-        to,
-        dryRun,
-        resubmit,
-        bypassQbo,
-        limit
-      );
+      summary = await processPayouts(context, stripe, from, to, dryRun, resubmit, bypassQbo, limit);
     }
 
     if (!dryRun) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -200,6 +200,7 @@ const SalesforceRecordQboSyncQuerySchema = z
     salesforceId: z.string(),
     dryRun: BoolLikeQuerySchema.optional(),
     importQboReceipts: BoolLikeQuerySchema.optional(),
+    debug: BoolLikeQuerySchema.optional(),
   })
   .passthrough();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,12 @@ const stripeTrueUp = stripeTrueUpModule.default || stripeTrueUpModule;
 const manualQboSyncModule = require('./handlers/manualQboSync');
 const manualQboSync = manualQboSyncModule.default || manualQboSyncModule;
 const salesforcePaymentsSyncModule = require('./handlers/salesforcePaymentsSync');
-const salesforcePaymentsSync =
-  salesforcePaymentsSyncModule.default || salesforcePaymentsSyncModule;
+const salesforcePaymentsSync = salesforcePaymentsSyncModule.default || salesforcePaymentsSyncModule;
 const qboCustomersSyncModule = require('./handlers/qboCustomersSync');
 const qboCustomersSync = qboCustomersSyncModule.default || qboCustomersSyncModule;
+const salesforceRecordQboSyncModule = require('./handlers/salesforceRecordQboSync');
+const salesforceRecordQboSync =
+  salesforceRecordQboSyncModule.default || salesforceRecordQboSyncModule;
 const eventRegistrationModule = require('./handlers/eventRegistration');
 const eventRegistration = eventRegistrationModule.default || eventRegistrationModule;
 const eventCheckInModule = require('./handlers/eventCheckIn');
@@ -190,6 +192,14 @@ const QboCustomersSyncQuerySchema = z
     maxRuntimeMs: PositiveIntLikeSchema.optional(),
     includeInactive: BoolLikeQuerySchema.optional(),
     exampleLimit: PositiveIntLikeSchema.optional(),
+  })
+  .passthrough();
+
+const SalesforceRecordQboSyncQuerySchema = z
+  .object({
+    salesforceId: z.string(),
+    dryRun: BoolLikeQuerySchema.optional(),
+    importQboReceipts: BoolLikeQuerySchema.optional(),
   })
   .passthrough();
 
@@ -365,6 +375,32 @@ registerFunction('qboCustomersSync', 'QBO customer sync to Salesforce contacts',
   },
 });
 
+registerFunction(
+  'salesforceRecordQboSync',
+  'Sync QuickBooks and Salesforce for one Salesforce record',
+  {
+    handler: salesforceRecordQboSync,
+    description:
+      'Resolves a Salesforce Contact or Account by Id, links the matching QuickBooks customer, syncs supported transactions, and can optionally import unmatched QBO sales receipts into Salesforce with a dry-run summary.',
+    tags: ['QBO', 'Salesforce'],
+    security: functionAuthSecurity,
+    methods: ['GET', 'POST'],
+    authLevel: 'function',
+    azureFunctionRoutePrefix: 'api',
+    route: 'qbo/salesforce-record-sync',
+    request: {
+      query: SalesforceRecordQboSyncQuerySchema,
+    },
+    responses: {
+      200: { description: 'Single-record sync completed' },
+      400: { description: 'Invalid sync request' },
+      404: { description: 'Salesforce record not found' },
+      409: { description: 'Link conflict or unresolved customer' },
+      500: { description: 'Single-record sync failed' },
+    },
+  }
+);
+
 // define simple event registration schema
 const EventRegistrationSchema = z.object({
   eventId: z.string(),
@@ -412,12 +448,9 @@ const EventCheckInSchema = z
     email: z.string().email().optional(),
     eventId: z.string().optional(),
   })
-  .refine(
-    (data) => !!data.registrationId || (data.email && data.eventId),
-    {
-      message: 'registrationId or both email and eventId must be supplied',
-    }
-  );
+  .refine((data) => !!data.registrationId || (data.email && data.eventId), {
+    message: 'registrationId or both email and eventId must be supplied',
+  });
 
 registerFunction('eventCheckIn', 'Check in an event attendee', {
   handler: eventCheckIn,
@@ -532,6 +565,7 @@ export {
   manualQboSync,
   salesforcePaymentsSync,
   qboCustomersSync,
+  salesforceRecordQboSync,
   eventRegistration,
   eventCheckIn,
 };

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -167,6 +167,14 @@ export interface QuickBooksBankDeposit {
 interface PostOptions {
   fetcher?: Fetcher;
   accessToken?: string;
+  debugLogger?: (event: {
+    operation: string;
+    stage: 'request' | 'response' | 'error';
+    request?: Record<string, unknown>;
+    response?: unknown;
+    status?: number;
+    error?: string;
+  }) => void;
 }
 
 interface PostResult {
@@ -882,7 +890,8 @@ const findCustomerByDisplayName = async (
 
 const fetchQuickBooksCustomer = async (
   id: string,
-  context: QuickBooksRequestContext
+  context: QuickBooksRequestContext,
+  debugLogger?: PostOptions['debugLogger']
 ): Promise<Record<string, unknown>> => {
   const trimmedId = id.trim();
   if (!trimmedId) {
@@ -890,6 +899,15 @@ const fetchQuickBooksCustomer = async (
   }
 
   const url = `${buildQboUrl('customer')}/${encodeURIComponent(trimmedId)}`;
+  debugLogger?.({
+    operation: 'getQuickBooksCustomerById',
+    stage: 'request',
+    request: {
+      method: 'GET',
+      url,
+      customerId: trimmedId,
+    },
+  });
   const response = await context.request(url, {
     method: 'GET',
     headers: { Accept: 'application/json' },
@@ -897,6 +915,17 @@ const fetchQuickBooksCustomer = async (
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => undefined);
+    debugLogger?.({
+      operation: 'getQuickBooksCustomerById',
+      stage: 'error',
+      status: response.status,
+      request: {
+        method: 'GET',
+        url,
+        customerId: trimmedId,
+      },
+      error: errorText ?? response.statusText,
+    });
     throw new Error(
       `Failed to load QuickBooks customer "${trimmedId}" (status ${response.status}): ${
         errorText ?? response.statusText
@@ -914,6 +943,18 @@ const fetchQuickBooksCustomer = async (
     throw new Error('QuickBooks customer response did not include a Customer record.');
   }
 
+  debugLogger?.({
+    operation: 'getQuickBooksCustomerById',
+    stage: 'response',
+    status: response.status,
+    request: {
+      method: 'GET',
+      url,
+      customerId: trimmedId,
+    },
+    response: customer,
+  });
+
   return customer;
 };
 
@@ -922,15 +963,16 @@ export const getQuickBooksCustomerById = async (
   options?: PostOptions
 ): Promise<Record<string, unknown>> => {
   const context = await createRequestContext(options);
-  return fetchQuickBooksCustomer(id, context);
+  return fetchQuickBooksCustomer(id, context, options?.debugLogger);
 };
 
 const updateQuickBooksCustomer = async (
   id: string,
   updates: Record<string, unknown>,
-  context: QuickBooksRequestContext
+  context: QuickBooksRequestContext,
+  debugLogger?: PostOptions['debugLogger']
 ): Promise<Record<string, unknown>> => {
-  const customer = await fetchQuickBooksCustomer(id, context);
+  const customer = await fetchQuickBooksCustomer(id, context, debugLogger);
   const syncTokenRaw = customer.SyncToken;
   const syncToken =
     typeof syncTokenRaw === 'number'
@@ -951,6 +993,16 @@ const updateQuickBooksCustomer = async (
   };
 
   const url = `${buildQboUrl('customer')}?operation=update`;
+  debugLogger?.({
+    operation: 'updateQuickBooksCustomer',
+    stage: 'request',
+    request: {
+      method: 'POST',
+      url,
+      customerId: id,
+      payload,
+    },
+  });
   const response = await context.request(url, {
     method: 'POST',
     headers: {
@@ -962,6 +1014,18 @@ const updateQuickBooksCustomer = async (
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => undefined);
+    debugLogger?.({
+      operation: 'updateQuickBooksCustomer',
+      stage: 'error',
+      status: response.status,
+      request: {
+        method: 'POST',
+        url,
+        customerId: id,
+        payload,
+      },
+      error: errorText ?? response.statusText,
+    });
     throw new Error(
       `Failed to update QuickBooks customer "${id}" (status ${response.status}): ${
         errorText ?? response.statusText
@@ -979,6 +1043,19 @@ const updateQuickBooksCustomer = async (
     throw new Error('QuickBooks customer update response did not include a Customer record.');
   }
 
+  debugLogger?.({
+    operation: 'updateQuickBooksCustomer',
+    stage: 'response',
+    status: response.status,
+    request: {
+      method: 'POST',
+      url,
+      customerId: id,
+      payload,
+    },
+    response: updated,
+  });
+
   return updated;
 };
 
@@ -993,7 +1070,7 @@ export const updateQuickBooksCustomerSalesforceId = async (
   }
 
   const context = await createRequestContext(options);
-  const customer = await fetchQuickBooksCustomer(id, context);
+  const customer = await fetchQuickBooksCustomer(id, context, options?.debugLogger);
   const customFields = Array.isArray(customer.CustomField)
     ? (customer.CustomField as QuickBooksCustomField[])
     : [];
@@ -1017,7 +1094,8 @@ export const updateQuickBooksCustomerSalesforceId = async (
         } satisfies QuickBooksCustomField,
       ],
     },
-    context
+    context,
+    options?.debugLogger
   );
 };
 
@@ -3636,6 +3714,15 @@ export const query = async <T = unknown>(query: string, options?: PostOptions): 
 
   const url = buildQboQueryUrl(trimmedQuery);
   const context = await createRequestContext(options);
+  options?.debugLogger?.({
+    operation: 'query',
+    stage: 'request',
+    request: {
+      method: 'GET',
+      url,
+      query: trimmedQuery,
+    },
+  });
   const response = await context.request(url, {
     method: 'GET',
     headers: {
@@ -3645,6 +3732,17 @@ export const query = async <T = unknown>(query: string, options?: PostOptions): 
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => undefined);
+    options?.debugLogger?.({
+      operation: 'query',
+      stage: 'error',
+      status: response.status,
+      request: {
+        method: 'GET',
+        url,
+        query: trimmedQuery,
+      },
+      error: errorText ?? response.statusText,
+    });
     throw new Error(
       `QuickBooks query failed (status ${response.status}): ${errorText ?? response.statusText}`
     );
@@ -3657,6 +3755,17 @@ export const query = async <T = unknown>(query: string, options?: PostOptions): 
       : undefined;
 
   if (!queryResponse) {
+    options?.debugLogger?.({
+      operation: 'query',
+      stage: 'response',
+      status: response.status,
+      request: {
+        method: 'GET',
+        url,
+        query: trimmedQuery,
+      },
+      response: data,
+    });
     return data as T;
   }
 
@@ -3665,9 +3774,31 @@ export const query = async <T = unknown>(query: string, options?: PostOptions): 
   );
 
   if (!values) {
+    options?.debugLogger?.({
+      operation: 'query',
+      stage: 'response',
+      status: response.status,
+      request: {
+        method: 'GET',
+        url,
+        query: trimmedQuery,
+      },
+      response: [],
+    });
     return [] as T;
   }
 
+  options?.debugLogger?.({
+    operation: 'query',
+    stage: 'response',
+    status: response.status,
+    request: {
+      method: 'GET',
+      url,
+      query: trimmedQuery,
+    },
+    response: values,
+  });
   return values as T;
 };
 

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -898,7 +898,7 @@ const fetchQuickBooksCustomer = async (
     throw new Error('QuickBooks customer ID is required to load customer details.');
   }
 
-  const url = `${buildQboUrl('customer')}/${encodeURIComponent(trimmedId)}`;
+  const url = buildQboCustomerReadUrl(trimmedId);
   debugLogger?.({
     operation: 'getQuickBooksCustomerById',
     stage: 'request',
@@ -2142,6 +2142,13 @@ const buildQboUrl = (entity: string): string => {
   const base = QBO_BASE_URL[env.quickBooks.environment];
   const realmId = getRealmId();
   return `${base}/${encodeURIComponent(realmId)}/${entity}`;
+};
+
+const buildQboCustomerReadUrl = (customerId: string): string => {
+  const url = new URL(`${buildQboUrl('customer')}/${encodeURIComponent(customerId)}`);
+  url.searchParams.set('minorversion', '75');
+  url.searchParams.set('include', 'enhancedAllCustomFields');
+  return url.toString();
 };
 
 const accountLookupCache = new Map<string, string>();

--- a/src/services/qboSvc.ts
+++ b/src/services/qboSvc.ts
@@ -77,6 +77,13 @@ interface QuickBooksEmailAddress {
   Address: string;
 }
 
+interface QuickBooksCustomField {
+  DefinitionId?: string;
+  Name?: string;
+  Type?: string;
+  StringValue?: string;
+}
+
 interface QuickBooksPhysicalAddress {
   Line1?: string;
   Line2?: string;
@@ -117,7 +124,7 @@ export interface QuickBooksSalesReceipt {
   ShipAddr?: QuickBooksPhysicalAddress;
   ClassRef?: QuickBooksReference;
   Line: QuickBooksSalesReceiptLine[];
-} 
+}
 
 interface QuickBooksJournalEntryLineDetail {
   PostingType: 'Debit' | 'Credit';
@@ -189,7 +196,7 @@ interface BuildSalesReceiptInput {
   lineAmountCents?: number;
   lineServiceDate?: string;
   lineClassRef?: string;
-} 
+}
 
 type StripeCustomerContext = {
   charge?: Stripe.Charge | null;
@@ -857,14 +864,16 @@ const findCustomerByDisplayName = async (
     customers.find((customer) => {
       const name = customer?.DisplayName;
       return (
-        typeof name === 'string' && name.trim().toLowerCase() === normalizedDisplayName.toLowerCase()
+        typeof name === 'string' &&
+        name.trim().toLowerCase() === normalizedDisplayName.toLowerCase()
       );
     }) ?? null;
 
   const reference = extractReferenceFromRecord(existing, 'Id', 'DisplayName');
   if (reference) {
     const recordEmail = (existing?.PrimaryEmailAddr as { Address?: string } | undefined)?.Address;
-    const normalizedEmail = typeof recordEmail === 'string' ? recordEmail.trim().toLowerCase() : null;
+    const normalizedEmail =
+      typeof recordEmail === 'string' ? recordEmail.trim().toLowerCase() : null;
     cacheCustomerReference(reference, normalizedEmail, normalizedDisplayName);
   }
 
@@ -906,6 +915,14 @@ const fetchQuickBooksCustomer = async (
   }
 
   return customer;
+};
+
+export const getQuickBooksCustomerById = async (
+  id: string,
+  options?: PostOptions
+): Promise<Record<string, unknown>> => {
+  const context = await createRequestContext(options);
+  return fetchQuickBooksCustomer(id, context);
 };
 
 const updateQuickBooksCustomer = async (
@@ -963,6 +980,45 @@ const updateQuickBooksCustomer = async (
   }
 
   return updated;
+};
+
+export const updateQuickBooksCustomerSalesforceId = async (
+  id: string,
+  salesforceId: string,
+  options?: PostOptions
+): Promise<Record<string, unknown>> => {
+  const trimmedSalesforceId = salesforceId.trim();
+  if (!trimmedSalesforceId) {
+    throw new Error('Salesforce ID is required to update the QuickBooks customer.');
+  }
+
+  const context = await createRequestContext(options);
+  const customer = await fetchQuickBooksCustomer(id, context);
+  const customFields = Array.isArray(customer.CustomField)
+    ? (customer.CustomField as QuickBooksCustomField[])
+    : [];
+  const salesforceField = customFields.find((field) => field?.Name === 'Salesforce ID');
+
+  if (!salesforceField?.DefinitionId) {
+    throw new Error(
+      'QuickBooks customer does not expose a "Salesforce ID" custom field definition.'
+    );
+  }
+
+  return updateQuickBooksCustomer(
+    id,
+    {
+      CustomField: [
+        {
+          DefinitionId: salesforceField.DefinitionId,
+          Name: salesforceField.Name,
+          Type: salesforceField.Type,
+          StringValue: trimmedSalesforceId,
+        } satisfies QuickBooksCustomField,
+      ],
+    },
+    context
+  );
 };
 
 const ensureSalesReceiptCustomer = async (
@@ -1757,12 +1813,15 @@ export const buildSalesReceipt = ({
   if (stripeFee > 0) {
     const stripeFeeAmount = -centsToDollars(stripeFee);
     if (!Number.isFinite(stripeFeeAmount)) {
-      throw new Error(`Invalid stripe fee amount calculated for sales receipt: ${stripeFeeAmount} (from ${stripeFee} cents)`);
+      throw new Error(
+        `Invalid stripe fee amount calculated for sales receipt: ${stripeFeeAmount} (from ${stripeFee} cents)`
+      );
     }
 
-    const feeItemAccountRef = typeof feesAccountName === 'string' && feesAccountName.trim()
-      ? createAccountRef(feesAccountName)
-      : undefined;
+    const feeItemAccountRef =
+      typeof feesAccountName === 'string' && feesAccountName.trim()
+        ? createAccountRef(feesAccountName)
+        : undefined;
 
     lines.push({
       Amount: stripeFeeAmount,
@@ -1841,10 +1900,12 @@ export const buildSalesReceipt = ({
       receipt.CustomerMemo = { value: truncated };
     }
   } catch (e) {
-    logger.debug('Failed to build CustomerMemo for sales receipt', { error: e instanceof Error ? e.message : String(e) });
+    logger.debug('Failed to build CustomerMemo for sales receipt', {
+      error: e instanceof Error ? e.message : String(e),
+    });
   }
 
-  return receipt; 
+  return receipt;
 };
 
 const createJournalEntryLine = (
@@ -2122,7 +2183,9 @@ const findAccountRecordByName = async (
     accounts.find((account) => {
       const name = account?.Name;
       return typeof name === 'string' && name.trim().toLowerCase() === normalizedName.toLowerCase();
-    }) ?? accounts[0] ?? null
+    }) ??
+    accounts[0] ??
+    null
   );
 };
 
@@ -3079,9 +3142,13 @@ export const postChargeToQbo = async ({
       feesAccountName: feesAccountRef.value,
       stripeFeeAmountCents: feeAmount,
       stripeChargeId: stripe?.charge?.id ?? null,
-      stripeInvoiceId: typeof stripe?.charge?.invoice === 'string' ? (stripe as any).charge.invoice : null,
+      stripeInvoiceId:
+        typeof stripe?.charge?.invoice === 'string' ? (stripe as any).charge.invoice : null,
       stripeInvoiceNumber: (stripe?.checkoutSession as any)?.invoice?.number ?? null,
-      stripeSubscriptionId: (stripe?.checkoutSession as any)?.subscription ?? (stripe?.paymentIntent as any)?.subscription ?? null,
+      stripeSubscriptionId:
+        (stripe?.checkoutSession as any)?.subscription ??
+        (stripe?.paymentIntent as any)?.subscription ??
+        null,
       customer: receiptCustomer,
       description,
       coverFeesAmountCents,
@@ -3396,7 +3463,11 @@ export const ensureAccount = async (
       const accountId = account.Id;
       const accountResolvedName = account.Name;
       const resolvedId =
-        typeof accountId === 'number' ? accountId.toString() : typeof accountId === 'string' ? accountId.trim() : null;
+        typeof accountId === 'number'
+          ? accountId.toString()
+          : typeof accountId === 'string'
+            ? accountId.trim()
+            : null;
       const resolvedName =
         typeof accountResolvedName === 'string' && accountResolvedName.trim()
           ? accountResolvedName.trim()
@@ -3450,7 +3521,11 @@ export const ensureAccount = async (
 
       // If account type is specified and doesn't match, throw an error
       // Special case: allow "Undeposited Funds" to be used even if type doesn't match
-      if (accountType && account.AccountType !== accountType && accountName !== 'Undeposited Funds') {
+      if (
+        accountType &&
+        account.AccountType !== accountType &&
+        accountName !== 'Undeposited Funds'
+      ) {
         const errorMsg = `Account "${accountName}" exists but is type "${account.AccountType}". For this operation, a "${accountType}" account is required. Please use a different account or create a new one with the correct type.`;
         logger.error('Account type mismatch - operation cannot proceed', {
           accountName,
@@ -3615,8 +3690,13 @@ export const queryReference = async (
     const entity =
       entities.find((candidate) => {
         const candidateName = candidate?.Name;
-        return typeof candidateName === 'string' && candidateName.trim().toLowerCase() === name.trim().toLowerCase();
-      }) ?? entities[0] ?? null;
+        return (
+          typeof candidateName === 'string' &&
+          candidateName.trim().toLowerCase() === name.trim().toLowerCase()
+        );
+      }) ??
+      entities[0] ??
+      null;
 
     const reference = extractReferenceFromRecord(entity, 'Id', 'Name');
     if (reference) {
@@ -3743,5 +3823,7 @@ export default {
   ensureAccount,
   queryReference,
   ensureReference,
+  getQuickBooksCustomerById,
+  updateQuickBooksCustomerSalesforceId,
   query,
 };

--- a/src/services/salesforce/salesforceCrm.js
+++ b/src/services/salesforce/salesforceCrm.js
@@ -16,6 +16,20 @@ class SalesforceCrmService extends BaseCrmService {
     return String(value).replace(/'/g, "\\'");
   }
 
+  toSoqlDateTimeLiteral(value) {
+    const normalizedValue = String(value ?? '').trim();
+    if (!normalizedValue) {
+      return null;
+    }
+
+    const parsedDate = new Date(normalizedValue);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return null;
+    }
+
+    return parsedDate.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  }
+
   getQueryRecords(result) {
     if (!result || !Array.isArray(result.records)) {
       return [];
@@ -105,10 +119,15 @@ class SalesforceCrmService extends BaseCrmService {
       return null;
     }
 
+    const receivedAtLiteral = this.toSoqlDateTimeLiteral(received);
+    if (!receivedAtLiteral) {
+      return null;
+    }
+
     let soql =
       `SELECT Id FROM Transaction__c WHERE Contact__c = '${this.escapeSoqlLiteral(contact)}'` +
       ` AND Amount_Gross__c = ${amount}` +
-      ` AND Received_At__c = ${this.escapeSoqlLiteral(received)}`;
+      ` AND Received_At__c = ${receivedAtLiteral}`;
 
     if (transactionData.RecordTypeId) {
       soql += ` AND RecordTypeId = '${this.escapeSoqlLiteral(transactionData.RecordTypeId)}'`;

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -58,7 +58,8 @@ export type TransactionExternalIdField =
   | 'stripe_subscription_id__c'
   | 'stripe_invoice_id__c'
   | 'stripe_credit_note_id__c'
-  | 'stripe_payout_id__c';
+  | 'stripe_payout_id__c'
+  | 'qbo_doc_id__c';
 
 const TRANSACTION_EXTERNAL_ID_FIELDS: TransactionExternalIdField[] = [
   'stripe_payment_intent_id__c',
@@ -70,6 +71,7 @@ const TRANSACTION_EXTERNAL_ID_FIELDS: TransactionExternalIdField[] = [
   'stripe_subscription_id__c',
   'stripe_invoice_id__c',
   'stripe_credit_note_id__c',
+  'qbo_doc_id__c',
 ];
 
 export interface QuickBooksDocumentReference {
@@ -113,6 +115,7 @@ export interface SalesforceSvc {
   ) => Promise<{ id: string; contactId: string | null } | null>;
   upsertCustomerByStripeId: (dto: CustomerUpsertDTO) => Promise<UpsertResult>;
   findContactIdById?: (contactId: string) => Promise<string | null>;
+  findAccountIdById?: (accountId: string) => Promise<string | null>;
 }
 
 type TransactionRecordInput = Partial<TransactionUpsertDTO> & {
@@ -341,9 +344,12 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     const received = dto.received_at__c;
 
     if (
-      typeof contact === 'string' && contact.trim().length > 0 &&
-      typeof amount === 'number' && !Number.isNaN(amount) &&
-      typeof received === 'string' && received.trim().length > 0
+      typeof contact === 'string' &&
+      contact.trim().length > 0 &&
+      typeof amount === 'number' &&
+      !Number.isNaN(amount) &&
+      typeof received === 'string' &&
+      received.trim().length > 0
     ) {
       const escapedContact = escapeForSoqlLiteral(contact.trim());
       const escapedReceived = escapeForSoqlLiteral(received.trim());
@@ -800,6 +806,20 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     return record?.Id ?? null;
   };
 
+  const findAccountIdById = async (accountId: string): Promise<string | null> => {
+    const normalizedId = ensureNonEmpty(accountId, 'Account ID');
+    const escapedId = escapeForSoqlLiteral(normalizedId);
+    const result = await connection.query<{ Id?: string }>(
+      `SELECT Id FROM Account WHERE Id = '${escapedId}' LIMIT 1`
+    );
+    const records = toLookupRecords(result);
+    const record = records.find(
+      (candidate): candidate is { Id: string } =>
+        typeof candidate.Id === 'string' && candidate.Id.trim().length > 0
+    );
+    return record?.Id ?? null;
+  };
+
   return {
     upsertTransactionByExternalId,
     linkPayoutOnTransactions,
@@ -808,6 +828,7 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
     findTransactionRecordByExternalId,
     upsertCustomerByStripeId,
     findContactIdById,
+    findAccountIdById,
   };
 };
 

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -238,6 +238,20 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
   const escapeForSoqlLiteral = (value: string): string =>
     value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
 
+  const toSoqlDateTimeLiteral = (value: string): string | null => {
+    const normalizedValue = value.trim();
+    if (!normalizedValue) {
+      return null;
+    }
+
+    const parsedDate = new Date(normalizedValue);
+    if (Number.isNaN(parsedDate.getTime())) {
+      return null;
+    }
+
+    return parsedDate.toISOString().replace(/\.\d{3}Z$/, 'Z');
+  };
+
   const toLookupRecords = (result: unknown): TransactionLookupRecord[] => {
     if (Array.isArray(result)) {
       return result as TransactionLookupRecord[];
@@ -352,11 +366,15 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
       received.trim().length > 0
     ) {
       const escapedContact = escapeForSoqlLiteral(contact.trim());
-      const escapedReceived = escapeForSoqlLiteral(received.trim());
+      const receivedAtLiteral = toSoqlDateTimeLiteral(received);
+      if (!receivedAtLiteral) {
+        return null;
+      }
+
       let soql =
         `SELECT Id FROM ${TRANSACTION_OBJECT} WHERE Contact__c = '${escapedContact}'` +
         ` AND Amount_Gross__c = ${amount}` +
-        ` AND Received_At__c = ${escapedReceived}`;
+        ` AND Received_At__c = ${receivedAtLiteral}`;
 
       if (recordTypeId) {
         const escapedRecordTypeId = escapeForSoqlLiteral(recordTypeId);

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -150,6 +150,10 @@ const resolveFieldApiName = (field: keyof TransactionRecordInput): string => {
 const sanitizeTransactionRecord = (input: TransactionRecordInput): TransactionRecord => {
   const record: TransactionRecord = {};
   for (const key of Object.keys(input) as Array<keyof TransactionRecordInput>) {
+    if (key === 'Name') {
+      continue;
+    }
+
     const value = input[key];
     if (value === undefined) {
       continue;

--- a/src/services/salesforceSvc.ts
+++ b/src/services/salesforceSvc.ts
@@ -271,6 +271,9 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
   const buildInLiteralList = (values: string[]): string =>
     values.map((value) => `'${escapeForSoqlLiteral(value)}'`).join(',');
 
+  const isUnsupportedExternalIdFieldError = (message: string): boolean =>
+    message.includes('does not match an External ID, Salesforce Id, or indexed field');
+
   const resolveRecordTypeId = async (
     recordTypeName: string,
     sObject: string = TRANSACTION_OBJECT
@@ -440,13 +443,17 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
       })
     );
     if (!result.success) {
+      const unsupportedExternalIdFieldError = result.errors.find(
+        (error) =>
+          typeof error?.message === 'string' && isUnsupportedExternalIdFieldError(error.message)
+      );
       const duplicateError = result.errors.find(
         (error) =>
           typeof error?.message === 'string' &&
           error.message.includes('more than one record found for external id field')
       );
 
-      if (duplicateError) {
+      if (duplicateError || unsupportedExternalIdFieldError) {
         const fallbackId = await resolveExistingTransactionId(
           key,
           normalizedExternalId,
@@ -481,7 +488,7 @@ export const createSalesforceSvc = ({ connection }: SalesforceSvcOptions): Sales
           const newRecord = sanitizeTransactionRecord({
             ...dto,
             RecordTypeId: recordTypeId,
-            [key]: undefined,
+            [key]: duplicateError ? undefined : normalizedExternalId,
           });
 
           const [insertResult] = toArray(


### PR DESCRIPTION
### Motivation
- Provide a single-record sync endpoint to reconcile a Salesforce Contact/Account with QuickBooks and to allow safe backfills and document synchronizations via a dry-run summary. 
- Improve deterministic linking between QuickBooks customers and Salesforce records by honoring the QuickBooks custom field `Salesforce ID` and Salesforce `QuickBooks_ID__c` when present. 
- Make Stripe-to-Salesforce metadata handling more robust by resolving `salesforce_id` metadata to either `Contact` or `Account` and associating transactions accordingly. 

### Description
- Add a new handler `salesforceRecordQboSync` that resolves a Salesforce Contact or Account by Id, finds the linked QuickBooks customer (including authoritative reads), builds a dry-run `summary` with planned backfills/creates/updates/conflicts, and performs backfills/creates/updates when not in dry-run; this handler is registered at `api/qbo/salesforce-record-sync` and covered by a new test file `__tests__/salesforceRecordQboSync.test.ts`.
- Extend `qboCustomersSync` to read QuickBooks `CustomField` (Salesforce ID), prefer validating that value as a `Contact` before checking `Account`, support finding Salesforce records by `QuickBooks_ID__c`, and backfill QuickBooks with Salesforce Ids via a new dependency `updateQboCustomerSalesforceId`; updated behavior is exercised by expanded tests in `__tests__/qboCustomersSync.test.ts`.
- Add `updateQuickBooksCustomerSalesforceId` and `getQuickBooksCustomerById` exports to `src/services/qboSvc.ts` to enable authoritative reads and updates of the QuickBooks customer `Salesforce ID` custom field.
- Improve `stripeTrueUp` metadata resolution by replacing `resolveContactIdFromMetadata` with `resolveSalesforceReferenceFromMetadata` which can validate metadata to either `Contact` or `Account`; propagate that resolved reference into transaction payloads and logs; add a new test exercising account metadata handling in `__tests__/stripeTrueUp.test.ts`.
- Add `findAccountIdById` to the Salesforce service wrapper in `src/services/salesforceSvc.ts` and expose it on the `SalesforceSvc` interface to allow account validation lookups.
- Miscellaneous refactors and formatting fixes (SOQL escaping, trimmed helpers, logging improvements, and a few lint-style adjustments) across the modified files.

### Testing
- Ran unit tests for the modified and new suites including `__tests__/qboCustomersSync.test.ts`, the new `__tests__/salesforceRecordQboSync.test.ts`, and updated `__tests__/stripeTrueUp.test.ts` under `vitest` as part of the project test run. 
- All updated and newly added automated tests completed successfully with the expected assertions (no regressions observed in the exercised code paths).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c04c20e79c8324bfbe48a0d60de603)